### PR TITLE
Postgres SSL option 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.DS_Store*
+.idea/
 node_modules
 docs/.vuepress/dist
 .env
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,8 +118,8 @@ The table below shows the `production` variables. The `development` variables ha
 | CB_DB_HOST <br /><br /> `required` | `localhost` | The host address where the database is located |
 | CB_DB_PORT | `3306` | The port of the hosting address |
 | CB_DB_DIALECT <br /><br /> `required` | `mysql` | Which database to use between `mysql` and `postgres` |
-| CB_SECRET <br /><br /> `required` | `change_to_random_string` | A secure string which is used to encrypt the data in the database |
 | CB_DB_CERT | No default | If your DB requires an SSL connection, use this variable to provide the string value of the certificate |
+| CB_SECRET <br /><br /> `required` | `change_to_random_string` | A secure string which is used to encrypt the data in the database |
 | CB_API_HOST <br /><br /> `required` | `localhost` | The address where the `server` app is running from. This variable is used internally by the `server` app. <br /> **This value is overwritten by the PORT variable (if set)**|
 | CB_API_PORT <br /><br /> `required` | `4019` | The port where the `server` app is running from. This variable is used internally by the `server` app |
 | REACT_APP_CLIENT_HOST <br /><br /> `required` | `http://localhost:4018` | The full address where the `client` app is running from. This variable is used in the `client` app and it's populated during the building process.<br /><br />`Note` The app needs to be restarted/rebuilt when this value is changed. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@ The table below shows the `production` variables. The `development` variables ha
 | CB_DB_PORT | `3306` | The port of the hosting address |
 | CB_DB_DIALECT <br /><br /> `required` | `mysql` | Which database to use between `mysql` and `postgres` |
 | CB_SECRET <br /><br /> `required` | `change_to_random_string` | A secure string which is used to encrypt the data in the database |
+| CB_CB_DB_CERT | No default | If your DB requires an SSL connection, use this variable to provide the string value of the certificate |
 | CB_API_HOST <br /><br /> `required` | `localhost` | The address where the `server` app is running from. This variable is used internally by the `server` app. <br /> **This value is overwritten by the PORT variable (if set)**|
 | CB_API_PORT <br /><br /> `required` | `4019` | The port where the `server` app is running from. This variable is used internally by the `server` app |
 | REACT_APP_CLIENT_HOST <br /><br /> `required` | `http://localhost:4018` | The full address where the `client` app is running from. This variable is used in the `client` app and it's populated during the building process.<br /><br />`Note` The app needs to be restarted/rebuilt when this value is changed. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ The table below shows the `production` variables. The `development` variables ha
 | CB_DB_PORT | `3306` | The port of the hosting address |
 | CB_DB_DIALECT <br /><br /> `required` | `mysql` | Which database to use between `mysql` and `postgres` |
 | CB_SECRET <br /><br /> `required` | `change_to_random_string` | A secure string which is used to encrypt the data in the database |
-| CB_CB_DB_CERT | No default | If your DB requires an SSL connection, use this variable to provide the string value of the certificate |
+| CB_DB_CERT | No default | If your DB requires an SSL connection, use this variable to provide the string value of the certificate |
 | CB_API_HOST <br /><br /> `required` | `localhost` | The address where the `server` app is running from. This variable is used internally by the `server` app. <br /> **This value is overwritten by the PORT variable (if set)**|
 | CB_API_PORT <br /><br /> `required` | `4019` | The port where the `server` app is running from. This variable is used internally by the `server` app |
 | REACT_APP_CLIENT_HOST <br /><br /> `required` | `http://localhost:4018` | The full address where the `client` app is running from. This variable is used in the `client` app and it's populated during the building process.<br /><br />`Note` The app needs to be restarted/rebuilt when this value is changed. |

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -36,6 +36,8 @@ CB_DB_PASSWORD= # Database password
 CB_DB_HOST= # Database host
 CB_DB_PORT= # The port on which your database server runs
 CB_DB_DIALECT= # 'mysql' or `postgres`
+# If your database requires an SSL connection
+CB_DB_CERT= # String format of the certificate 
 
 ### DEVELOPMENT
 
@@ -45,4 +47,6 @@ CB_DB_PASSWORD_DEV= # Database password
 CB_DB_HOST_DEV= # Database host
 CB_DB_PORT_DEV= # The port on which your database server runs
 CB_DB_DIALECT_DEV= # 'mysql' or `postgres`
+# If your database requires an SSL connection
+CB_DB_CERT_DEV= # String format of the certificate 
 ```

--- a/server/models/config/config.js
+++ b/server/models/config/config.js
@@ -9,6 +9,7 @@ module.exports = {
     host: process.env.CB_DB_HOST_DEV,
     dialect: process.env.CB_DB_DIALECT_DEV || "mysql",
     port: process.env.CB_DB_PORT_DEV || 3306,
+    cert: process.env.CB_DB_CERT_DEV,
   },
   test: {
     username: process.env.CB_DB_USERNAME_DEV,
@@ -17,6 +18,7 @@ module.exports = {
     host: process.env.CB_DB_HOST_DEV,
     dialect: process.env.CB_DB_DIALECT_DEV || "mysql",
     port: process.env.CB_DB_PORT_DEV || 3306,
+    cert: process.env.CB_DB_CERT_DEV,
   },
   production: {
     username: process.env.CB_DB_USERNAME,
@@ -25,5 +27,6 @@ module.exports = {
     host: process.env.CB_DB_HOST,
     dialect: process.env.CB_DB_DIALECT || "mysql",
     port: process.env.CB_DB_PORT || 3306,
+    cert: process.env.CB_DB_CERT
   }
 };

--- a/server/models/models/index.js
+++ b/server/models/models/index.js
@@ -10,7 +10,7 @@ const packageJson = require("../../package.json");
 
 const db = {};
 
-const sequelize = new Sequelize(config.database, config.username, config.password, {
+const options = {
   host: config.host,
   port: config.port,
   dialect: config.dialect,
@@ -28,7 +28,15 @@ const sequelize = new Sequelize(config.database, config.username, config.passwor
   dialectOptions: {
     charset: "utf8mb4",
   },
-});
+};
+
+if (config.cert) {
+  options.dialectOptions.ssl = {
+    ca: Buffer.from(config.cert, "base64").toString("ascii")
+  };
+}
+
+const sequelize = new Sequelize(config.database, config.username, config.password, options);
 
 fs
   .readdirSync(__dirname)


### PR DESCRIPTION
## Commit Message

This pull request enhances the database connection options for Chartbrew, allowing for a SSL certificate to be defined as part of the connection parameters.  Reference: https://github.com/chartbrew/chartbrew/issues/129

## Before submitting this PR, I tested this by
* I tested the happy path for my use case, but I did not perform a regression test against other use cases that likely overlap with this changed code.  Un-tested paths I see:  `mysql`, `postgress without ssl`, and `mysql with ssl` 