### PR TITLE
Add support for global dataset date filters

### DIFF
--- a/client/src/containers/AddChart/AddChart.js
+++ b/client/src/containers/AddChart/AddChart.js
@@ -386,7 +386,7 @@ function AddChart(props) {
             {match.params.chartId && newChart.type && datasets.length > 0 && (
               <ChartSettings
                 type={newChart.type}
-                subType={newChart.subType}
+                datasets={datasets}
                 pointRadius={newChart.pointRadius}
                 startDate={newChart.startDate}
                 endDate={newChart.endDate}

--- a/client/src/containers/AddChart/components/ChartSettings.js
+++ b/client/src/containers/AddChart/components/ChartSettings.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
   Form, Segment, Checkbox, Grid, Modal, Button,
-  Accordion, Icon, Dropdown, Label, Header,
+  Accordion, Icon, Dropdown, Label, Header, Message,
 } from "semantic-ui-react";
 import moment from "moment";
 import { DateRangePicker } from "react-date-range";
@@ -25,9 +25,10 @@ function ChartSettings(props) {
   const [dateRange, setDateRange] = useState(initSelectionRange);
   const [labelStartDate, setLabelStartDate] = useState("");
   const [labelEndDate, setLabelEndDate] = useState("");
+  const [dateBlocked, setDateBlocked] = useState(false);
 
   const {
-    type, pointRadius, displayLegend,
+    type, pointRadius, displayLegend, datasets,
     endDate, currentEndDate, timeInterval,
     includeZeros, startDate, onChange, onComplete,
   } = props;
@@ -37,6 +38,16 @@ function ChartSettings(props) {
       _onViewRange(true, true);
     }
   }, []);
+
+  useEffect(() => {
+    let noDateFieldFound = false;
+    datasets.map((dataset) => {
+      if (!dataset.dateField) noDateFieldFound = true;
+      return dataset;
+    });
+
+    setDateBlocked(noDateFieldFound);
+  }, [datasets]);
 
   useEffect(() => {
     setDateRange({ startDate, endDate });
@@ -120,54 +131,72 @@ function ChartSettings(props) {
           Global date settings
         </Accordion.Title>
         <Accordion.Content active={activeOption === "daterange"}>
+          {dateBlocked && (
+            <Message size="small">
+              {"All datasets must have a date field selected for the Date Filter to work."}
+            </Message>
+          )}
           <Form>
             <Form.Group widths="equal" style={{ paddingBottom: 20 }}>
-              <Form.Field>
-                <Button
-                  content="Date filter"
-                  primary
-                  icon="calendar"
-                  labelPosition="right"
-                  onClick={() => _onViewRange(true)}
-                      />
-                <Checkbox
-                  checked={startDate != null || endDate != null}
-                  onChange={(e, data) => _onActivateRange(data.checked)}
-                  style={{ ...styles.accordionToggle, ...styles.inlineCheckbox }}
-                      />
-                <div style={{ marginTop: 5 }}>
-                  {startDate && (
+              {!dateBlocked && (
+                <Form.Field>
+                  <Button
+                    content="Date filter"
+                    primary
+                    icon="calendar"
+                    labelPosition="right"
+                    onClick={() => _onViewRange(true)}
+                  />
+                  <Checkbox
+                    checked={startDate != null || endDate != null}
+                    onChange={(e, data) => _onActivateRange(data.checked)}
+                    style={{ ...styles.accordionToggle, ...styles.inlineCheckbox }}
+                  />
+                  <div style={{ marginTop: 5 }}>
+                    {startDate && (
                     <Label
                       color="olive"
                       as="a"
                       onClick={() => setDateRangeModal(true)}
-                          >
+                    >
                       {labelStartDate}
                     </Label>
-                  )}
-                  {startDate && (<span> to </span>)}
-                  {endDate && (
+                    )}
+                    {startDate && (<span> to </span>)}
+                    {endDate && (
                     <Label
                       color="olive"
                       as="a"
                       onClick={() => setDateRangeModal(true)}
-                          >
+                    >
                       {labelEndDate}
                     </Label>
-                  )}
-                </div>
-              </Form.Field>
+                    )}
+                  </div>
+                </Form.Field>
+              )}
+              {dateBlocked && (
+                <Form.Field>
+                  <Button
+                    content="Date filter"
+                    primary
+                    icon="calendar"
+                    labelPosition="right"
+                    disabled
+                  />
+                </Form.Field>
+              )}
               <Form.Field>
                 <Checkbox
                   label="Keep the date range updated with current dates"
                   toggle
                   checked={currentEndDate}
-                  disabled={!dateRange.endDate}
+                  disabled={!dateRange.endDate || dateBlocked}
                   onChange={() => {
                     onChange({ currentEndDate: !currentEndDate });
                   }}
                   style={styles.accordionToggle}
-                      />
+                />
               </Form.Field>
             </Form.Group>
             <Form.Group widths="equal">
@@ -194,7 +223,7 @@ function ChartSettings(props) {
                   }]}
                   value={timeInterval || "day"}
                   onChange={(e, data) => onChange({ timeInterval: data.value })}
-                      />
+                />
               </Form.Field>
               <Form.Field>
                 <label>Show zeros</label>
@@ -203,7 +232,7 @@ function ChartSettings(props) {
                   toggle
                   checked={includeZeros}
                   onChange={() => onChange({ includeZeros: !includeZeros })}
-                      />
+                />
               </Form.Field>
             </Form.Group>
           </Form>
@@ -327,6 +356,7 @@ ChartSettings.defaultProps = {
 
 ChartSettings.propTypes = {
   type: PropTypes.string.isRequired,
+  datasets: PropTypes.array.isRequired,
   displayLegend: PropTypes.bool,
   pointRadius: PropTypes.number,
   startDate: PropTypes.object,

--- a/server/charts/AxisChart.js
+++ b/server/charts/AxisChart.js
@@ -33,7 +33,24 @@ class AxisChart {
       let xAxisData = [];
       let yAxisData = [];
 
-      const filteredData = dataFilter(dataset);
+      let filteredData = dataFilter(dataset.data, xAxis, dataset.options.conditions);
+
+      if (dataset.dateField && this.chart.startDate && this.chart.endDate) {
+        const startDate = moment(this.chart.startDate).startOf(this.chart.timeInterval);
+        const endDate = moment(this.chart.endDate).endOf(this.chart.timeInterval);
+
+        const dateConditions = [{
+          field: dataset.dateField,
+          value: startDate,
+          operator: "greaterOrEqual",
+        }, {
+          field: dataset.dateField,
+          value: endDate,
+          operator: "lessOrEqual",
+        }];
+
+        filteredData = dataFilter(filteredData, dataset.dateField, dateConditions);
+      }
 
       // first, handle the xAxis
       if (xAxis.indexOf("root[]") > -1) {

--- a/server/charts/AxisChart.js
+++ b/server/charts/AxisChart.js
@@ -192,15 +192,23 @@ class AxisChart {
     // now build each dataset matching keys from logObj and allKeys
     for (let i = 0; i < logObj.length; i++) {
       this.axisData.y[i] = [];
+      let previousValue;
       for (const key of allKeys) {
         // add just the first element for now
         if (logObj[i][key]) {
           this.axisData.y[i].push(logObj[i][key][0]);
+        } else if (this.chart.subType.indexOf("AddTimeseries") > -1 && previousValue) {
+          this.axisData.y[i].push(previousValue);
         } else {
           this.axisData.y[i].push(0);
         }
+
+        if (logObj[i][key]) {
+          [previousValue] = logObj[i][key];
+        }
       }
     }
+
     this.axisData.x = allKeys;
 
     let chart;

--- a/server/charts/AxisChart.js
+++ b/server/charts/AxisChart.js
@@ -22,6 +22,17 @@ class AxisChart {
   plot() {
     const finalXAxisData = [];
     let gXType;
+
+    // check if the global date filter should be on or off
+    // the filter should work only if all the datasets have a dateField
+    let canDateFilter = true;
+    this.datasets.map((dataset) => {
+      if (!dataset.options || !dataset.options.dateField) {
+        canDateFilter = false;
+      }
+      return dataset;
+    });
+
     for (let i = 0; i < this.datasets.length; i++) {
       const dataset = this.datasets[i];
       const { yAxisOperation, dateField } = dataset.options;
@@ -35,7 +46,7 @@ class AxisChart {
 
       let filteredData = dataFilter(dataset.data, xAxis, dataset.options.conditions);
 
-      if (dateField && this.chart.startDate && this.chart.endDate) {
+      if (dateField && this.chart.startDate && this.chart.endDate && canDateFilter) {
         let startDate = moment(this.chart.startDate);
         let endDate = moment(this.chart.endDate);
 

--- a/server/charts/dataFilter.js
+++ b/server/charts/dataFilter.js
@@ -6,7 +6,6 @@ const determineType = require("../modules/determineType");
 // TODO: deal with nested objects when field = "fieldParent.fieldChild"
 function compareDates(data, field, condition) {
   let newData = data;
-
   switch (condition.operator) {
     case "is":
       newData = _.filter(newData, (o) => moment(o[field]).isSame(condition.value));

--- a/server/charts/dataFilter.js
+++ b/server/charts/dataFilter.js
@@ -132,19 +132,16 @@ function compareBooleans(data, field, condition) {
   return newData;
 }
 
-module.exports = (dataset) => {
-  const { conditions, xAxis } = dataset.options;
-  const { data } = dataset;
-
+module.exports = (data, selectedField, conditions) => {
   if (!conditions || conditions.length < 1) {
     return data;
   }
 
   let finalData;
-  if (xAxis.indexOf("root[]") > -1) {
+  if (selectedField.indexOf("root[]") > -1) {
     finalData = data;
   } else {
-    const arrayFinder = xAxis.substring(0, xAxis.indexOf("]") - 1);
+    const arrayFinder = selectedField.substring(0, selectedField.indexOf("]") - 1);
     finalData = _.get(data, arrayFinder);
   }
 


### PR DESCRIPTION
This is changing the behaviour of the global dates settings (screenshot below) to work with the new custom X & Y charts. The method before worked because of the specific `timeseries` `subType` that has now been removed in #57 

![image](https://user-images.githubusercontent.com/5342321/97256317-aed9f480-184d-11eb-87cb-08b8f89f2d1c.png)

The new behaviour will allow each dataset to have a custom date field that can be used for the global date filtering:

![image](https://user-images.githubusercontent.com/5342321/97256368-cc0ec300-184d-11eb-9ba3-fa9b9a12d321.png)
