### PR TITLE
Reduce lodash usage to minimum

### DIFF
--- a/client/src/components/InviteMembersForm.js
+++ b/client/src/components/InviteMembersForm.js
@@ -5,7 +5,6 @@ import { withRouter } from "react-router";
 import {
   Segment, Dropdown, Message, Header, Divider, Form, Button, Icon, Grid, Checkbox, Popup
 } from "semantic-ui-react";
-import _ from "lodash";
 
 import { email } from "../config/validations";
 
@@ -75,7 +74,7 @@ function InviteMembersForm(props) {
 
   const _onChangeProjectAccess = (projectId) => {
     const newAccess = [].concat(projectAccess) || [];
-    const isFound = _.indexOf(projectAccess, projectId);
+    const isFound = projectAccess.indexOf(projectId);
 
     if (isFound === -1) {
       newAccess.push(projectId);
@@ -184,7 +183,7 @@ function InviteMembersForm(props) {
               <Checkbox
                 label={project.name}
                 checked={
-                  _.indexOf(projectAccess, project.id) > -1
+                  projectAccess.includes(project.id)
                 }
                 onClick={() => _onChangeProjectAccess(project.id)}
               />

--- a/client/src/containers/AddChart/AddChart.js
+++ b/client/src/containers/AddChart/AddChart.js
@@ -8,7 +8,7 @@ import {
 } from "semantic-ui-react";
 import { ToastContainer, toast, Flip } from "react-toastify";
 import "react-toastify/dist/ReactToastify.min.css";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { useWindowSize } from "react-use";
 
 import ChartPreview from "./components/ChartPreview";
@@ -96,7 +96,7 @@ function AddChart(props) {
   useEffect(() => {
     charts.map((chart) => {
       if (chart.id === parseInt(match.params.chartId, 10)) {
-        if (!_.isEqual(chart, newChart)) {
+        if (!isEqual(chart, newChart)) {
           setNewChart(chart);
           setChartName(chart.name);
         }
@@ -109,7 +109,7 @@ function AddChart(props) {
     let found = false;
     charts.map((chart) => {
       if (chart.id === parseInt(match.params.chartId, 10)) {
-        if (!_.isEqual(chart, newChart)) {
+        if (!isEqual(chart, newChart)) {
           setSaveRequired(true);
           found = true;
         }

--- a/client/src/containers/AddChart/components/ApiBuilder.js
+++ b/client/src/containers/AddChart/components/ApiBuilder.js
@@ -8,7 +8,6 @@ import {
 } from "semantic-ui-react";
 import AceEditor from "react-ace";
 import uuid from "uuid/v4";
-import _ from "lodash";
 import { toast } from "react-toastify";
 
 import "ace-builds/src-min-noconflict/mode-json";
@@ -89,7 +88,7 @@ function ApiBuilder(props) {
       setApiRequest(formattedApiRequest);
 
       // get the request data if it exists
-      const requestBody = _.find(requests, { options: { id: dataset.id } });
+      const requestBody = requests.find(request => request.options.id === dataset.id);
       if (requestBody) {
         setResult(JSON.stringify(requestBody.data, null, 2));
       }

--- a/client/src/containers/AddChart/components/DatarequestModal.js
+++ b/client/src/containers/AddChart/components/DatarequestModal.js
@@ -5,7 +5,7 @@ import { withRouter } from "react-router";
 import {
   Modal, Button, Loader, Container, Placeholder,
 } from "semantic-ui-react";
-import _ from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 import { toast } from "react-toastify";
 
 import ApiBuilder from "./ApiBuilder";
@@ -77,7 +77,7 @@ function DatarequestModal(props) {
   }, [dataRequest]);
 
   useEffect(() => {
-    const request = _.find(requests, { options: { id: dataset.id } });
+    const request = requests.find(request === request.options.id === dataset.id);
     setResult(request);
     if (open && connection.type !== "firestore") changeTutorial("requestmodal");
   }, [requests, dataset]);
@@ -130,7 +130,7 @@ function DatarequestModal(props) {
 
   const _onSaveRequest = (dr = dataRequest) => {
     setLoading(true);
-    const newDr = _.cloneDeep(dr);
+    const newDr = cloneDeep(dr);
     return updateDataRequest(
       match.params.projectId,
       match.params.chartId,

--- a/client/src/containers/AddChart/components/Dataset.js
+++ b/client/src/containers/AddChart/components/Dataset.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import {
   Popup, Icon, Dropdown, Button, Grid,
   Form, Input, Modal, Header, Menu, TransitionablePortal,
@@ -71,7 +71,7 @@ function Dataset(props) {
 
   // update the dataset prop based on new changes
   useEffect(() => {
-    if (_.isEqual(dataset, newDataset)) {
+    if (isEqual(dataset, newDataset)) {
       setSaveRequired(false);
       return;
     }

--- a/client/src/containers/Chart/Chart.js
+++ b/client/src/containers/Chart/Chart.js
@@ -8,7 +8,6 @@ import {
   Dropdown, Message, Popup, Form, TextArea, Label, Input, Divider,
 } from "semantic-ui-react";
 import moment from "moment";
-import _ from "lodash";
 
 import {
   removeChart as removeChartAction,
@@ -192,7 +191,7 @@ function Chart(props) {
       chart.Datasets.map((dataset) => {
         if (dataset.fieldsSchema) {
           Object.keys(dataset.fieldsSchema).forEach((key) => {
-            if (_.find(dashboardFilters, (o) => o.field === key)) {
+            if (dashboardFilters.find((o) => o.field === key)) {
               found = true;
             }
           });
@@ -227,7 +226,7 @@ function Chart(props) {
   };
 
   const _getChartIndex = () => {
-    return _.findIndex(charts, (c) => c.id === chart.id);
+    return charts.findIndex((c) => c.id === chart.id);
   };
 
   const _onExport = () => {

--- a/client/src/containers/Connections/ChartMogul/ChartMogulTemplate.js
+++ b/client/src/containers/Connections/ChartMogul/ChartMogulTemplate.js
@@ -4,7 +4,6 @@ import {
   Segment, Form, Button, Icon, Header, Label, Message, Container, Divider, Grid, Checkbox, Dropdown,
 } from "semantic-ui-react";
 import cookie from "react-cookies";
-import _ from "lodash";
 
 import { generateDashboard } from "../../../actions/project";
 import { API_HOST } from "../../../config/settings";
@@ -127,7 +126,7 @@ function ChartMogulTemplate(props) {
 
   const _onChangeSelectedCharts = (tid) => {
     const newCharts = [].concat(selectedCharts) || [];
-    const isSelected = _.indexOf(selectedCharts, tid);
+    const isSelected = selectedCharts.indexOf(tid);
 
     if (isSelected === -1) {
       newCharts.push(tid);
@@ -262,7 +261,7 @@ function ChartMogulTemplate(props) {
                     <Checkbox
                       label={chart.name}
                       checked={
-                        _.indexOf(selectedCharts, chart.tid) > -1
+                        selectedCharts.includes(chart.tid)
                       }
                       onClick={() => _onChangeSelectedCharts(chart.tid)}
                     />

--- a/client/src/containers/Connections/CustomTemplates/CustomTemplateForm.js
+++ b/client/src/containers/Connections/CustomTemplates/CustomTemplateForm.js
@@ -4,7 +4,7 @@ import { useWindowSize } from "react-use";
 import {
   Button, Card, Checkbox, Header, Image, Divider, Grid, Icon, Popup, TransitionablePortal, Modal
 } from "semantic-ui-react";
-import _ from "lodash";
+import clone from "lodash/clone";
 
 import connectionImages from "../../../config/connectionImages";
 import { generateDashboard } from "../../../actions/project";
@@ -106,13 +106,13 @@ function CustomTemplateForm(props) {
   };
 
   const _onToggleConnection = (cid) => {
-    const newList = _.clone(selectedConnections);
+    const newList = clone(selectedConnections);
     newList[cid].active = !newList[cid].active;
     setSelectedConnections(newList);
   };
 
   const _onToggleCreateNew = (cid) => {
-    const newList = _.clone(selectedConnections);
+    const newList = clone(selectedConnections);
 
     if (newList[cid]) {
       newList[cid].createNew = !newList[cid].createNew;
@@ -122,7 +122,7 @@ function CustomTemplateForm(props) {
 
   const _onChangeSelectedCharts = (tid) => {
     const newCharts = [].concat(selectedCharts) || [];
-    const isSelected = _.indexOf(selectedCharts, tid);
+    const isSelected = selectedCharts.indexOf(tid);
 
     if (isSelected === -1) {
       newCharts.push(tid);
@@ -160,7 +160,7 @@ function CustomTemplateForm(props) {
       }
     }
 
-    if (dependency && _.indexOf(selectedCharts, chart.tid) > -1) {
+    if (dependency && selectedCharts.includes(chart.tid)) {
       _onChangeSelectedCharts(chart.tid);
     }
 
@@ -249,7 +249,7 @@ function CustomTemplateForm(props) {
                 <Checkbox
                   label={chart.name}
                   checked={
-                    _.indexOf(selectedCharts, chart.tid) > -1
+                    selectedCharts.includes(chart.tid)
                   }
                   onClick={() => _onChangeSelectedCharts(chart.tid)}
                 />

--- a/client/src/containers/Connections/Firebase/FirebaseBuilder.js
+++ b/client/src/containers/Connections/Firebase/FirebaseBuilder.js
@@ -6,7 +6,6 @@ import {
   Grid, Form, Input, Button, Icon, Label,
 } from "semantic-ui-react";
 import AceEditor from "react-ace";
-import _ from "lodash";
 import { toast } from "react-toastify";
 
 import "ace-builds/src-min-noconflict/mode-json";
@@ -38,7 +37,7 @@ function FirebaseBuilder(props) {
   useEffect(() => {
     if (dataRequest) {
       // get the request data if it exists
-      const requestBody = _.find(requests, { options: { id: dataset.id } });
+      const requestBody = requests.find(request => request.options.id === dataset.id);
       if (requestBody) {
         setResult(JSON.stringify(requestBody.data, null, 2));
       }

--- a/client/src/containers/Connections/GoogleAnalytics/GaBuilder.js
+++ b/client/src/containers/Connections/GoogleAnalytics/GaBuilder.js
@@ -6,7 +6,6 @@ import {
   Grid, Form, Button, Icon, Header, Divider, Dropdown, Label, Input, Popup, Message,
 } from "semantic-ui-react";
 import AceEditor from "react-ace";
-import _ from "lodash";
 import { toast } from "react-toastify";
 import { Calendar } from "react-date-range";
 import { format, sub } from "date-fns";
@@ -120,7 +119,9 @@ function GaBuilder(props) {
 
   useEffect(() => {
     if (configuration.accountId) {
-      const acc = _.findLast(analyticsData.items, { id: configuration.accountId });
+      const acc = [...analyticsData.items]
+        .reverse()
+        .find(item => item.id === configuration.accountId);
       const propertyOpt = [];
       if (acc && acc.webProperties) {
         acc.webProperties.forEach((prop) => {
@@ -138,10 +139,14 @@ function GaBuilder(props) {
 
   useEffect(() => {
     if (configuration.propertyId && configuration.accountId) {
-      const acc = _.findLast(analyticsData.items, { id: configuration.accountId });
+      const acc = [...analyticsData.items]
+        .reverse()
+        .find(item => item.id === configuration.accountId);
 
       if (acc) {
-        const prop = _.findLast(acc.webProperties, { id: configuration.propertyId });
+        const prop = [...acc.webProperties]
+          .reverse()
+          .find(property => property.id === configuration.propertyId);
         const viewOpt = [];
         if (prop && prop.profiles) {
           prop.profiles.forEach((view) => {
@@ -177,7 +182,7 @@ function GaBuilder(props) {
   const _initRequest = () => {
     if (dataRequest) {
       // get the request data if it exists
-      const requestBody = _.find(requests, { options: { id: dataset.id } });
+      const requestBody = requests.find(request => request.options.id === dataset.id);
       if (requestBody) {
         setResult(JSON.stringify(requestBody.data, null, 2));
       }

--- a/client/src/containers/Connections/GoogleAnalytics/GaTemplate.js
+++ b/client/src/containers/Connections/GoogleAnalytics/GaTemplate.js
@@ -5,7 +5,6 @@ import {
   Segment, Form, Button, Icon, Header, Label, Message,
   Container, Divider, List, Grid, Checkbox, Dropdown,
 } from "semantic-ui-react";
-import _ from "lodash";
 import cookie from "react-cookies";
 
 import {
@@ -80,7 +79,9 @@ function GaTemplate(props) {
 
   useEffect(() => {
     if (configuration.accountId) {
-      const acc = _.findLast(accountsData.items, { id: configuration.accountId });
+      const acc = [...accountsData.items]
+        .reverse()
+        .find(item => item.id === configuration.accountId);
       const propertyOpt = [];
       if (acc && acc.webProperties) {
         acc.webProperties.forEach((prop) => {
@@ -98,10 +99,14 @@ function GaTemplate(props) {
 
   useEffect(() => {
     if (configuration.propertyId && configuration.accountId) {
-      const acc = _.findLast(accountsData.items, { id: configuration.accountId });
+      const acc = [...accountsData.items]
+        .reverse()
+        .find(item => item.id === configuration.accountId);
 
       if (acc) {
-        const prop = _.findLast(acc.webProperties, { id: configuration.propertyId });
+        const prop = [...acc.webProperties]
+          .reverse()
+          .find(property => property.id === configuration.propertyId);
         const viewOpt = [];
         if (prop && prop.profiles) {
           prop.profiles.forEach((view) => {
@@ -283,7 +288,7 @@ function GaTemplate(props) {
 
   const _onChangeSelectedCharts = (tid) => {
     const newCharts = [].concat(selectedCharts) || [];
-    const isSelected = _.indexOf(selectedCharts, tid);
+    const isSelected = selectedCharts.indexOf(tid);
 
     if (isSelected === -1) {
       newCharts.push(tid);
@@ -465,7 +470,7 @@ function GaTemplate(props) {
                     <Checkbox
                       label={chart.name}
                       checked={
-                        _.indexOf(selectedCharts, chart.tid) > -1
+                        selectedCharts.includes(chart.tid)
                       }
                       onClick={() => _onChangeSelectedCharts(chart.tid)}
                     />

--- a/client/src/containers/Connections/Mailgun/MailgunTemplate.js
+++ b/client/src/containers/Connections/Mailgun/MailgunTemplate.js
@@ -4,7 +4,6 @@ import {
   Segment, Form, Button, Icon, Header, Label, Message,
   Container, Divider, Grid, Checkbox, Dropdown,
 } from "semantic-ui-react";
-import _ from "lodash";
 import cookie from "react-cookies";
 
 import { generateDashboard } from "../../../actions/project";
@@ -145,7 +144,7 @@ function MailgunTemplate(props) {
 
   const _onChangeSelectedCharts = (tid) => {
     const newCharts = [].concat(selectedCharts) || [];
-    const isSelected = _.indexOf(selectedCharts, tid);
+    const isSelected = selectedCharts.indexOf(tid);
 
     if (isSelected === -1) {
       newCharts.push(tid);
@@ -297,7 +296,7 @@ function MailgunTemplate(props) {
                     <Checkbox
                       label={chart.name}
                       checked={
-                        _.indexOf(selectedCharts, chart.tid) > -1
+                        selectedCharts.includes(chart.tid)
                       }
                       onClick={() => _onChangeSelectedCharts(chart.tid)}
                     />

--- a/client/src/containers/Connections/SimpleAnalytics/SimpleAnalyticsTemplate.js
+++ b/client/src/containers/Connections/SimpleAnalytics/SimpleAnalyticsTemplate.js
@@ -4,7 +4,6 @@ import {
   Segment, Form, Button, Icon, Header, Label, Message,
   Container, Divider, List, Grid, Checkbox, Dropdown,
 } from "semantic-ui-react";
-import _ from "lodash";
 import cookie from "react-cookies";
 
 import { generateDashboard } from "../../../actions/project";
@@ -123,7 +122,7 @@ function SimpleAnalyticsTemplate(props) {
 
   const _onChangeSelectedCharts = (tid) => {
     const newCharts = [].concat(selectedCharts) || [];
-    const isSelected = _.indexOf(selectedCharts, tid);
+    const isSelected = selectedCharts.indexOf(tid);
 
     if (isSelected === -1) {
       newCharts.push(tid);
@@ -263,7 +262,7 @@ function SimpleAnalyticsTemplate(props) {
                     <Checkbox
                       label={chart.name}
                       checked={
-                        _.indexOf(selectedCharts, chart.tid) > -1
+                        selectedCharts.includes(chart.tid)
                       }
                       onClick={() => _onChangeSelectedCharts(chart.tid)}
                     />

--- a/client/src/containers/Login.js
+++ b/client/src/containers/Login.js
@@ -5,7 +5,6 @@ import { Link } from "react-router-dom";
 import {
   Message, Container, Segment, Header
 } from "semantic-ui-react";
-import _ from "lodash";
 
 import LoginForm from "../components/LoginForm";
 import { cleanErrors as cleanErrorsAction } from "../actions/error";
@@ -23,7 +22,7 @@ class Login extends Component {
 
   render() {
     const { errors } = this.props;
-    const loginError = _.find(errors, { pathname: window.location.pathname });
+    const loginError = errors.find(error => error.pathname === window.location.pathname);
 
     return (
       <div style={styles.container}>

--- a/client/src/containers/ProjectDashboard/ProjectDashboard.js
+++ b/client/src/containers/ProjectDashboard/ProjectDashboard.js
@@ -8,7 +8,8 @@ import {
 } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 import { useLocalStorage, useWindowSize } from "react-use";
-import _ from "lodash";
+import clone from "lodash/clone";
+import cloneDeep from "lodash/cloneDeep";
 import { createMedia } from "@artsy/fresnel";
 import { ToastContainer, toast, Flip } from "react-toastify";
 import "react-toastify/dist/ReactToastify.min.css";
@@ -78,7 +79,7 @@ function ProjectDashboard(props) {
   }, [charts]);
 
   useEffect(() => {
-    if (!autoRefreshed && _.indexOf(autoRefresh, match.params.projectId) > -1) {
+    if (!autoRefreshed && autoRefresh.includes(match.params.projectId)) {
       _onRefreshData();
     }
   }, [autoRefreshed]);
@@ -90,7 +91,7 @@ function ProjectDashboard(props) {
   const _onAddFilter = (filter) => {
     const { projectId } = match.params;
 
-    const newFilters = _.clone(filters) || {};
+    const newFilters = clone(filters) || {};
     if (!newFilters[projectId]) newFilters[projectId] = [];
     newFilters[projectId].push(filter);
     setFilters(newFilters);
@@ -102,16 +103,16 @@ function ProjectDashboard(props) {
     const { projectId } = match.params;
     _runFiltering();
     if (filters && filters[projectId].length === 1) {
-      const newFilters = _.cloneDeep(filters);
+      const newFilters = cloneDeep(filters);
       delete newFilters[projectId];
       setFilters(newFilters);
       return;
     }
 
-    const index = _.findIndex(filters[projectId], { id: filterId });
+    const index = filters[projectId].findIndex(filter => filter.id === filterId);
     if (!index && index !== 0) return;
 
-    const newFilters = _.cloneDeep(filters);
+    const newFilters = cloneDeep(filters);
     newFilters[projectId].splice(index, 1);
 
     setFilters(newFilters);
@@ -184,7 +185,7 @@ function ProjectDashboard(props) {
       chart.Datasets.map((dataset) => {
         if (dataset.fieldsSchema) {
           Object.keys(dataset.fieldsSchema).forEach((key) => {
-            if (_.find(filters[match.params.projectId], (o) => o.field === key)) {
+            if (filters[match.params.projectId].find((o) => o.field === key)) {
               found = true;
             }
           });
@@ -197,7 +198,7 @@ function ProjectDashboard(props) {
   };
 
   const _getOperator = (operator) => {
-    const found = _.find(operators, (o) => o.value === operator);
+    const found = operators.find((o) => o.value === operator);
     return (found && found.key) || "";
   };
 
@@ -272,7 +273,7 @@ function ProjectDashboard(props) {
 
   const _onChangeAutoRefresh = () => {
     const tempAutoRefresh = autoRefresh || [];
-    const index = _.indexOf(autoRefresh, match.params.projectId);
+    const index = autoRefresh.indexOf(match.params.projectId);
     if (index > -1) {
       tempAutoRefresh.splice(index, 1);
     } else {
@@ -425,7 +426,7 @@ function ProjectDashboard(props) {
                           >
                             <Checkbox
                               toggle
-                              checked={_.indexOf(autoRefresh, match.params.projectId) > -1}
+                              checked={autoRefresh.includes(match.params.projectId)}
                               onChange={_onChangeAutoRefresh}
                             />
                           </Label>

--- a/client/src/containers/ProjectDashboard/components/ChartExport.js
+++ b/client/src/containers/ProjectDashboard/components/ChartExport.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import {
   Button, Checkbox, Container, Divider, Grid, Header, Popup
 } from "semantic-ui-react";
-import _ from "lodash";
+import clone from "lodash/clone";
 
 function ChartExport(props) {
   const {
@@ -12,8 +12,8 @@ function ChartExport(props) {
   const [selectedIds, setSelectedIds] = useState([]);
 
   const _onSelectChart = (id) => {
-    const foundIndex = _.indexOf(selectedIds, id);
-    const newSelectedIds = _.clone(selectedIds);
+    const foundIndex = selectedIds.indexOf(id);
+    const newSelectedIds = clone(selectedIds);
 
     if (foundIndex > -1) {
       newSelectedIds.splice(foundIndex, 1);
@@ -62,7 +62,7 @@ function ChartExport(props) {
           return (
             <Grid.Column key={chart.id}>
               <Checkbox
-                checked={_.indexOf(selectedIds, chart.id) > -1}
+                checked={selectedIds.includes(chart.id)}
                 onChange={() => _onSelectChart(chart.id)}
                 label={chart.name}
               />

--- a/client/src/containers/ProjectDashboard/components/Filters.js
+++ b/client/src/containers/ProjectDashboard/components/Filters.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import _ from "lodash";
+import clone from "lodash/clone";
 import uuid from "uuid/v4";
 import {
   Button, Container, Divider, Dropdown, Grid, Header, Icon, Input, Label, Popup,
@@ -33,7 +33,7 @@ function Filters(props) {
             if (dataset.fieldsSchema) {
               Object.keys(dataset.fieldsSchema).forEach((key) => {
                 const type = dataset.fieldsSchema[key];
-                if (_.findIndex(tempFieldOptions, { key }) !== -1) return;
+                if (tempFieldOptions.findIndex(option => option.key === key) !== -1) return;
                 tempFieldOptions.push({
                   key,
                   text: key && key.replace("root[].", "").replace("root.", ""),
@@ -64,7 +64,7 @@ function Filters(props) {
   }, [charts]);
 
   const _updateFilter = (value, type) => {
-    const newFilter = _.clone(filter);
+    const newFilter = clone(filter);
     newFilter[type] = value;
     newFilter.saved = false;
 
@@ -109,6 +109,9 @@ function Filters(props) {
     });
   };
 
+  const operator = operators.find(o => o.value === filter.operator);
+  const fieldOption = fieldOptions.find(o => o.value === filter.field);
+
   return (
     <Container>
       <Grid columns={1} relaxed>
@@ -134,48 +137,40 @@ function Filters(props) {
               className="button"
               options={operators}
               search
-              text={
-                (
-                  _.find(operators, { value: filter.operator })
-                  && _.find(operators, { value: filter.operator }).key
-                )
-                || "="
-              }
+              text={(operator && operator.key) || "="}
               value={filter.operator}
               onChange={(e, data) => _updateFilter(data.value, "operator")}
             />
 
             {(!filter.field
-              || (_.find(fieldOptions, { value: filter.field })
-                && _.find(fieldOptions, { value: filter.field }).type !== "date")) && (
+              || (fieldOption && fieldOption.type !== "date")) && (
                 <Input
                   placeholder="Enter a value"
                   value={filter.value}
                   onChange={(e, data) => _updateFilter(data.value, "value")}
                 />
             )}
-            {_.find(fieldOptions, { value: filter.field })
-              && _.find(fieldOptions, { value: filter.field }).type === "date" && (
-                <Popup
-                  on="click"
-                  position="bottom center"
-                  trigger={(
-                    <Input
-                      placeholder="Enter a value"
-                      icon="calendar alternate"
-                      iconPosition="left"
-                      value={filter.value && format(new Date(filter.value), "Pp", { locale: enGB })}
-                    />
-                  )}
-                  content={(
-                    <Calendar
-                      date={(filter.value && new Date(filter.value)) || new Date()}
-                      onChange={(date) => _updateFilter(formatISO(date), "value")}
-                      locale={enGB}
-                      color={secondary}
-                    />
-                  )}
-                />
+            {fieldOption && fieldOption.type === "date" && (
+            <Popup
+              on="click"
+              position="bottom center"
+              trigger={(
+                <Input
+                  placeholder="Enter a value"
+                  icon="calendar alternate"
+                  iconPosition="left"
+                  value={filter.value && format(new Date(filter.value), "Pp", { locale: enGB })}
+                  />
+              )}
+              content={(
+                <Calendar
+                  date={(filter.value && new Date(filter.value)) || new Date()}
+                  onChange={(date) => _updateFilter(formatISO(date), "value")}
+                  locale={enGB}
+                  color={secondary}
+                  />
+              )}
+              />
             )}
             <Popup
               trigger={<Icon style={{ marginLeft: 15 }} size="large" name="question circle outline" />}

--- a/client/src/containers/Signup.js
+++ b/client/src/containers/Signup.js
@@ -6,7 +6,6 @@ import { Link } from "react-router-dom";
 import {
   Message, Divider, Container, Segment, Form, Button, Header, Icon, Label,
 } from "semantic-ui-react";
-import _ from "lodash";
 
 import { createUser, createInvitedUser, oneaccountAuth } from "../actions/user";
 import { addTeamMember } from "../actions/team";
@@ -147,7 +146,7 @@ class Signup extends Component {
       loading, addedToTeam,
     } = this.state;
 
-    const signupError = _.find(errors, { pathname: window.location.pathname });
+    const signupError = errors.find(error => error.pathname === window.location.pathname);
 
     return (
       <div style={styles.container}>

--- a/client/src/containers/TeamMembers/TeamMembers.js
+++ b/client/src/containers/TeamMembers/TeamMembers.js
@@ -6,7 +6,7 @@ import {
   Dimmer, Message, Segment, Button, Divider, Dropdown, Checkbox, Grid,
   Loader, Container, Header, Modal, List, TransitionablePortal, Popup, Icon, Label,
 } from "semantic-ui-react";
-import _ from "lodash";
+import clone from "lodash/clone";
 import { ToastContainer, toast, Flip } from "react-toastify";
 import "react-toastify/dist/ReactToastify.min.css";
 import { useWindowSize } from "react-use";
@@ -112,7 +112,7 @@ function TeamMembers(props) {
 
   const _onChangeProjectAccess = (projectId) => {
     const newAccess = projectAccess[changedMember.id].projects || [];
-    const isFound = _.indexOf(projectAccess[changedMember.id].projects, projectId);
+    const isFound = projectAccess[changedMember.id].projects.indexOf(projectId);
 
     if (isFound === -1) {
       newAccess.push(projectId);
@@ -136,7 +136,7 @@ function TeamMembers(props) {
       canExport: !changedRole.canExport,
     }, changedMember.id, team.id)
       .then(() => {
-        const newChangedRole = _.clone(changedRole);
+        const newChangedRole = clone(changedRole);
         newChangedRole.canExport = !changedRole.canExport;
         setChangedRole(newChangedRole);
         _getTeam();
@@ -385,7 +385,7 @@ function TeamMembers(props) {
                         toggle
                         label={project.name}
                         checked={
-                          _.indexOf(projectAccess[changedMember.id].projects, project.id) > -1
+                          projectAccess[changedMember.id].projects.includes(project.id)
                         }
                         onClick={() => _onChangeProjectAccess(project.id)}
                       />

--- a/client/src/containers/UserDashboard.js
+++ b/client/src/containers/UserDashboard.js
@@ -6,7 +6,6 @@ import {
   Divider, Dimmer, Loader, Form, Modal, Header, Message, Container,
   Button, Icon, Grid, Card, Step, TransitionablePortal,
 } from "semantic-ui-react";
-import _ from "lodash";
 import { useWindowSize } from "react-use";
 
 import {
@@ -62,7 +61,7 @@ function UserDashboard(props) {
       let shouldOpenNewProject = false;
       let teamOwned;
       teams.map((team) => {
-        if (team.TeamRoles && _.find(team.TeamRoles, { user_id: user.data.id, role: "owner" })) {
+        if (team.TeamRoles && team.TeamRoles.find(teamRole => teamRole.user_id === user.data.id && teamRole.role === "owner")) {
           teamOwned = team;
 
           if (teamOwned.Projects && teamOwned.Projects.length === 0) {

--- a/client/src/modules/fieldFinder.js
+++ b/client/src/modules/fieldFinder.js
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import determineType from "./determineType";
 
 function findFields(coll, currentKey, first, fields) {
@@ -77,7 +75,7 @@ export default function init(collection, checkObjects) {
 
     multiFields.forEach((m) => {
       m.forEach((f) => {
-        if (_.findIndex(fields, { field: f.field }) === -1) {
+        if (fields.findIndex(field => field.field === f.field) === -1) {
           fields.push(f);
         }
       });
@@ -91,7 +89,7 @@ export default function init(collection, checkObjects) {
 
     multiFields.forEach((m) => {
       m.forEach((f) => {
-        if (_.findIndex(fields, { field: f.field }) === -1) {
+        if (fields.findIndex(field => field.field === f.field) === -1) {
           fields.push(f);
         }
       });

--- a/client/src/reducers/template.js
+++ b/client/src/reducers/template.js
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import {
   ADD_TEMPLATE,
   ADD_TEMPLATE_FAILED,
@@ -38,7 +36,7 @@ export default function template(state = {
     case FETCHING_TEMPLATES:
       return { ...state, loading: true, error: false };
     case REMOVE_TEMPLATE:
-      const removeIndex = _.findIndex(state.data, { id: action.id });
+      const removeIndex = state.data.findIndex(item => item.id === action.id);
 
       if (removeIndex === -1) return state;
 


### PR DESCRIPTION
To make the client code a bit smaller and hopefully faster, I replaced several functions imported from `lodash` with built-in functions. I left `flatMap` as I am not aware what are the browsers you want to support, I also left `isEqual`, `clone` and `cloneDeep` as they do not have native alternatives, but now they are directly imported to improve tree-shaking.