### PR TITLE
Caching data from requests to avoid making repeated calls during the Chart creation

### DIFF
--- a/client/src/actions/chart.js
+++ b/client/src/actions/chart.js
@@ -198,10 +198,10 @@ export function runQuery(projectId, chartId) {
   };
 }
 
-export function getPreviewData(projectId, chart) {
+export function getPreviewData(projectId, chart, noSource = false) {
   return (dispatch) => {
     const token = cookie.load("brewToken");
-    const url = `${API_HOST}/project/${projectId}/chart/preview`;
+    const url = `${API_HOST}/project/${projectId}/chart/preview?no_source=${noSource}`;
     const method = "POST";
     const body = JSON.stringify(chart);
     const headers = new Headers({

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -145,6 +145,7 @@ class AddChart extends Component {
     this.setState({
       newChart: { ...newChart, connection_id: value, query },
       selectedConnection,
+      noSource: true,
     });
   }
 
@@ -317,22 +318,29 @@ class AddChart extends Component {
     const newRequest = apiRequest;
     newRequest.headers = newHeaders;
 
+    this.setState({ noSource: false });
+
     return newRequest;
   }
 
-  _onPreview = () => {
+  _onPreview = (e, refresh) => {
     const { getPreviewData, match } = this.props;
-    const { newChart, selectedConnection } = this.state;
+    const { newChart, selectedConnection, noSource } = this.state;
     const previewData = newChart;
+
+    let tempNoSource = noSource;
+    if (refresh === true) {
+      tempNoSource = false;
+    }
 
     if (selectedConnection && selectedConnection.type === "api") {
       previewData.apiRequest = this._formatApiRequest();
     }
 
     this.setState({ previewLoading: true, previewError: false });
-    getPreviewData(match.params.projectId, previewData)
+    getPreviewData(match.params.projectId, previewData, tempNoSource)
       .then((chartData) => {
-        this.setState({ previewChart: chartData, previewLoading: false });
+        this.setState({ previewChart: chartData, previewLoading: false, noSource: true });
       })
       .catch(() => {
         this.setState({ previewLoading: false, previewError: true });
@@ -795,15 +803,28 @@ class AddChart extends Component {
                         <Header textAlign="left" as="h3" dividing>
                           Build your chart
                         </Header>
-                        <Button
-                          icon
-                          labelPosition="left"
-                          onClick={this._onPreview}
-                          style={{ marginBottom: 20 }}
-                        >
-                          <Icon name="refresh" />
-                          Refresh Preview
-                        </Button>
+                        <Button.Group widths={10}>
+                          <Button
+                            icon
+                            labelPosition="left"
+                            onClick={this._onPreview}
+                            style={{ marginBottom: 20 }}
+                          >
+                            <Icon name="refresh" />
+                            Refresh Preview
+                          </Button>
+
+                          <Button
+                            icon
+                            labelPosition="right"
+                            onClick={() => this._onPreview(null, true)}
+                            style={{ marginBottom: 20 }}
+                            basic
+                          >
+                            <Icon name="refresh" />
+                            Refresh Data
+                          </Button>
+                        </Button.Group>
                       </Container>
                       {previewChart
                         && (
@@ -1131,7 +1152,9 @@ const mapDispatchToProps = (dispatch) => {
     createChart: (projectId, data) => dispatch(createChart(projectId, data)),
     runQuery: (projectId, chartId) => dispatch(runQuery(projectId, chartId)),
     updateChart: (projectId, chartId, data) => dispatch(updateChart(projectId, chartId, data)),
-    getPreviewData: (projectId, chart) => dispatch(getPreviewData(projectId, chart)),
+    getPreviewData: (projectId, chart, noSource) => {
+      return dispatch(getPreviewData(projectId, chart, noSource));
+    },
     cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -811,7 +811,7 @@ class AddChart extends Component {
                             style={{ marginBottom: 20 }}
                           >
                             <Icon name="refresh" />
-                            Refresh Preview
+                            Refresh preview
                           </Button>
 
                           <Button
@@ -821,8 +821,8 @@ class AddChart extends Component {
                             style={{ marginBottom: 20 }}
                             basic
                           >
-                            <Icon name="refresh" />
-                            Refresh Data
+                            <Icon name="angle double down" />
+                            Get latest data
                           </Button>
                         </Button.Group>
                       </Container>

--- a/server/api/ChartRoute.js
+++ b/server/api/ChartRoute.js
@@ -189,7 +189,7 @@ module.exports = (app) => {
 
         let chart = req.body;
         if (chart.chart) chart = chart.chart; // eslint-disable-line
-        return chartController.previewChart(chart, req.params.project_id);
+        return chartController.previewChart(chart, req.params.project_id, req.query.no_source);
       })
       .then((chart) => {
         return res.status(200).send(chart);

--- a/server/api/ChartRoute.js
+++ b/server/api/ChartRoute.js
@@ -50,7 +50,7 @@ module.exports = (app) => {
 
         // assign the project id to the new chart
         req.body.project_id = req.params.project_id;
-        return chartController.create(req.body);
+        return chartController.create(req.body, req.user);
       })
       .then((chart) => {
         return res.status(200).send(chart);
@@ -77,7 +77,7 @@ module.exports = (app) => {
         if (!permission.granted) {
           throw new Error(401);
         }
-        return chartController.update(req.params.id, req.body);
+        return chartController.update(req.params.id, req.body, req.user);
       })
       .then((chart) => {
         return res.status(200).send(chart);
@@ -189,7 +189,12 @@ module.exports = (app) => {
 
         let chart = req.body;
         if (chart.chart) chart = chart.chart; // eslint-disable-line
-        return chartController.previewChart(chart, req.params.project_id, req.query.no_source);
+        return chartController.previewChart(
+          chart,
+          req.params.project_id,
+          req.user,
+          req.query.no_source
+        );
       })
       .then((chart) => {
         return res.status(200).send(chart);

--- a/server/controllers/ChartCacheController.js
+++ b/server/controllers/ChartCacheController.js
@@ -1,0 +1,52 @@
+const ChartCache = require("../models/ChartCache");
+
+class ChartCacheController {
+  constructor() {
+    this.chartCache = ChartCache;
+  }
+
+  create(userId, data, type = "CHART_CACHE") {
+    return this.chartCache.create({
+      user_id: userId,
+      data,
+      type,
+    })
+      .then((cache) => {
+        return new Promise(resolve => resolve(cache));
+      })
+      .catch((e) => {
+        return new Promise((resolve, reject) => reject(e));
+      });
+  }
+
+  findLast(userId) {
+    return this.chartCache.findAll({
+      where: { user_id: userId },
+      order: [["createdAt", "DESC"]],
+    })
+      .then((cache) => {
+        if (!cache || cache.length < 1) {
+          return new Promise(resolve => resolve([]));
+        }
+
+        // return only the last one
+        return new Promise(resolve => resolve(cache[0]));
+      })
+      .catch(() => {
+        // this operation shouldn't stop what else is running
+        return new Promise(resolve => resolve([]));
+      });
+  }
+
+  deleteAll(userId) {
+    return this.chartCache.destroy({ where: { user_id: userId } })
+      .then((result) => {
+        return new Promise(resolve => resolve(result));
+      })
+      .catch((e) => {
+        return new Promise((resolve, reject) => reject(e));
+      });
+  }
+}
+
+module.exports = ChartCacheController;

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -10,6 +10,7 @@ const DatasetController = require("./DatasetController");
 const ConnectionController = require("./ConnectionController");
 const ProjectController = require("./ProjectController");
 const ApiRequestController = require("./ApiRequestController");
+const ChartCacheController = require("./ChartCacheController");
 
 // charts
 const LineChart = require("../charts/LineChart");
@@ -23,9 +24,10 @@ class ChartController {
     this.dataset = new DatasetController();
     this.project = new ProjectController();
     this.apiRequestController = new ApiRequestController();
+    this.chartCache = new ChartCacheController();
   }
 
-  create(data) {
+  create(data, user) {
     let chartId;
     return this.chart.create(data)
       .then((chart) => {
@@ -58,6 +60,11 @@ class ChartController {
         }
       })
       .then(() => {
+        // delete chart cache
+        if (user) {
+          this.chartCache.deleteAll(user.id);
+        }
+
         return this.findById(chartId);
       })
       .catch((error) => {
@@ -102,11 +109,17 @@ class ChartController {
       });
   }
 
-  update(id, data) {
+  update(id, data, user) {
     if (data.autoUpdate) {
       return this.chart.update(data, { where: { id } })
         .then(() => {
           const updatePromises = [];
+
+          // clear chart cache
+          if (user) {
+            this.chartCache.deleteAll(user.id);
+          }
+
           if (data.Datasets || data.apiRequest) {
             if (data.Datasets) {
               updatePromises
@@ -365,9 +378,20 @@ class ChartController {
       });
   }
 
-  getPreviewData(chart, projectId) {
-    return this.connection.findById(chart.connection_id)
+  getPreviewData(chart, projectId, user, noSource) {
+    return this.chartCache.findLast(user.id)
+      .then((cache) => {
+        if (noSource === "true") {
+          return new Promise(resolve => resolve(cache));
+        }
+
+        return this.connection.findById(chart.connection_id);
+      })
       .then((connection) => {
+        if (noSource === "true") {
+          return new Promise(resolve => resolve(connection.data));
+        }
+
         if (connection.type === "mongodb") {
           return this.testQuery(chart, projectId);
         } else if (connection.type === "api") {
@@ -378,17 +402,22 @@ class ChartController {
           throw new Error("The connection type is not supported");
         }
       })
+      .then((data) => {
+        if (noSource !== "true") {
+          // cache, but do it async
+          this.chartCache.create(user.id, data);
+        }
+
+        return new Promise(resolve => resolve(data));
+      })
       .catch((error) => {
+        // console.log("Error", error);
         return new Promise((resolve, reject) => reject(error));
       });
   }
 
-  previewChart(chart, projectId, noSource) {
-    if (noSource === "true") {
-      return new Promise(resolve => resolve(chart.chartData));
-    }
-
-    return this.getPreviewData(chart, projectId)
+  previewChart(chart, projectId, user, noSource) {
+    return this.getPreviewData(chart, projectId, user, noSource)
       .then((data) => {
         // LINE CHART
         if (chart.type === "line") {

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -115,11 +115,6 @@ class ChartController {
         .then(() => {
           const updatePromises = [];
 
-          // clear chart cache
-          if (user) {
-            this.chartCache.deleteAll(user.id);
-          }
-
           if (data.Datasets || data.apiRequest) {
             if (data.Datasets) {
               updatePromises
@@ -144,6 +139,11 @@ class ChartController {
       where: { id },
     })
       .then(() => {
+        // clear chart cache
+        if (user) {
+          this.chartCache.deleteAll(user.id);
+        }
+
         const updatePromises = [];
         if (data.Datasets || data.apiRequest) {
           if (data.Datasets) {

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -383,7 +383,11 @@ class ChartController {
       });
   }
 
-  previewChart(chart, projectId) {
+  previewChart(chart, projectId, noSource) {
+    if (noSource === "true") {
+      return new Promise(resolve => resolve(chart.chartData));
+    }
+
     return this.getPreviewData(chart, projectId)
       .then((data) => {
         // LINE CHART

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ const settings = process.env.NODE_ENV === "production" ? require("./settings") :
 const models = require("./models/index");
 const routes = require("./api");
 const updateChartsCron = require("./modules/updateChartsCron");
+const cleanChartCache = require("./modules/cleanChartCache");
 
 const app = express();
 app.settings = settings;
@@ -40,6 +41,7 @@ app.listen(app.settings.port, () => {
   // start CronJob, making sure the database is populated for the first time
   setTimeout(() => {
     updateChartsCron();
+    cleanChartCache();
   }, 3000);
 
   console.log(`Running server on port ${app.settings.port}`); // eslint-disable-line

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const settings = process.env.NODE_ENV === "production" ? require("./settings") :
 const models = require("./models/index");
 const routes = require("./api");
 const updateChartsCron = require("./modules/updateChartsCron");
-const cleanChartCache = require("./modules/cleanChartCache");
+const cleanChartCache = require("./modules/CleanChartCache");
 
 const app = express();
 app.settings = settings;

--- a/server/models/ChartCache.js
+++ b/server/models/ChartCache.js
@@ -1,0 +1,45 @@
+const Sequelize = require("sequelize");
+const simplecrypt = require("simplecrypt");
+
+const db = require("../modules/dbConnection");
+const settings = process.env.NODE_ENV === "production" ? require("../settings") : require("../settings-dev");
+
+const sc = simplecrypt({
+  password: settings.secret,
+  salt: "10",
+});
+
+const ChartCache = db.define("ChartCache", {
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  user_id: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    reference: {
+      model: "User",
+      key: "id",
+      onDelete: "cascade",
+    },
+  },
+  data: {
+    type: Sequelize.TEXT("long"),
+    allowNull: false,
+    get() {
+      try {
+        return JSON.parse(sc.decrypt(this.getDataValue("data")));
+      } catch (e) {
+        return this.getDataValue("data");
+      }
+    },
+    set(val) {
+      return this.setDataValue("data", sc.encrypt(JSON.stringify(val)));
+    },
+  },
+}, {
+  freezeTableName: true
+});
+
+module.exports = ChartCache;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -9,6 +9,7 @@ const dataset = require("./Dataset");
 const teamInvintation = require("./TeamInvintation");
 const savedQuery = require("./SavedQuery");
 const apiRequest = require("./ApiRequest");
+const chartCache = require("./ChartCache");
 
 // create the database relations
 team.hasMany(project, { foreignKey: "team_id" });
@@ -18,6 +19,7 @@ team.hasMany(teamInvintation, { foreignKey: "team_id" });
 user.hasMany(teamRole, { foreignKey: "user_id" });
 user.hasMany(projectRole, { foreignKey: "user_id" });
 user.hasMany(teamInvintation, { foreignKey: "user_id" });
+user.hasMany(chartCache, { foreignKey: "user_id" });
 
 project.hasMany(projectRole, { foreignKey: "project_id" });
 project.hasMany(connection, { foreignKey: "project_id" });

--- a/server/modules/CleanChartCache.js
+++ b/server/modules/CleanChartCache.js
@@ -1,0 +1,38 @@
+const moment = require("moment");
+const { CronJob } = require("cron");
+
+const ChartCache = require("../models/ChartCache");
+
+function clean() {
+  return ChartCache.findAll()
+    .then((cache) => {
+      const cleanPromises = [];
+      for (const item of cache) {
+        const timeDiff = moment().diff(item.createdAt, "hours");
+
+        if (timeDiff > 23) {
+          cleanPromises.push(ChartCache.destroy({ where: { id: item.id } }));
+        }
+      }
+
+      if (cleanPromises.length > 0) return Promise.all(cleanPromises);
+
+      return [];
+    })
+    .catch(() => {
+      console.log("Error while cleaning the chart caches. You might want to delete them manually"); // eslint-disable-line
+    });
+}
+
+module.exports = () => {
+  clean();
+
+  // now run the cron job every hour
+  const cron = new CronJob("0 0 * * * *", () => {
+    clean();
+  });
+
+  cron.start();
+
+  return cron;
+};


### PR DESCRIPTION
- [x] Cache data temporarily on the server-side
- [ ] Clear the cache when the user updated or created the query/chart
- [ ] Create a cron task to delete any cache that's older than < time >
- [x] Pass around a flag to let the server know when to use the cached data
- [x] Give the user the option to refresh the chart with or without getting new data from the source connection

![image](https://user-images.githubusercontent.com/5342321/70064624-237ac380-15ea-11ea-8942-2322358f3677.png)
