### PR TITLE
:bug: hide nav bar in printview

### DIFF
--- a/client/src/containers/ProjectBoard/ProjectBoard.js
+++ b/client/src/containers/ProjectBoard/ProjectBoard.js
@@ -174,9 +174,10 @@ function ProjectBoard(props) {
             )} />
         </Switch>
       )}
-      <Navbar />
+
       {!isPrinting && (
         <>
+          <Navbar />
           <Media greaterThan="mobile">
             {/* extract the navbar height from here */}
             <div style={{ height: height - 50 }}>


### PR DESCRIPTION
The nav bar appears and overlaps the information in the print preview, This code fixes it.