### PR TITLE
[Feature] API pagination to split big requests into multiple ones

### DIFF
--- a/client/src/components/ApiBuilder.js
+++ b/client/src/components/ApiBuilder.js
@@ -469,9 +469,14 @@ class ApiBuilder extends Component {
             <Grid.Column width={6}>
               <Header as="h3" dividing style={{ paddingTop: 15 }}>Result:</Header>
               {requestSuccess && (
-                <Label color="green" style={{ marginBottom: 10 }}>
-                  {`${requestSuccess.statusCode} ${requestSuccess.statusText}`}
-                </Label>
+                <>
+                  <Label color="green" style={{ marginBottom: 10 }}>
+                    {`${requestSuccess.statusCode} ${requestSuccess.statusText}`}
+                  </Label>
+                  <Label style={{ marginBottom: 10 }}>
+                    {`Length: ${result ? JSON.parse(result).length : 0}`}
+                  </Label>
+                </>
               )}
               {requestError && (
                 <Label color="red" style={{ marginBottom: 10 }}>
@@ -520,7 +525,7 @@ ApiBuilder.propTypes = {
   apiRequest: PropTypes.object,
   chartId: PropTypes.number,
   items: PropTypes.string,
-  itemsLimit: PropTypes.string,
+  itemsLimit: PropTypes.number,
   offset: PropTypes.string,
   pagination: PropTypes.bool,
   onPaginationChanged: PropTypes.func.isRequired,

--- a/client/src/components/ApiBuilder.js
+++ b/client/src/components/ApiBuilder.js
@@ -463,6 +463,7 @@ class ApiBuilder extends Component {
                   offset={offset}
                   pagination={pagination}
                   onPaginationChanged={onPaginationChanged}
+                  apiRoute={apiRequest.route}
                 />
               )}
             </Grid.Column>
@@ -509,7 +510,7 @@ const styles = {
 ApiBuilder.defaultProps = {
   apiRequest: null,
   chartId: -1,
-  items: "items",
+  items: "limit",
   itemsLimit: 100,
   offset: "offset",
   pagination: false,

--- a/client/src/components/ApiBuilder.js
+++ b/client/src/components/ApiBuilder.js
@@ -236,6 +236,7 @@ class ApiBuilder extends Component {
   _onTest = () => {
     const {
       match, connection, testApiRequest, onComplete,
+      offset, items, itemsLimit, pagination,
     } = this.props;
     const {
       headers, apiRequest
@@ -248,8 +249,13 @@ class ApiBuilder extends Component {
       }
     }
 
-    const finalApiRequest = apiRequest;
-    finalApiRequest.headers = newHeaders;
+    const finalApiRequest = { apiRequest };
+    finalApiRequest.apiRequest.headers = newHeaders;
+
+    finalApiRequest.pagination = pagination;
+    finalApiRequest.items = items;
+    finalApiRequest.offset = offset;
+    finalApiRequest.itemsLimit = itemsLimit;
 
     this.setState({ requestLoading: true, requestSuccess: false, requestError: false });
     testApiRequest(match.params.projectId, connection.id, finalApiRequest)
@@ -499,7 +505,7 @@ ApiBuilder.defaultProps = {
   apiRequest: null,
   chartId: -1,
   items: "items",
-  itemsLimit: "limit",
+  itemsLimit: 100,
   offset: "offset",
   pagination: false,
 };

--- a/client/src/components/ApiBuilder.js
+++ b/client/src/components/ApiBuilder.js
@@ -15,6 +15,7 @@ import "brace/theme/tomorrow";
 
 import { testApiRequest } from "../actions/connection";
 import { getApiRequestByChart } from "../actions/apiRequest";
+import ApiPagination from "./ApiPagination";
 
 /*
   Description
@@ -275,7 +276,10 @@ class ApiBuilder extends Component {
       methods, activeMenu, requestSuccess, requestError,
       requestLoading, body, result, apiRequest,
     } = this.state;
-    const { connection } = this.props;
+    const {
+      connection, items, limit, offset, pagination, onItemsChanged,
+      onLimitChanged, onOffsetChanged, onPaginationChanged,
+    } = this.props;
 
     return (
       <div style={styles.container}>
@@ -335,6 +339,11 @@ class ApiBuilder extends Component {
                   disabled={apiRequest.method === "GET" || apiRequest.method === "OPTIONS"}
                   active={activeMenu === "body"}
                   onClick={() => this.setState({ activeMenu: "body" })}
+                />
+                <Menu.Item
+                  name="Pagination"
+                  active={activeMenu === "pagination"}
+                  onClick={() => this.setState({ activeMenu: "pagination" })}
                 />
               </Menu>
               {activeMenu === "headers" && (
@@ -441,6 +450,18 @@ class ApiBuilder extends Component {
                   />
                 </div>
               )}
+              {activeMenu === "pagination" && (
+                <ApiPagination
+                  items={items}
+                  onItemsChanged={onItemsChanged}
+                  limit={limit}
+                  onLimitChanged={onLimitChanged}
+                  offset={offset}
+                  onOffsetChanged={onOffsetChanged}
+                  pagination={pagination}
+                  onPaginationChanged={onPaginationChanged}
+                />
+              )}
             </Grid.Column>
             <Grid.Column width={6}>
               <Header as="h3" dividing style={{ paddingTop: 15 }}>Result:</Header>
@@ -480,6 +501,19 @@ const styles = {
 ApiBuilder.defaultProps = {
   apiRequest: null,
   chartId: -1,
+  items: {
+    key: "items",
+    value: 1000,
+  },
+  limit: {
+    key: "limit",
+    value: 5000,
+  },
+  offset: {
+    key: "offset",
+    value: 0,
+  },
+  pagination: false,
 };
 
 ApiBuilder.propTypes = {
@@ -491,6 +525,14 @@ ApiBuilder.propTypes = {
   onChangeRequest: PropTypes.func.isRequired,
   apiRequest: PropTypes.object,
   chartId: PropTypes.number,
+  items: PropTypes.object,
+  limit: PropTypes.object,
+  offset: PropTypes.object,
+  pagination: PropTypes.bool,
+  onItemsChanged: PropTypes.func.isRequired,
+  onLimitChanged: PropTypes.func.isRequired,
+  onOffsetChanged: PropTypes.func.isRequired,
+  onPaginationChanged: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = () => {

--- a/client/src/components/ApiBuilder.js
+++ b/client/src/components/ApiBuilder.js
@@ -277,7 +277,7 @@ class ApiBuilder extends Component {
       requestLoading, body, result, apiRequest,
     } = this.state;
     const {
-      connection, items, limit, offset, pagination,
+      connection, items, itemsLimit, offset, pagination,
       onPaginationChanged,
     } = this.props;
 
@@ -453,7 +453,7 @@ class ApiBuilder extends Component {
               {activeMenu === "pagination" && (
                 <ApiPagination
                   items={items}
-                  limit={limit}
+                  itemsLimit={itemsLimit}
                   offset={offset}
                   pagination={pagination}
                   onPaginationChanged={onPaginationChanged}
@@ -499,7 +499,7 @@ ApiBuilder.defaultProps = {
   apiRequest: null,
   chartId: -1,
   items: "items",
-  limit: "limit",
+  itemsLimit: "limit",
   offset: "offset",
   pagination: false,
 };
@@ -514,7 +514,7 @@ ApiBuilder.propTypes = {
   apiRequest: PropTypes.object,
   chartId: PropTypes.number,
   items: PropTypes.string,
-  limit: PropTypes.string,
+  itemsLimit: PropTypes.string,
   offset: PropTypes.string,
   pagination: PropTypes.bool,
   onPaginationChanged: PropTypes.func.isRequired,

--- a/client/src/components/ApiBuilder.js
+++ b/client/src/components/ApiBuilder.js
@@ -277,8 +277,8 @@ class ApiBuilder extends Component {
       requestLoading, body, result, apiRequest,
     } = this.state;
     const {
-      connection, items, limit, offset, pagination, onItemsChanged,
-      onLimitChanged, onOffsetChanged, onPaginationChanged,
+      connection, items, limit, offset, pagination,
+      onPaginationChanged,
     } = this.props;
 
     return (
@@ -453,11 +453,8 @@ class ApiBuilder extends Component {
               {activeMenu === "pagination" && (
                 <ApiPagination
                   items={items}
-                  onItemsChanged={onItemsChanged}
                   limit={limit}
-                  onLimitChanged={onLimitChanged}
                   offset={offset}
-                  onOffsetChanged={onOffsetChanged}
                   pagination={pagination}
                   onPaginationChanged={onPaginationChanged}
                 />
@@ -501,18 +498,9 @@ const styles = {
 ApiBuilder.defaultProps = {
   apiRequest: null,
   chartId: -1,
-  items: {
-    key: "items",
-    value: 1000,
-  },
-  limit: {
-    key: "limit",
-    value: 5000,
-  },
-  offset: {
-    key: "offset",
-    value: 0,
-  },
+  items: "items",
+  limit: "limit",
+  offset: "offset",
   pagination: false,
 };
 
@@ -525,13 +513,10 @@ ApiBuilder.propTypes = {
   onChangeRequest: PropTypes.func.isRequired,
   apiRequest: PropTypes.object,
   chartId: PropTypes.number,
-  items: PropTypes.object,
-  limit: PropTypes.object,
-  offset: PropTypes.object,
+  items: PropTypes.string,
+  limit: PropTypes.string,
+  offset: PropTypes.string,
   pagination: PropTypes.bool,
-  onItemsChanged: PropTypes.func.isRequired,
-  onLimitChanged: PropTypes.func.isRequired,
-  onOffsetChanged: PropTypes.func.isRequired,
   onPaginationChanged: PropTypes.func.isRequired,
 };
 

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -39,10 +39,10 @@ class ApiPagination extends Component {
               <Popup
                 content={"The query parameter name that limits the number of item per request."}
                 trigger={(
-                  <label>
+                  <p>
                     {"Items per page "}
                     <Icon name="info circle" />
-                  </label>
+                  </p>
                 )}
               />
             </Form.Field>
@@ -61,10 +61,10 @@ class ApiPagination extends Component {
               <Popup
                 content={"The query parameter name used for the starting point of the first request. "}
                 trigger={(
-                  <label>
+                  <p>
                     {"Offset "}
                     <Icon name="info circle" />
-                  </label>
+                  </p>
                 )}
               />
             </Form.Field>
@@ -83,10 +83,10 @@ class ApiPagination extends Component {
               <Popup
                 content={"The total amount of items to get (all the paged items put together) - Leave empty or 0 for unlimited"}
                 trigger={(
-                  <label>
+                  <p>
                     {"Total maximum number "}
                     <Icon name="info circle" />
-                  </label>
+                  </p>
                 )}
               />
             </Form.Field>

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -18,17 +18,22 @@ class ApiPagination extends Component {
       <Container>
         <p>
           {
-          `ChartBrew can paginate the request. 
+          `ChartBrew can paginate the request by making multiple requests automatically. 
           It can get all the data you need based 
-          on the configuration below. If your API support pagination, 
-          selector names below. The selectors are identified in the query 
-          parameters or in the request body, so make sure you write those 
-          in the query or body.`
+          on the configuration below. Make sure your API supports pagination first.`
           }
         </p>
-        <p>{"Instead of making one big request, ChartBrew can paginate the requests automatically."}</p>
+        <p>{"Fill out your pagination query paramters' names and the max amount you want to get in total"}</p>
         <Divider />
         <Form>
+          <Form.Field>
+            <Checkbox
+              label="Activate pagination"
+              toggle
+              checked={pagination}
+              onChange={() => onPaginationChanged("pagination", !pagination)}
+            />
+          </Form.Field>
           <Form.Group widths={2}>
             <Form.Field width={6}>
               <Popup
@@ -43,6 +48,7 @@ class ApiPagination extends Component {
             </Form.Field>
             <Form.Field width={6}>
               <Input
+                disabled={!pagination}
                 placeholder="Items per page"
                 value={items}
                 onChange={(e, data) => onPaginationChanged("items", data.value)}
@@ -64,6 +70,7 @@ class ApiPagination extends Component {
             </Form.Field>
             <Form.Field width={6}>
               <Input
+                disabled={!pagination}
                 placeholder="Offset"
                 value={offset}
                 onChange={(e, data) => onPaginationChanged("offset", data.value)}
@@ -85,6 +92,7 @@ class ApiPagination extends Component {
             </Form.Field>
             <Form.Field width={6}>
               <Input
+                disabled={!pagination}
                 placeholder="Limit"
                 type="number"
                 value={itemsLimit}
@@ -92,39 +100,34 @@ class ApiPagination extends Component {
               />
             </Form.Field>
           </Form.Group>
-
-          <Form.Field>
-            <Checkbox
-              label="Activate pagination"
-              toggle
-              checked={pagination}
-              onChange={() => onPaginationChanged("pagination", !pagination)}
-            />
-          </Form.Field>
         </Form>
 
-        <Divider />
-        <span>
-          {"You should include these query parameters: "}
-          <Label>{`${items}=<xxx>&${offset}=<xxx> `}</Label>
-          {(apiRoute.indexOf(`?${items}=`) > -1 || apiRoute.indexOf(`&${items}=`) > -1) && (
-            <Label color="green">{`${items} was found`}</Label>
-          )}
-          {(apiRoute.indexOf(`?${items}=`) === -1 && apiRoute.indexOf(`&${items}=`) === -1) && (
-            <Label color="red">{`${items} not found in route`}</Label>
-          )}
-          {(apiRoute.indexOf(`?${offset}=`) > -1 || apiRoute.indexOf(`&${offset}=`) > -1) && (
-            <Label color="green">{`${offset} was found`}</Label>
-          )}
-          {(apiRoute.indexOf(`?${offset}=`) === -1 && apiRoute.indexOf(`&${offset}=`) === -1) && (
-            <Label color="red">{`${offset} not found in route`}</Label>
-          )}
-        </span>
-        <Divider hidden />
-        <p>
-          {"The maximum amount of item that you're going to get is: "}
-          <Label>{ itemsLimit === "0" || !itemsLimit ? "no max" : itemsLimit }</Label>
-        </p>
+        {pagination && (
+          <>
+            <Divider />
+            <span>
+              {"You should include these query parameters: "}
+              <Label>{`${items}=<xxx>&${offset}=<xxx> `}</Label>
+              {(apiRoute.indexOf(`?${items}=`) > -1 || apiRoute.indexOf(`&${items}=`) > -1) && (
+                <Label color="green">{`${items} was found`}</Label>
+              )}
+              {(apiRoute.indexOf(`?${items}=`) === -1 && apiRoute.indexOf(`&${items}=`) === -1) && (
+                <Label color="red">{`${items} not found in route`}</Label>
+              )}
+              {(apiRoute.indexOf(`?${offset}=`) > -1 || apiRoute.indexOf(`&${offset}=`) > -1) && (
+                <Label color="green">{`${offset} was found`}</Label>
+              )}
+              {(apiRoute.indexOf(`?${offset}=`) === -1 && apiRoute.indexOf(`&${offset}=`) === -1) && (
+                <Label color="red">{`${offset} not found in route`}</Label>
+              )}
+            </span>
+            <Divider hidden />
+            <p>
+              {"The maximum amount of item that you're going to get is: "}
+              <Label>{itemsLimit === "0" || !itemsLimit ? "no max" : itemsLimit}</Label>
+            </p>
+          </>
+        )}
       </Container>
     );
   }

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -1,0 +1,139 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import {
+  Container, Form, Input, Checkbox, Icon, Popup, Divider,
+} from "semantic-ui-react";
+
+/*
+  Component used for creating an automated pagination for APIs
+*/
+class ApiPagination extends Component {
+  render() {
+    const {
+      items, limit, offset, pagination, onItemsChanged,
+      onLimitChanged, onOffsetChanged, onPaginationChanged,
+    } = this.props;
+
+    return (
+      <Container>
+        <p>
+          {
+          `ChartBrew can paginate the request. 
+          It can get all the data you need based 
+          on the configuration below. If your API support pagination, 
+          modify the keys and values accordingly.`
+          }
+        </p>
+        <p>{"Instead of making one big request, ChartBrew can paginate the requests automatically."}</p>
+        <Divider />
+        <Form>
+          <Form.Group widths={3}>
+            <Form.Field width={4}>
+              <Popup
+                content={"The amount of items to get per request"}
+                trigger={(
+                  <label>
+                    {"Items "}
+                    <Icon name="info circle" />
+                  </label>
+                )}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Items per page"
+                value={items.key}
+                onChange={(e, data) => onItemsChanged("key", data.value)}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Value"
+                value={items.value}
+                onChange={(e, data) => onItemsChanged("value", data.value)}
+              />
+            </Form.Field>
+          </Form.Group>
+
+          <Form.Group widths={3}>
+            <Form.Field width={4}>
+              <Popup
+                content={"The total amount of items to get. Put 0 for getting everything."}
+                trigger={(
+                  <label>
+                    {"Limit "}
+                    <Icon name="info circle" />
+                  </label>
+                )}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Limit"
+                value={limit.key}
+                onChange={(e, data) => onLimitChanged("key", data.value)}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Value"
+                value={limit.value}
+                onChange={(e, data) => onLimitChanged("value", data.value)}
+              />
+            </Form.Field>
+          </Form.Group>
+
+          <Form.Group widths={3}>
+            <Form.Field width={4}>
+              <Popup
+                content={"Set this to whatever value you want to start from"}
+                trigger={(
+                  <label>
+                    {"Offset "}
+                    <Icon name="info circle" />
+                  </label>
+                )}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Offset"
+                value={offset.key}
+                onChange={(e, data) => onOffsetChanged("key", data.value)}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Value"
+                value={offset.value}
+                onChange={(e, data) => onOffsetChanged("value", data.value)}
+              />
+            </Form.Field>
+          </Form.Group>
+
+          <Form.Field>
+            <Checkbox
+              label="Activate pagination"
+              toggle
+              checked={pagination}
+              onChange={() => onPaginationChanged(!pagination)}
+            />
+          </Form.Field>
+        </Form>
+      </Container>
+    );
+  }
+}
+
+ApiPagination.propTypes = {
+  items: PropTypes.object.isRequired,
+  limit: PropTypes.object.isRequired,
+  offset: PropTypes.object.isRequired,
+  pagination: PropTypes.bool.isRequired,
+  onItemsChanged: PropTypes.func.isRequired,
+  onLimitChanged: PropTypes.func.isRequired,
+  onOffsetChanged: PropTypes.func.isRequired,
+  onPaginationChanged: PropTypes.func.isRequired,
+};
+
+export default ApiPagination;

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -10,8 +10,8 @@ import {
 class ApiPagination extends Component {
   render() {
     const {
-      items, limit, offset, pagination, onItemsChanged,
-      onLimitChanged, onOffsetChanged, onPaginationChanged,
+      items, limit, offset, pagination,
+      onPaginationChanged,
     } = this.props;
 
     return (
@@ -21,13 +21,15 @@ class ApiPagination extends Component {
           `ChartBrew can paginate the request. 
           It can get all the data you need based 
           on the configuration below. If your API support pagination, 
-          modify the keys and values accordingly.`
+          selector names below. The selectors are identified in the query 
+          parameters or in the request body, so make sure you write those 
+          in the query or body.`
           }
         </p>
         <p>{"Instead of making one big request, ChartBrew can paginate the requests automatically."}</p>
         <Divider />
         <Form>
-          <Form.Group widths={3}>
+          <Form.Group widths={2}>
             <Form.Field width={4}>
               <Popup
                 content={"The amount of items to get per request"}
@@ -42,20 +44,13 @@ class ApiPagination extends Component {
             <Form.Field width={6}>
               <Input
                 placeholder="Items per page"
-                value={items.key}
-                onChange={(e, data) => onItemsChanged("key", data.value)}
-              />
-            </Form.Field>
-            <Form.Field width={6}>
-              <Input
-                placeholder="Value"
-                value={items.value}
-                onChange={(e, data) => onItemsChanged("value", data.value)}
+                value={items}
+                onChange={(e, data) => onPaginationChanged("items", data.value)}
               />
             </Form.Field>
           </Form.Group>
 
-          <Form.Group widths={3}>
+          <Form.Group widths={2}>
             <Form.Field width={4}>
               <Popup
                 content={"The total amount of items to get. Put 0 for getting everything."}
@@ -70,20 +65,13 @@ class ApiPagination extends Component {
             <Form.Field width={6}>
               <Input
                 placeholder="Limit"
-                value={limit.key}
-                onChange={(e, data) => onLimitChanged("key", data.value)}
-              />
-            </Form.Field>
-            <Form.Field width={6}>
-              <Input
-                placeholder="Value"
-                value={limit.value}
-                onChange={(e, data) => onLimitChanged("value", data.value)}
+                value={limit}
+                onChange={(e, data) => onPaginationChanged("limit", data.value)}
               />
             </Form.Field>
           </Form.Group>
 
-          <Form.Group widths={3}>
+          <Form.Group widths={2}>
             <Form.Field width={4}>
               <Popup
                 content={"Set this to whatever value you want to start from"}
@@ -98,15 +86,8 @@ class ApiPagination extends Component {
             <Form.Field width={6}>
               <Input
                 placeholder="Offset"
-                value={offset.key}
-                onChange={(e, data) => onOffsetChanged("key", data.value)}
-              />
-            </Form.Field>
-            <Form.Field width={6}>
-              <Input
-                placeholder="Value"
-                value={offset.value}
-                onChange={(e, data) => onOffsetChanged("value", data.value)}
+                value={offset}
+                onChange={(e, data) => onPaginationChanged("offset", data.value)}
               />
             </Form.Field>
           </Form.Group>
@@ -116,7 +97,7 @@ class ApiPagination extends Component {
               label="Activate pagination"
               toggle
               checked={pagination}
-              onChange={() => onPaginationChanged(!pagination)}
+              onChange={() => onPaginationChanged("pagination", !pagination)}
             />
           </Form.Field>
         </Form>
@@ -126,13 +107,10 @@ class ApiPagination extends Component {
 }
 
 ApiPagination.propTypes = {
-  items: PropTypes.object.isRequired,
-  limit: PropTypes.object.isRequired,
-  offset: PropTypes.object.isRequired,
+  items: PropTypes.string.isRequired,
+  limit: PropTypes.string.isRequired,
+  offset: PropTypes.string.isRequired,
   pagination: PropTypes.bool.isRequired,
-  onItemsChanged: PropTypes.func.isRequired,
-  onLimitChanged: PropTypes.func.isRequired,
-  onOffsetChanged: PropTypes.func.isRequired,
   onPaginationChanged: PropTypes.func.isRequired,
 };
 

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -108,7 +108,7 @@ class ApiPagination extends Component {
 
 ApiPagination.propTypes = {
   items: PropTypes.string.isRequired,
-  itemsLimit: PropTypes.string.isRequired,
+  itemsLimit: PropTypes.number.isRequired,
   offset: PropTypes.string.isRequired,
   pagination: PropTypes.bool.isRequired,
   onPaginationChanged: PropTypes.func.isRequired,

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -10,7 +10,7 @@ import {
 class ApiPagination extends Component {
   render() {
     const {
-      items, limit, offset, pagination,
+      items, itemsLimit, offset, pagination,
       onPaginationChanged,
     } = this.props;
 
@@ -65,8 +65,8 @@ class ApiPagination extends Component {
             <Form.Field width={6}>
               <Input
                 placeholder="Limit"
-                value={limit}
-                onChange={(e, data) => onPaginationChanged("limit", data.value)}
+                value={itemsLimit}
+                onChange={(e, data) => onPaginationChanged("itemsLimit", data.value)}
               />
             </Form.Field>
           </Form.Group>
@@ -108,7 +108,7 @@ class ApiPagination extends Component {
 
 ApiPagination.propTypes = {
   items: PropTypes.string.isRequired,
-  limit: PropTypes.string.isRequired,
+  itemsLimit: PropTypes.string.isRequired,
   offset: PropTypes.string.isRequired,
   pagination: PropTypes.bool.isRequired,
   onPaginationChanged: PropTypes.func.isRequired,

--- a/client/src/components/ApiPagination.js
+++ b/client/src/components/ApiPagination.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import {
-  Container, Form, Input, Checkbox, Icon, Popup, Divider,
+  Container, Form, Input, Checkbox, Icon, Popup, Divider, Label,
 } from "semantic-ui-react";
 
 /*
@@ -11,7 +11,7 @@ class ApiPagination extends Component {
   render() {
     const {
       items, itemsLimit, offset, pagination,
-      onPaginationChanged,
+      onPaginationChanged, apiRoute,
     } = this.props;
 
     return (
@@ -30,12 +30,12 @@ class ApiPagination extends Component {
         <Divider />
         <Form>
           <Form.Group widths={2}>
-            <Form.Field width={4}>
+            <Form.Field width={6}>
               <Popup
-                content={"The amount of items to get per request"}
+                content={"The query parameter name that limits the number of item per request."}
                 trigger={(
                   <label>
-                    {"Items "}
+                    {"Items per page "}
                     <Icon name="info circle" />
                   </label>
                 )}
@@ -51,30 +51,9 @@ class ApiPagination extends Component {
           </Form.Group>
 
           <Form.Group widths={2}>
-            <Form.Field width={4}>
-              <Popup
-                content={"The total amount of items to get. Put 0 for getting everything."}
-                trigger={(
-                  <label>
-                    {"Limit "}
-                    <Icon name="info circle" />
-                  </label>
-                )}
-              />
-            </Form.Field>
             <Form.Field width={6}>
-              <Input
-                placeholder="Limit"
-                value={itemsLimit}
-                onChange={(e, data) => onPaginationChanged("itemsLimit", data.value)}
-              />
-            </Form.Field>
-          </Form.Group>
-
-          <Form.Group widths={2}>
-            <Form.Field width={4}>
               <Popup
-                content={"Set this to whatever value you want to start from"}
+                content={"The query parameter name used for the starting point of the first request. "}
                 trigger={(
                   <label>
                     {"Offset "}
@@ -92,6 +71,28 @@ class ApiPagination extends Component {
             </Form.Field>
           </Form.Group>
 
+          <Form.Group widths={2}>
+            <Form.Field width={6}>
+              <Popup
+                content={"The total amount of items to get (all the paged items put together) - Leave empty or 0 for unlimited"}
+                trigger={(
+                  <label>
+                    {"Total maximum number "}
+                    <Icon name="info circle" />
+                  </label>
+                )}
+              />
+            </Form.Field>
+            <Form.Field width={6}>
+              <Input
+                placeholder="Limit"
+                type="number"
+                value={itemsLimit}
+                onChange={(e, data) => onPaginationChanged("itemsLimit", data.value)}
+              />
+            </Form.Field>
+          </Form.Group>
+
           <Form.Field>
             <Checkbox
               label="Activate pagination"
@@ -101,10 +102,37 @@ class ApiPagination extends Component {
             />
           </Form.Field>
         </Form>
+
+        <Divider />
+        <span>
+          {"You should include these query parameters: "}
+          <Label>{`${items}=<xxx>&${offset}=<xxx> `}</Label>
+          {(apiRoute.indexOf(`?${items}=`) > -1 || apiRoute.indexOf(`&${items}=`) > -1) && (
+            <Label color="green">{`${items} was found`}</Label>
+          )}
+          {(apiRoute.indexOf(`?${items}=`) === -1 && apiRoute.indexOf(`&${items}=`) === -1) && (
+            <Label color="red">{`${items} not found in route`}</Label>
+          )}
+          {(apiRoute.indexOf(`?${offset}=`) > -1 || apiRoute.indexOf(`&${offset}=`) > -1) && (
+            <Label color="green">{`${offset} was found`}</Label>
+          )}
+          {(apiRoute.indexOf(`?${offset}=`) === -1 && apiRoute.indexOf(`&${offset}=`) === -1) && (
+            <Label color="red">{`${offset} not found in route`}</Label>
+          )}
+        </span>
+        <Divider hidden />
+        <p>
+          {"The maximum amount of item that you're going to get is: "}
+          <Label>{ itemsLimit === "0" || !itemsLimit ? "no max" : itemsLimit }</Label>
+        </p>
       </Container>
     );
   }
 }
+
+ApiPagination.defaultProps = {
+  apiRoute: "",
+};
 
 ApiPagination.propTypes = {
   items: PropTypes.string.isRequired,
@@ -112,6 +140,7 @@ ApiPagination.propTypes = {
   offset: PropTypes.string.isRequired,
   pagination: PropTypes.bool.isRequired,
   onPaginationChanged: PropTypes.func.isRequired,
+  apiRoute: PropTypes.string,
 };
 
 export default ApiPagination;

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -43,6 +43,7 @@ class AddChart extends Component {
           xAxis: "root",
           legend: "Dataset #1",
         }],
+        offset: "offset",
       },
       ddConnections: [],
       updatedEdit: false, // eslint-disable-line

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -27,8 +27,6 @@ import ApiBuilder from "../components/ApiBuilder";
 import PostgresQueryBuilder from "../components/PostgresQueryBuilder";
 import MysqlQueryBuilder from "../components/MysqlQueryBuilder";
 
-const numRegex = /^[0-9]*$/;
-
 /*
   Container used for setting up a new chart
 */
@@ -331,70 +329,16 @@ class AddChart extends Component {
     return newRequest;
   }
 
-  _onItemsChanged = (type, value) => {
-    const { newChart } = this.state;
-
-    if (type === "key") {
-      this.setState({
-        newChart: {
-          ...newChart, items: { ...newChart.items, key: value },
-        },
-      });
-    } else if (type === "value" && value.match(numRegex)) {
-      this.setState({
-        newChart: {
-          ...newChart, items: { ...newChart.items, value },
-        },
-      });
-    }
-  }
-
-  _onLimitChanged = (type, value) => {
-    const { newChart } = this.state;
-
-    if (type === "key") {
-      this.setState({
-        newChart: {
-          ...newChart, limit: { ...newChart.limit, key: value },
-        },
-      });
-    } else if (type === "value" && value.match(numRegex)) {
-      this.setState({
-        newChart: {
-          ...newChart, limit: { ...newChart.limit, value },
-        },
-      });
-    }
-  }
-
-  _onOffsetChanged = (type, value) => {
-    const { newChart } = this.state;
-
-    if (type === "key") {
-      this.setState({
-        newChart: {
-          ...newChart, offset: { ...newChart.offset, key: value },
-        },
-      });
-    } else if (type === "value" && value.match(numRegex)) {
-      this.setState({
-        newChart: {
-          ...newChart, offset: { ...newChart.offset, value },
-        },
-      });
-    }
-  }
-
-  _onPaginationChanged = (value) => {
+  _onPaginationChanged = (type, value) => {
     const { newChart } = this.state;
 
     this.setState({
       newChart: {
-        ...newChart,
-        pagination: value,
+        ...newChart, [type]: value,
       },
     });
   }
+
   /* End of API Stuff */
 
   _onPreview = (e, refresh) => {
@@ -837,9 +781,6 @@ class AddChart extends Component {
                     items={newChart.items}
                     offset={newChart.offset}
                     pagination={newChart.pagination}
-                    onLimitChanged={this._onLimitChanged}
-                    onItemsChanged={this._onItemsChanged}
-                    onOffsetChanged={this._onOffsetChanged}
                     onPaginationChanged={this._onPaginationChanged}
                   />
                   )}

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -27,6 +27,8 @@ import ApiBuilder from "../components/ApiBuilder";
 import PostgresQueryBuilder from "../components/PostgresQueryBuilder";
 import MysqlQueryBuilder from "../components/MysqlQueryBuilder";
 
+const numRegex = /^[0-9]*$/;
+
 /*
   Container used for setting up a new chart
 */
@@ -43,6 +45,10 @@ class AddChart extends Component {
           xAxis: "root",
           legend: "Dataset #1",
         }],
+        // TODO: remove this before commit
+        name: "Something",
+        type: "line",
+        subType: "lcTimeseries",
       },
       ddConnections: [],
       updatedEdit: false, // eslint-disable-line
@@ -302,6 +308,8 @@ class AddChart extends Component {
     });
   }
 
+  /* API Stuff */
+
   _formatApiRequest = () => {
     const { apiRequest } = this.state;
     if (!apiRequest) return {};
@@ -322,6 +330,72 @@ class AddChart extends Component {
 
     return newRequest;
   }
+
+  _onItemsChanged = (type, value) => {
+    const { newChart } = this.state;
+
+    if (type === "key") {
+      this.setState({
+        newChart: {
+          ...newChart, items: { ...newChart.items, key: value },
+        },
+      });
+    } else if (type === "value" && value.match(numRegex)) {
+      this.setState({
+        newChart: {
+          ...newChart, items: { ...newChart.items, value },
+        },
+      });
+    }
+  }
+
+  _onLimitChanged = (type, value) => {
+    const { newChart } = this.state;
+
+    if (type === "key") {
+      this.setState({
+        newChart: {
+          ...newChart, limit: { ...newChart.limit, key: value },
+        },
+      });
+    } else if (type === "value" && value.match(numRegex)) {
+      this.setState({
+        newChart: {
+          ...newChart, limit: { ...newChart.limit, value },
+        },
+      });
+    }
+  }
+
+  _onOffsetChanged = (type, value) => {
+    const { newChart } = this.state;
+
+    if (type === "key") {
+      this.setState({
+        newChart: {
+          ...newChart, offset: { ...newChart.offset, key: value },
+        },
+      });
+    } else if (type === "value" && value.match(numRegex)) {
+      this.setState({
+        newChart: {
+          ...newChart, offset: { ...newChart.offset, value },
+        },
+      });
+    }
+  }
+
+  _onPaginationChanged = (value) => {
+    const { newChart } = this.state;
+
+    this.setState({
+      newChart: {
+        ...newChart,
+        pagination: value,
+      },
+    });
+  }
+  /* End of API Stuff */
 
   _onPreview = (e, refresh) => {
     const { getPreviewData, match } = this.props;
@@ -759,6 +833,14 @@ class AddChart extends Component {
                       this.setState({ apiRequest });
                     }}
                     chartId={newChart.id}
+                    limit={newChart.limit}
+                    items={newChart.items}
+                    offset={newChart.offset}
+                    pagination={newChart.pagination}
+                    onLimitChanged={this._onLimitChanged}
+                    onItemsChanged={this._onItemsChanged}
+                    onOffsetChanged={this._onOffsetChanged}
+                    onPaginationChanged={this._onPaginationChanged}
                   />
                   )}
 

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -329,9 +329,14 @@ class AddChart extends Component {
   _onPaginationChanged = (type, value) => {
     const { newChart } = this.state;
 
+    let newValue = value;
+    if (type === "itemsLimit" && value && value !== "0") {
+      newValue = Math.abs(parseInt(value, 10));
+    }
+
     this.setState({
       newChart: {
-        ...newChart, [type]: value,
+        ...newChart, [type]: newValue,
       },
     });
   }

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -43,10 +43,6 @@ class AddChart extends Component {
           xAxis: "root",
           legend: "Dataset #1",
         }],
-        // TODO: remove this before commit
-        name: "Something",
-        type: "line",
-        subType: "lcTimeseries",
       },
       ddConnections: [],
       updatedEdit: false, // eslint-disable-line
@@ -777,7 +773,7 @@ class AddChart extends Component {
                       this.setState({ apiRequest });
                     }}
                     chartId={newChart.id}
-                    limit={newChart.limit}
+                    itemsLimit={newChart.itemsLimit}
                     items={newChart.items}
                     offset={newChart.offset}
                     pagination={newChart.pagination}

--- a/server/api/ConnectionRoute.js
+++ b/server/api/ConnectionRoute.js
@@ -228,7 +228,7 @@ module.exports = (app) => {
 
         return connectionController.testApiRequest(requestData);
       })
-      .then((apiRequest) => {        
+      .then((apiRequest) => {
         if (!apiRequest) return res.status(500).send("Api Request Error");
         return res.status(200).send(apiRequest);
       })

--- a/server/api/ConnectionRoute.js
+++ b/server/api/ConnectionRoute.js
@@ -223,7 +223,10 @@ module.exports = (app) => {
           throw new Error(401);
         }
 
-        return connectionController.testApiRequest(req.params.connection_id, req.body);
+        const requestData = req.body;
+        requestData.connection_id = req.params.connection_id;
+
+        return connectionController.testApiRequest(requestData);
       })
       .then((apiRequest) => {
         if (!apiRequest) return res.status(500).send("Api Request Error");

--- a/server/api/ConnectionRoute.js
+++ b/server/api/ConnectionRoute.js
@@ -228,7 +228,7 @@ module.exports = (app) => {
 
         return connectionController.testApiRequest(requestData);
       })
-      .then((apiRequest) => {
+      .then((apiRequest) => {        
         if (!apiRequest) return res.status(500).send("Api Request Error");
         return res.status(200).send(apiRequest);
       })

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -356,7 +356,7 @@ class ChartController {
   }
 
   getApiChartData(chart) {
-    return this.connection.testApiRequest(chart.connection_id, chart.apiRequest)
+    return this.connection.testApiRequest(chart)
       .then((data) => {
         return new Promise(resolve => resolve(data));
       })
@@ -411,7 +411,6 @@ class ChartController {
         return new Promise(resolve => resolve(data));
       })
       .catch((error) => {
-        // console.log("Error", error);
         return new Promise((resolve, reject) => reject(error));
       });
   }

--- a/server/controllers/ConnectionController.js
+++ b/server/controllers/ConnectionController.js
@@ -24,7 +24,14 @@ function paginateRequests(options, limit, items, offset, totalResults) {
       const tempResults = totalResults.concat(results);
 
       if (results.length === 0 || (tempResults.length >= limit && limit !== 0)) {
-        return new Promise(resolve => resolve(tempResults));
+        let finalResults = tempResults;
+
+        // check if it goes above the limit
+        if (tempResults.length > limit && limit !== 0) {
+          finalResults = tempResults.slice(0, limit);
+        }
+
+        return new Promise(resolve => resolve(finalResults));
       }
 
       const newOptions = options;
@@ -179,7 +186,7 @@ class ConnectionController {
     connection_id, apiRequest, itemsLimit, items, offset, pagination,
   }) {
     const limit = itemsLimit
-      ? parseInt(itemsLimit, 10) : null;
+      ? parseInt(itemsLimit, 10) : 0;
 
     return this.findById(connection_id)
       .then((connection) => {

--- a/server/models/Chart.js
+++ b/server/models/Chart.js
@@ -105,6 +105,22 @@ const Chart = db.define("Chart", {
     allowNull: false,
     defaultValue: moment().toDate(),
   },
+  pagination: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false,
+  },
+  items: {
+    type: Sequelize.STRING,
+    defaultValue: "items",
+  },
+  itemsLimit: {
+    type: Sequelize.STRING,
+    defaultValue: "limit",
+  },
+  offset: {
+    type: Sequelize.STRING,
+    defaultValue: "offset",
+  },
 }, {
   freezeTableName: true
 });

--- a/server/models/Chart.js
+++ b/server/models/Chart.js
@@ -114,8 +114,8 @@ const Chart = db.define("Chart", {
     defaultValue: "items",
   },
   itemsLimit: {
-    type: Sequelize.STRING,
-    defaultValue: "limit",
+    type: Sequelize.INTEGER,
+    defaultValue: 100,
   },
   offset: {
     type: Sequelize.STRING,


### PR DESCRIPTION
The scope of this PR is to make it possible for the API requests to be split in multiple ones based on the pagination settings.

The Connection API should support pagination for this to work (most do unless it's a custom-made API). The general idea is like this:

* Set up pagination and activate it in the API Builder interface
* The settings will be used to split the request using query parameters or body data
* Async requests will run in parallel until all data is fetched, or until the set limit is hit

![image](https://user-images.githubusercontent.com/5342321/70397942-bfeffc00-1a16-11ea-8d8f-304d9a035c32.png)
