### PR TITLE
Simplify query string parsing

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,7 +49,6 @@
         "promise": "8.0.1",
         "prompts": "2.4.0",
         "prop-types": "^15.7.2",
-        "query-string": "^6.13.7",
         "raf": "3.4.0",
         "react": "^17.0.2",
         "react-ace": "^9.2.1",
@@ -13450,14 +13449,6 @@
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28716,20 +28707,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -31454,14 +31431,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -31656,14 +31625,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -46518,11 +46479,6 @@
         }
       }
     },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -58773,17 +58729,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -61131,11 +61076,6 @@
         }
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -61302,11 +61242,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,6 @@
     "promise": "8.0.1",
     "prompts": "2.4.0",
     "prop-types": "^15.7.2",
-    "query-string": "^6.13.7",
     "raf": "3.4.0",
     "react": "^17.0.2",
     "react-ace": "^9.2.1",

--- a/client/src/components/LoginForm.js
+++ b/client/src/components/LoginForm.js
@@ -14,7 +14,6 @@ import { required, email } from "../config/validations";
 
 import { ONE_ACCOUNT_ENABLED } from "../config/settings";
 
-const queryString = require("qs"); // eslint-disable-line
 /*
   Contains login functionality
 */
@@ -95,12 +94,12 @@ class LoginForm extends Component {
 
   loginUser(values) {
     const { login, addTeamMember, history } = this.props;
-    const parsedParams = queryString.parse(document.location.search.slice(1));
+    const params = new URLSearchParams(document.location.search);
 
     this.setState({ loading: true });
     login(values).then((user) => {
-      if (parsedParams.inviteToken) {
-        addTeamMember(user.id, parsedParams.inviteToken);
+      if (params.has("inviteToken")) {
+        addTeamMember(user.id, params.get("inviteToken"));
       }
       this.setState({ loading: false });
       history.push("/user");

--- a/client/src/containers/Connections/Connections.js
+++ b/client/src/containers/Connections/Connections.js
@@ -6,7 +6,6 @@ import {
   Card, Image, Button, Icon, Container, Divider,
   Modal, Header, Message, Segment, TransitionablePortal, Menu, Label,
 } from "semantic-ui-react";
-import queryString from "query-string";
 import { useWindowSize } from "react-use";
 
 import MongoConnectionForm from "./components/MongoConnectionForm";
@@ -73,12 +72,12 @@ function Connections(props) {
 
   useEffect(() => {
     if (connections && connections.length > 0 && !selectedConnection && !editConnection) {
-      const parsedParams = queryString.parse(document.location.search);
-      if (parsedParams.edit && parsedParams.type) {
-        setTemplateConnection(parseInt(parsedParams.edit, 10));
-        setFormType(parsedParams.type);
-      } else if (parsedParams.edit) {
-        const foundConnection = connections.filter((c) => `${c.id}` === parsedParams.edit)[0];
+      const params = new URLSearchParams(document.location.search);
+      if (params.has("edit") && params.has("type")) {
+        setTemplateConnection(parseInt(params.get("edit"), 10));
+        setFormType(params.get("type"));
+      } else if (params.has("edit")) {
+        const foundConnection = connections.filter((c) => `${c.id}` === params.get("edit"))[0];
         if (foundConnection) {
           setEditConnection(foundConnection);
           setFormType(foundConnection.type);

--- a/client/src/containers/GoogleAuth.js
+++ b/client/src/containers/GoogleAuth.js
@@ -6,7 +6,6 @@ import {
   Grid, Loader, Container, Dimmer, Button, Header, Icon
 } from "semantic-ui-react";
 import cookie from "react-cookies";
-import queryString from "query-string";
 
 import { API_HOST } from "../config/settings";
 
@@ -25,8 +24,10 @@ function GoogleAuth(props) {
   }, []);
 
   const _processAuth = () => {
-    const parsedParams = queryString.parse(document.location.search.slice(1));
-    const { state, code } = parsedParams;
+    const params = new URLSearchParams(document.location.search);
+    const state = params.get("state");
+    const code = params.get("code");
+
     if (!state || !code) {
       setError(true);
       return false;

--- a/client/src/containers/PasswordReset.js
+++ b/client/src/containers/PasswordReset.js
@@ -12,7 +12,6 @@ import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import { blue } from "../config/colors";
 import cbLogoSmall from "../assets/logo_inverted.png";
 
-const queryString = require("qs"); // eslint-disable-line
 /*
   Component for verifying a new user
 */
@@ -30,7 +29,7 @@ function PasswordReset(props) {
   }, []);
 
   const _onSubmit = () => {
-    const parsedParams = queryString.parse(document.location.search.slice(1));
+    const params = new URLSearchParams(document.location.search);
 
     if (!password || password.length < 6) {
       setError("Please enter at least 6 characters for your password");
@@ -45,8 +44,8 @@ function PasswordReset(props) {
     setSuccess(false);
     setError(false);
     changePasswordWithToken({
-      token: parsedParams.token,
-      hash: parsedParams.hash,
+      token: params.get("token"),
+      hash: params.get("hash"),
       password,
     })
       .then(() => {

--- a/client/src/containers/ProjectBoard/ProjectBoard.js
+++ b/client/src/containers/ProjectBoard/ProjectBoard.js
@@ -6,7 +6,6 @@ import {
   Dimmer, Loader, Container, Grid, Divider,
 } from "semantic-ui-react";
 import SplitPane from "react-split-pane";
-import queryString from "query-string";
 import { createMedia } from "@artsy/fresnel";
 
 import { getProject, changeActiveProject } from "../../actions/project";
@@ -52,8 +51,8 @@ function ProjectBoard(props) {
   const [isPrinting, setIsPrinting] = useState(false);
 
   useEffect(() => {
-    const parsedParams = queryString.parse(document.location.search.slice(1));
-    if (parsedParams.new) history.push("connections");
+    const params = new URLSearchParams(document.location.search);
+    if (params.has("new")) history.push("connections");
 
     cleanErrors();
     _init();

--- a/client/src/containers/ProjectSettings.js
+++ b/client/src/containers/ProjectSettings.js
@@ -10,7 +10,6 @@ import canAccess from "../config/canAccess";
 import { updateProject, changeActiveProject, removeProject } from "../actions/project";
 import { cleanErrors as cleanErrorsAction } from "../actions/error";
 
-const queryString = require("qs"); // eslint-disable-line
 /*
   Component for verifying a new user
 */

--- a/client/src/containers/Signup.js
+++ b/client/src/containers/Signup.js
@@ -17,7 +17,6 @@ import { cleanErrors as cleanErrorsAction } from "../actions/error";
 
 import { ONE_ACCOUNT_ENABLED } from "../config/settings";
 
-const queryString = require("qs"); // eslint-disable-line
 /*
   Description
 */
@@ -46,10 +45,10 @@ class Signup extends Component {
   submitUser = (values) => {
     const { createUser, history } = this.props;
 
-    const parsedParams = queryString.parse(document.location.search.slice(1));
+    const params = new URLSearchParams(document.location.search);
     this.setState({ loading: true });
-    if (parsedParams.inviteToken) {
-      this._createInvitedUser(values, parsedParams.inviteToken);
+    if (params.has("inviteToken")) {
+      this._createInvitedUser(values, params.get("inviteToken"));
     } else {
       createUser(values)
         .then(() => {
@@ -85,11 +84,11 @@ class Signup extends Component {
     const { oneaccountAuth, history } = this.props;
     const data = event.detail;
 
-    const parsedParams = queryString.parse(document.location.search.slice(1));
+    const params = new URLSearchParams(document.location.search);
     if (!this._isMounted) return;
     this.setState({ oaloading: true });
-    if (parsedParams.inviteToken) {
-      this._createInvitedUser(data, parsedParams.inviteToken);
+    if (params.has("inviteToken")) {
+      this._createInvitedUser(data, params.get("inviteToken"));
     } else {
       oneaccountAuth(data)
         .then(() => {

--- a/client/src/containers/UserInvite.js
+++ b/client/src/containers/UserInvite.js
@@ -10,7 +10,6 @@ import {
 import cookie from "react-cookies";
 import { addTeamMember, getUserByTeamInvite } from "../actions/team";
 
-const queryString = require("qs"); // eslint-disable-line
 /*
   Component for inviting user to the team
 */
@@ -32,12 +31,12 @@ class UserInvite extends Component {
   updateProps = (nextProps) => {
     const { addTeamMember } = this.props;
     const { fetched } = this.state;
-    const parsedParams = queryString.parse(document.location.search.slice(1));
+    const params = new URLSearchParams(document.location.search);
 
-    this.setState({ teamId: parsedParams.team_id });
+    this.setState({ teamId: params.get("team_id") });
     if (nextProps.user.data.id && !fetched) {
       this.setState({ fetched: true });
-      addTeamMember(nextProps.user.data.id, parsedParams.token)
+      addTeamMember(nextProps.user.data.id, params.get("token"))
         .then(() => {
           this.setState({ success: true, loading: false });
         })
@@ -49,15 +48,16 @@ class UserInvite extends Component {
 
   redirectUser() {
     const { getUserByTeamInvite, history } = this.props;
-    const parsedParams = queryString.parse(document.location.search);
+    const params = new URLSearchParams(document.location.search);
+    const token = params.get("token");
 
-    getUserByTeamInvite(parsedParams.token)
+    getUserByTeamInvite(token)
       .then((invitedUser) => {
         if (cookie.load("brewToken")) cookie.remove("brewToken");
         if (invitedUser) {
-          history.push(`/login?inviteToken=${parsedParams.token}`);
+          history.push(`/login?inviteToken=${token}`);
         } else {
-          history.push(`/signup?inviteToken=${parsedParams.token}`);
+          history.push(`/signup?inviteToken=${token}`);
         }
       })
       .catch(() => {

--- a/client/src/containers/VerifyUser.js
+++ b/client/src/containers/VerifyUser.js
@@ -8,7 +8,6 @@ import {
 
 import { verify } from "../actions/user";
 
-const queryString = require("qs"); // eslint-disable-line
 /*
   Component for verifying a new user
 */
@@ -20,9 +19,9 @@ function VerifyUser(props) {
   const [name, setName] = useState("");
 
   useEffect(() => {
-    const parsedParams = queryString.parse(document.location.search.slice(1));
+    const params = new URLSearchParams(document.location.search);
 
-    verify(parsedParams.id, parsedParams.token)
+    verify(params.get("id"), params.get("token"))
       .then((user) => {
         setSuccess(true);
         setLoading(false);


### PR DESCRIPTION
To simplify the code we can use the built-in [`URLSearchParams` API](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Now both `qs` CJS imports and `query-string` package can be removed which will reduce the client code bundle by quite a bit.