### PR TITLE
fixed db migration failed problem on windows.

### DIFF
--- a/server/models/models/index.js
+++ b/server/models/models/index.js
@@ -107,7 +107,7 @@ db.sequelize = sequelize;
 
 const umzug = new Umzug({
   migrations: {
-    glob: path.join(__dirname, "../migrations", "*.js"),
+    glob: ["./migrations/*.js", { cwd: path.join(__dirname, "..") }],
     resolve: (params) => {
       // Custom resolver function to require and run migration files
       const migration = require(params.path); // eslint-disable-line


### PR DESCRIPTION
When running the server on Windows, umzug migration will fail.
This is because the usage of backslashes in paths is restricted by glob on Windows.
[ref here](https://github.com/isaacs/node-glob/blob/main/README.md#windows)

on windows
`console.log(__dirname);
// D:\projects\chartbrew
`
on linux
`console.log(__dirname);
// home/user/projects/chartbrew
`
Test another approach with `replaceAll("\\", "/")` should also fix this issue.