### PR TITLE
Introduce the new Client Editor role with limited access to dataset queries

### DIFF
--- a/client/src/components/DatasetFilters.jsx
+++ b/client/src/components/DatasetFilters.jsx
@@ -6,12 +6,12 @@ import { format, formatISO } from "date-fns";
 import { Calendar } from "react-date-range";
 import { enGB } from "date-fns/locale";
 import { find } from "lodash";
+import { nanoid } from "@reduxjs/toolkit";
 
 import Row from "./Row";
 import Text from "./Text";
 import { secondary } from "../config/colors";
 import { operators } from "../modules/filterOperations";
-import { nanoid } from "@reduxjs/toolkit";
 
 function DatasetFilters(props) {
   const { onUpdate, fieldOptions, dataset } = props;
@@ -161,6 +161,7 @@ function DatasetFilters(props) {
                 selectedKey={condition.field}
                 onSelectionChange={(key) => _updateCondition(condition.id, key, "field")}
                 labelPlacement="outside"
+                size="sm"
               >
                 {fieldOptions.filter((f) => !f.isObject).map((field) => (
                   <AutocompleteItem
@@ -189,6 +190,7 @@ function DatasetFilters(props) {
                       variant="bordered"
                       labelPlacement="outside"
                       className="max-w-[100px]"
+                      size="sm"
                     />
                   </DropdownTrigger>
                   <DropdownMenu
@@ -214,6 +216,7 @@ function DatasetFilters(props) {
                         disabled={(condition.operator === "isNotNull" || condition.operator === "isNull")}
                         labelPlacement="outside"
                         variant="bordered"
+                        size="sm"
                       />
                     )}
                   {find(fieldOptions, { value: condition.field })
@@ -227,6 +230,7 @@ function DatasetFilters(props) {
                             disabled={(condition.operator === "isNotNull" || condition.operator === "isNull")}
                             labelPlacement="outside"
                             variant="bordered"
+                            size="sm"
                           />
                         </PopoverTrigger>
                         <PopoverContent>

--- a/client/src/components/FormulaTips.jsx
+++ b/client/src/components/FormulaTips.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Spacer } from "@nextui-org/react";
+import { Code, Spacer } from "@nextui-org/react";
 import { LuChevronRight } from "react-icons/lu";
 
 import Text from "./Text";
@@ -12,17 +12,18 @@ function FormulaTips() {
         <Text b>{"Formulas allow you to manipulate your final Metric results"}</Text>
       </Row>
       <Spacer y={1} />
-      <Row>
-        <Text>{"For"}</Text>
+      <Row className={"items-center"}>
+        <Text>{"Example for"}</Text>
         <Spacer x={0.5} />
-        <Text b>{"val = 12345"}</Text>
+        <Code>{"val = 12345"}</Code>
       </Row>
       <Spacer y={1} />
       <Row align="center">
         <LuChevronRight />
         <Spacer x={0.5} />
         <Text>
-          {"{val} => 12345"}
+          <Code>{"{val}"}</Code>
+          {" => 12345"}
         </Text>
       </Row>
       <Spacer y={1} />
@@ -30,7 +31,8 @@ function FormulaTips() {
         <LuChevronRight />
         <Spacer x={0.5} />
         <Text>
-          {"{val / 100} => 123.45"}
+          <Code>{"{val / 100}"}</Code>
+          {" => 123.45"}
         </Text>
       </Row>
       <Spacer y={1} />
@@ -38,7 +40,8 @@ function FormulaTips() {
         <LuChevronRight />
         <Spacer x={0.5} />
         <Text>
-          {"$ {val / 100} => $ 123.45"}
+          <Code>{"$ {val / 100}"}</Code>
+          {" => $ 123.45"}
         </Text>
       </Row>
       <Spacer y={1} />
@@ -46,7 +49,8 @@ function FormulaTips() {
         <LuChevronRight />
         <Spacer x={0.5} />
         <Text>
-          {"{val / 100} USD => 123.45 USD"}
+          <Code>{"{val / 100} USD"}</Code>
+          {" => 123.45 USD"}
         </Text>
       </Row>
     </div>

--- a/client/src/components/InviteMembersForm.jsx
+++ b/client/src/components/InviteMembersForm.jsx
@@ -5,7 +5,7 @@ import {
   Button, Tooltip, Spacer, Checkbox, Input, Accordion, Radio, AccordionItem, RadioGroup, Chip,
 } from "@nextui-org/react";
 import _ from "lodash";
-import { LuCheckCheck, LuClipboard, LuClipboardCheck, LuInfo, LuX } from "react-icons/lu";
+import { LuCheck, LuCheckCheck, LuCopy, LuInfo, LuX } from "react-icons/lu";
 import { useParams } from "react-router";
 
 import { generateInviteUrl } from "../slices/team";
@@ -92,6 +92,9 @@ function InviteMembersForm(props) {
   const _onCopyUrl = () => {
     setUrlCopied(true);
     navigator.clipboard.writeText(inviteUrl);
+    setTimeout(() => {
+      setUrlCopied(false);
+    }, 2000);
   };
 
   return (
@@ -118,15 +121,21 @@ function InviteMembersForm(props) {
               </Radio>
               <Radio
                 value="projectAdmin"
-                description={"Can manage all charts in the selected dashboards"}
+                description={"Can manage all charts and reports in the selected dashboards. Can also edit tagged datasets and admin filters."}
               >
-                Dashboard Editor
+                Client Admin
+              </Radio>
+              <Radio
+                value="projectEditor"
+                description={"Can view and edit all charts and reports in the selected dashboard. Can also edit tagged datasets but cannot edit admin filters."}
+              >
+                Client Editor
               </Radio>
               <Radio
                 value="projectViewer"
                 description={"Can view all charts and reports in the selected dashboard"}
               >
-                Dashboard Viewer
+                Client Viewer
               </Radio>
             </RadioGroup>
           </Row>
@@ -227,23 +236,24 @@ function InviteMembersForm(props) {
               label="Share this link with your team"
               id="url-text"
               value={inviteUrl}
-              fullWidth
               readOnly
               variant="bordered"
+              endContent={(
+                <Button
+                  color={urlCopied ? "success" : "default"}
+                  onClick={_onCopyUrl}
+                  size="sm"
+                  isIconOnly
+                  variant="light"
+                >
+                  {urlCopied ? <LuCheck /> : <LuCopy />}
+                </Button>
+              )}
+              className="max-w-[400px]"
             />
           </Row>
           <Spacer y={2} />
           <Row wrap="wrap" align="center">
-            <Button
-              endContent={urlCopied ? <LuClipboardCheck /> : <LuClipboard />}
-              color={urlCopied ? "success" : "primary"}
-              onClick={_onCopyUrl}
-              variant={urlCopied ? "flat" : "solid"}
-              size="sm"
-            >
-              {urlCopied ? "Copied" : "Copy to clipboard"}
-            </Button>
-            <Spacer x={4} />
             <Chip color="warning" variant={"flat"} size="sm">
               {`${role} role`}
             </Chip>

--- a/client/src/config/canAccess.js
+++ b/client/src/config/canAccess.js
@@ -22,8 +22,11 @@ export default function canAccess(role, userId, teamRoles) {
     case "projectAdmin":
       if (teamRole === "teamOwner" || teamRole === "teamAdmin" || teamRole === "projectAdmin") return true;
       break;
+    case "projectEditor":
+      if (teamRole === "teamOwner" || teamRole === "teamAdmin" || teamRole === "projectAdmin" || teamRole === "projectEditor") return true;
+      break;
     case "projectViewer":
-      if (teamRole === "teamOwner" || teamRole === "teamAdmin" || teamRole === "projectAdmin" || teamRole === "projectViewer") return true;
+      if (teamRole === "teamOwner" || teamRole === "teamAdmin" || teamRole === "projectAdmin" || teamRole === "projectEditor" || teamRole === "projectViewer") return true;
       break;
     default:
       return false;

--- a/client/src/containers/AddChart/components/ChartDatasets.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasets.jsx
@@ -116,7 +116,7 @@ function ChartDatasets(props) {
       <Row align={"center"} className={"justify-between"}>
         <Text size="h4">Datasets</Text>
         <div className="flex flex-row gap-1 items-center">
-          {addMode && canAccess("teamAdmin", user.id, team?.TeamRoles) && (
+          {canAccess("teamAdmin", user.id, team?.TeamRoles) && (
             <Button
               size="sm"
               color="primary"
@@ -125,16 +125,19 @@ function ChartDatasets(props) {
               Create dataset
             </Button>
           )}
-          <Button
-            isIconOnly
-            variant="faded"
-            size="sm"
-            onClick={() => setAddMode(!addMode)}
-            className="chart-cdc-add"
-          >
-            {!addMode && (<LuPlus />)}
-            {addMode && (<LuMinus />)}
-          </Button>
+
+          {datasets.length > 0 && chart?.ChartDatasetConfigs.length > 0 && (
+            <Button
+              isIconOnly
+              variant="faded"
+              size="sm"
+              onClick={() => setAddMode(!addMode)}
+              className="chart-cdc-add"
+            >
+              {!addMode && <LuPlus />}
+              {addMode && <LuMinus />}
+            </Button>
+          )}
         </div>
       </Row>
       <Spacer y={4} />
@@ -174,6 +177,10 @@ function ChartDatasets(props) {
             <Text size="sm">{`${_filteredDatasets().length} datasets found`}</Text>
           </div>
           <Spacer y={4} />
+
+          {datasets.length === 0 && (
+            <div>No datasets available.</div>
+          )}
 
           <ScrollShadow className="max-h-[500px] w-full">
             {datasets.length > 0 && _filteredDatasets().map((dataset, index) => (

--- a/client/src/containers/AddChart/components/DatasetAlerts.jsx
+++ b/client/src/containers/AddChart/components/DatasetAlerts.jsx
@@ -110,8 +110,8 @@ function DatasetAlerts(props) {
       return teamMembers;
     }
 
-    if (userRole.role === "projectAdmin") {
-      return teamMembers.filter((tm) => tm.TeamRoles?.find((tr) => tr.projects.includes(parseInt(projectId, 10)) && (tr.role === "projectAdmin" || tr.role === "projectViewer")));
+    if (userRole.role === "projectEditor") {
+      return teamMembers.filter((tm) => tm.TeamRoles?.find((tr) => tr.projects.includes(parseInt(projectId, 10)) && (tr.role === "projectAdmin" || tr.role === "projectEditor" || tr.role === "projectViewer")));
     }
 
     return [{ ...user }];

--- a/client/src/containers/Chart/Chart.jsx
+++ b/client/src/containers/Chart/Chart.jsx
@@ -452,12 +452,12 @@ function Chart(props) {
                     <Chip color="secondary" variant="flat" size="sm">Draft</Chip>
                   )}
                   <>
-                    {_canAccess("projectAdmin") && !editingLayout && (
+                    {_canAccess("projectEditor") && !editingLayout && (
                       <Link to={`/${params.teamId}/${params.projectId}/chart/${chart.id}/edit`}>
                         <Text b className={"text-default"}>{chart.name}</Text>
                       </Link>
                     )}
-                    {(!_canAccess("projectAdmin") || editingLayout) && (
+                    {(!_canAccess("projectEditor") || editingLayout) && (
                       <Text b>{chart.name}</Text>
                     )}
                   </>
@@ -553,7 +553,7 @@ function Chart(props) {
                     >
                       Refresh chart
                     </DropdownItem>
-                    {_canAccess("projectAdmin") && (
+                    {_canAccess("projectEditor") && (
                       <DropdownItem
                         startContent={<LuSettings />}
                         onClick={() => navigate(`/${params.teamId}/${params.projectId}/chart/${chart.id}/edit`)}
@@ -561,7 +561,7 @@ function Chart(props) {
                         Edit chart
                       </DropdownItem>
                     )}
-                    {_canAccess("projectAdmin") && (
+                    {_canAccess("projectEditor") && (
                       <DropdownItem
                         startContent={<LuLayoutDashboard className={editingLayout ? "text-primary" : ""} />}
                         onClick={onEditLayout}
@@ -572,7 +572,7 @@ function Chart(props) {
                         </span>
                       </DropdownItem>
                     )}
-                    {_canAccess("projectAdmin") && (
+                    {_canAccess("projectEditor") && (
                       <DropdownItem startContent={<LuCalendarClock />} onClick={_openUpdateModal}>
                         Auto-update
                       </DropdownItem>
@@ -583,12 +583,12 @@ function Chart(props) {
                     >
                       Export to Excel
                     </DropdownItem>
-                    {!chart.draft && _canAccess("projectAdmin") && (
+                    {!chart.draft && _canAccess("projectEditor") && (
                       <DropdownItem startContent={<LuTv2 />} onClick={_onChangeReport}>
                         {chart.onReport ? "Remove from report" : "Add to report"}
                       </DropdownItem>
                     )}
-                    {!chart.draft && chart.public && _canAccess("projectAdmin") && (
+                    {!chart.draft && chart.public && _canAccess("projectEditor") && (
                       <DropdownItem
                         startContent={chart.public ? <LuUnlock /> : <LuLock />}
                         onClick={_onPublicConfirmation}
@@ -606,7 +606,7 @@ function Chart(props) {
                         {"Open in a new tab"}
                       </DropdownItem>
                     )}
-                    {_canAccess("projectAdmin") && (
+                    {_canAccess("projectEditor") && (
                       <DropdownItem startContent={<LuTrash />} color="danger" onClick={_onDeleteChartConfirmation}>
                         Delete chart
                       </DropdownItem>
@@ -937,7 +937,7 @@ function Chart(props) {
                   label={chart.shareable ? "Disable sharing" : "Enable sharing"}
                   onChange={_onToggleShareable}
                   isSelected={chart.shareable}
-                  disabled={!_canAccess("projectAdmin")}
+                  disabled={!_canAccess("projectEditor")}
                   size="sm"
                 />
                 <Spacer x={0.5} />
@@ -965,7 +965,7 @@ function Chart(props) {
                   </Row>
                 </>
               )}
-              {!_canAccess("projectAdmin") && !chart.public && !chart.shareable && (
+              {!_canAccess("projectEditor") && !chart.public && !chart.shareable && (
                 <>
                   <Spacer y={2} />
                   <Row>

--- a/client/src/containers/Dataset/DatasetBuilder.jsx
+++ b/client/src/containers/Dataset/DatasetBuilder.jsx
@@ -468,11 +468,11 @@ function DatasetBuilder(props) {
             <div className="flex flex-col">
               <Popover>
                 <PopoverTrigger>
-                  <div className="flex flex-row gap-1 items-center">
+                  <div className="flex flex-row gap-1 items-center cursor-pointer">
                     <span className="text-sm">
                       {"Metric formula"}
                     </span>
-                    <LuInfo size={18} />
+                    <LuInfo size={18} className="hover:text-primary" />
                   </div>
                 </PopoverTrigger>
                 <PopoverContent>

--- a/client/src/containers/ProjectBoard/components/ProjectNavigation.jsx
+++ b/client/src/containers/ProjectBoard/components/ProjectNavigation.jsx
@@ -101,7 +101,7 @@ function ProjectNavigation(props) {
                   <LuPresentation color={_checkIfActive("public") ? secondary : "white"} size={24} />
                 </LinkNext>
               </Link>
-              {canAccess("projectAdmin")
+              {canAccess("projectEditor")
                 && (
                   <Link to={`/${teamId}/${projectId}/members`}>
                     <LinkNext className="pointer-events-none">
@@ -109,7 +109,7 @@ function ProjectNavigation(props) {
                     </LinkNext>
                   </Link>
                 )}
-              {canAccess("projectAdmin")
+              {canAccess("projectEditor")
                 && (
                   <Link to={`/${teamId}/${projectId}/settings`}>
                     <LinkNext className="pointer-events-none">
@@ -166,7 +166,7 @@ function ProjectNavigation(props) {
             </Popover>
           </Row>
           <Spacer y={8} />
-          {canAccess("projectAdmin")
+          {canAccess("projectEditor")
             && (
               <Row justify="center" align="center">
                 {menuSize === "small" && (
@@ -262,7 +262,7 @@ function ProjectNavigation(props) {
             </Link>
           </Row>
 
-          {canAccess("projectAdmin") && (
+          {canAccess("projectEditor") && (
             <>
               <Spacer y={1} />
               <Row justify={menuSize === "large" ? "flex-start" : "center"}>
@@ -295,7 +295,7 @@ function ProjectNavigation(props) {
               </Row>
             </>
           )}
-          {canAccess("projectAdmin") && (
+          {canAccess("projectEditor") && (
             <>
               <Spacer y={1} />
               <Row justify={menuSize === "large" ? "flex-start" : "center"}>

--- a/client/src/containers/ProjectDashboard/ProjectDashboard.jsx
+++ b/client/src/containers/ProjectDashboard/ProjectDashboard.jsx
@@ -864,7 +864,7 @@ function ProjectDashboard(props) {
               loading={exportLoading}
               error={exportError}
               onUpdate={(chartId, disabled) => _onUpdateExport(chartId, disabled)}
-              showDisabled={_canAccess("projectAdmin")}
+              showDisabled={_canAccess("projectEditor")}
             />
           </ModalBody>
         </ModalContent>

--- a/client/src/containers/ProjectSettings.jsx
+++ b/client/src/containers/ProjectSettings.jsx
@@ -154,7 +154,7 @@ function ProjectSettings(props) {
           <Button
             type="submit"
             color={success ? "success" : error ? "danger" : "primary"}
-            isDisabled={!_canAccess("projectAdmin")}
+            isDisabled={!_canAccess("projectEditor")}
             onClick={_onSaveName}
             isLoading={loading}
           >
@@ -188,7 +188,7 @@ function ProjectSettings(props) {
         <Button
           color="primary"
           variant="light"
-          disabled={!_canAccess("projectAdmin")}
+          disabled={!_canAccess("projectEditor")}
           onClick={() => _onGetMachineTimezone()}
           startContent={<LuClock4 />}
         >
@@ -200,7 +200,7 @@ function ProjectSettings(props) {
       <Spacer y={2} />
       <Row>
         <Button
-          isDisabled={!_canAccess("projectAdmin") || !projectTimezone || projectTimezone === project.timezone}
+          isDisabled={!_canAccess("projectEditor") || !projectTimezone || projectTimezone === project.timezone}
           onClick={() => _onSaveTimezone()}
           isLoading={loadingTimezone}
           color="primary"
@@ -212,7 +212,7 @@ function ProjectSettings(props) {
           <Button
             color="warning"
             variant="flat"
-            disabled={!_canAccess("projectAdmin")}
+            disabled={!_canAccess("projectEditor")}
             endContent={<LuX />}
             onClick={() => _onSaveTimezone(true)}
           >

--- a/client/src/containers/PublicDashboard/PublicDashboard.jsx
+++ b/client/src/containers/PublicDashboard/PublicDashboard.jsx
@@ -578,7 +578,7 @@ function PublicDashboard(props) {
                 </Tooltip>
               </div>
 
-              {project?.id && _canAccess("projectAdmin") && (
+              {project?.id && _canAccess("projectEditor") && (
                 <>
                   <div>
                     <Tooltip content="Change logo" placement="right-end">

--- a/client/src/containers/TeamMembers/TeamMembers.jsx
+++ b/client/src/containers/TeamMembers/TeamMembers.jsx
@@ -9,7 +9,7 @@ import {
 import _ from "lodash";
 import { ToastContainer, toast, Flip } from "react-toastify";
 import { useParams } from "react-router";
-import { LuBookKey, LuInfo, LuUsers2, LuX, LuXCircle } from "react-icons/lu";
+import { LuContact, LuFolderKey, LuInfo, LuStar, LuUser, LuX, LuXCircle } from "react-icons/lu";
 
 import "react-toastify/dist/ReactToastify.min.css";
 
@@ -122,10 +122,10 @@ function TeamMembers(props) {
         const newProjectAccess = _.cloneDeep(projectAccess);
         newProjectAccess[changedMember.id].projects = newAccess;
         setProjectAccess(newProjectAccess);
-        toast.success("Updated the user access 👨‍🎓");
+        toast.success("Updated the user access 🔑");
       })
       .catch(() => {
-        toast.error("Oh no! There's a server issue 🙈 Please try again");
+        toast.error("Oh no! There's a server issue. Please try again");
       });
   };
 
@@ -221,10 +221,11 @@ function TeamMembers(props) {
                       <Text size="sm" className={"text-foreground-500"}>{member.email}</Text>
                     </TableCell>
                     <TableCell key="role">
-                      {memberRole.role === "teamOwner" && <Chip color="primary" variant="flat" size="sm">Team Owner</Chip>}
-                      {memberRole.role === "teamAdmin" && <Chip color="success" variant="flat" size="sm">Team Admin</Chip>}
-                      {memberRole.role === "projectAdmin" && <Chip color="secondary" variant="flat" size="sm">Project admin</Chip>}
-                      {memberRole.role === "projectViewer" && <Chip color="default" variant="flat" size="sm">Project viewer</Chip>}
+                      {memberRole.role === "teamOwner" && <Chip color="primary" variant="flat" size="sm" startContent={<LuStar size={18} />}>Team Owner</Chip>}
+                      {memberRole.role === "teamAdmin" && <Chip color="success" variant="flat" size="sm" startContent={<LuStar size={18} />}>Team Admin</Chip>}
+                      {memberRole.role === "projectAdmin" && <Chip color="secondary" variant="flat" size="sm" startContent={<LuUser size={18} />}>Client admin</Chip>}
+                      {memberRole.role === "projectEditor" && <Chip color="warning" variant="flat" size="sm" startContent={<LuUser size={18} />}>Client editor</Chip>}
+                      {memberRole.role === "projectViewer" && <Chip color="default" variant="flat" size="sm" startContent={<LuUser size={18} />}>Client viewer</Chip>}
                     </TableCell>
                     <TableCell key="projectAccess">
                       {memberRole.role !== "teamOwner" && memberRole.role !== "teamAdmin" ? memberRole?.projects?.length : ""}
@@ -239,15 +240,15 @@ function TeamMembers(props) {
                         <Row className={"gap-2"}>
                           {_canAccess("teamAdmin") && memberRole.role !== "teamOwner" && memberRole !== "teamAdmin" && (
                             <>
-                              <Tooltip content="Adjust project access">
+                              <Tooltip content="Change dashboard access">
                                 <Button
                                   variant="light"
-                                  color="primary"
                                   isIconOnly
                                   auto
                                   onClick={() => _openProjectAccess(member)}
+                                  size="sm"
                                 >
-                                  <LuBookKey />
+                                  <LuFolderKey />
                                 </Button>
                               </Tooltip>
                             </>
@@ -255,53 +256,70 @@ function TeamMembers(props) {
                           {_canAccess("teamAdmin") && user.id !== member.id && (
                             <>
                               <Tooltip content="Change member role">
-                                <Dropdown>
-                                  <DropdownTrigger>
-                                    <Button variant="light" auto isIconOnly color="secondary">
-                                      <LuUsers2 />
-                                    </Button>
-                                  </DropdownTrigger>
-                                  <DropdownMenu
-                                    variant="bordered"
-                                    onAction={(key) => _onChangeRole(key, member)}
-                                    selectedKeys={[memberRole.role]}
-                                    selectionMode="single"
-                                  >
-                                    {user.id !== member.id
-                                      && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
-                                      && (
-                                        <DropdownItem
-                                          key="teamAdmin"
-                                          textValue="Team Admin"
-                                          description={"Full access, but can't delete the team"}
-                                        >
-                                          <Text>Team Admin</Text>
-                                        </DropdownItem>
-                                      )}
-                                    {user.id !== member.id
-                                      && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
-                                      && (
-                                        <DropdownItem
-                                          key="projectAdmin"
-                                          textValue="Project Admin"
-                                          description={"Can create, edit, and remove charts and connections in assigned projects"}
-                                        >
-                                          <Text>Project Admin</Text>
-                                        </DropdownItem>
-                                      )}
-                                    {user.id !== member.id
-                                      && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
-                                      && (
-                                        <DropdownItem
-                                          key="projectViewer"
-                                          textValue="Project Viewer"
-                                          description={"Can view charts in assigned projects"}
-                                        >
-                                          <Text>Project Viewer</Text>
-                                        </DropdownItem>
-                                      )}
-                                  </DropdownMenu>
-                                </Dropdown>
+                                <div>
+                                  <Dropdown>
+                                    <DropdownTrigger>
+                                      <Button variant="light" auto isIconOnly size="sm">
+                                        <LuContact />
+                                      </Button>
+                                    </DropdownTrigger>
+                                    <DropdownMenu
+                                      onAction={(key) => _onChangeRole(key, member)}
+                                      selectedKeys={[memberRole.role]}
+                                      selectionMode="single"
+                                      aria-label="Change member role"
+                                    >
+                                      {user.id !== member.id
+                                        && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
+                                        && (
+                                          <DropdownItem
+                                            key="teamAdmin"
+                                            textValue="Team Admin"
+                                            description={"Full access, but can't delete the team"}
+                                            className="max-w-[400px]"
+                                          >
+                                            <Text>Team Admin</Text>
+                                          </DropdownItem>
+                                        )}
+                                      {user.id !== member.id
+                                        && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
+                                        && (
+                                          <DropdownItem
+                                            key="projectAdmin"
+                                            textValue="Client admin"
+                                            description={"Can create, edit, and remove charts in assigned dashboards. The admins can also edit the tagged dataset configurations, including the query and admin filters."}
+                                            className="max-w-[400px]"
+                                          >
+                                            <Text>Client admin</Text>
+                                          </DropdownItem>
+                                        )}
+                                      {user.id !== member.id
+                                        && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
+                                        && (
+                                          <DropdownItem
+                                            key="projectEditor"
+                                            textValue="Client editor"
+                                            description={"Can create, edit, and remove charts in assigned dashboards. The editors can also edit the tagged dataset configurations, but cannot edit the query and admin filters."}
+                                            className="max-w-[400px]"
+                                          >
+                                            <Text>Client editor</Text>
+                                          </DropdownItem>
+                                        )}
+                                      {user.id !== member.id
+                                        && (_canAccess("teamOwner") || (_canAccess("teamAdmin") && memberRole.role !== "teamOwner"))
+                                        && (
+                                          <DropdownItem
+                                            key="projectViewer"
+                                            textValue="Dashboard viewer"
+                                            description={"Can view charts in assigned projects, but cannot edit or remove anything."}
+                                            className="max-w-[400px]"
+                                          >
+                                            <Text>Dashboard viewer</Text>
+                                          </DropdownItem>
+                                        )}
+                                    </DropdownMenu>
+                                  </Dropdown>
+                                </div>
                               </Tooltip>
                             </>
                           )}
@@ -314,6 +332,7 @@ function TeamMembers(props) {
                                   onClick={() => _onDeleteConfirmation(member.id)}
                                   isIconOnly
                                   color="danger"
+                                  size="sm"
                                 >
                                   <LuXCircle />
                                 </Button>

--- a/client/src/containers/UserDashboard/UserDashboard.jsx
+++ b/client/src/containers/UserDashboard/UserDashboard.jsx
@@ -494,7 +494,7 @@ function UserDashboard(props) {
                   >
                     <span className="text-lg">Dashboards</span>
                   </ListboxItem>
-                  {_canAccess("projectAdmin", team.TeamRoles) && (
+                  {_canAccess("teamAdmin", team.TeamRoles) && (
                     <ListboxItem
                       key="connections"
                       startContent={<LuPlug size={24} />}
@@ -505,7 +505,7 @@ function UserDashboard(props) {
                       <span className="text-lg">Connections</span>
                     </ListboxItem>
                   )}
-                  {_canAccess("projectAdmin", team.TeamRoles) && (
+                  {_canAccess("projectEditor", team.TeamRoles) && (
                     <ListboxItem
                       key="datasets"
                       showDivider={_canAccess("teamAdmin", team.TeamRoles)}
@@ -763,7 +763,7 @@ function UserDashboard(props) {
                       )}
                     </Table>
                   )}
-                  {projects && projects.length === 0 && !_canAccess("projectAdmin", team.TeamRoles) && (
+                  {projects && projects.length === 0 && !_canAccess("projectEditor", team.TeamRoles) && (
                     <Container>
                     <Text size="h3">
                         {"No project over here"}

--- a/server/api/ConnectionRoute.js
+++ b/server/api/ConnectionRoute.js
@@ -74,7 +74,7 @@ module.exports = (app) => {
         return next();
       }
 
-      if (role === "projectAdmin" || role === "projectViewer") {
+      if (role === "projectAdmin" || role === "projectViewer" || role === "projectEditor") {
         const connections = await connectionController.findByProjects(team_id, projects);
         if (!connections || connections.length === 0) {
           return res.status(404).json({ message: "No connections found" });

--- a/server/api/ConnectionRoute.js
+++ b/server/api/ConnectionRoute.js
@@ -82,6 +82,7 @@ module.exports = (app) => {
 
         // save the projects in the user object
         req.user.projects = projects;
+        req.user.permittedFields = permission.attributes;
 
         return next();
       }
@@ -126,12 +127,24 @@ module.exports = (app) => {
       }
 
       if (req.user.projects) {
-        const filteredConnections = connections.filter((connection) => {
+        let filteredConnections = connections.filter((connection) => {
           if (!connection.project_ids) return false;
           return connection.project_ids.some((projectId) => {
             return req.user.projects.includes(projectId);
           });
         });
+
+        if (req.user.permittedFields) {
+          filteredConnections = filteredConnections.map((connection) => {
+            const newConnection = connection.toJSON();
+            Object.keys(newConnection).forEach((key) => {
+              if (!req.user.permittedFields.includes(key)) {
+                newConnection[key] = null;
+              }
+            });
+            return newConnection;
+          });
+        }
 
         return res.status(200).send(filteredConnections);
       }
@@ -168,10 +181,20 @@ module.exports = (app) => {
   app.get("/team/:team_id/connections/:connection_id", verifyToken, checkPermissions("readOwn"), (req, res) => {
     return connectionController.findById(req.params.connection_id)
       .then((connection) => {
-        const newConnection = connection;
+        let newConnection = connection;
         if (!req.user.isEditor) {
           newConnection.password = "";
         }
+
+        if (req.user.permittedFields) {
+          newConnection = connection.toJSON();
+          Object.keys(newConnection).forEach((key) => {
+            if (!req.user.permittedFields.includes(key)) {
+              newConnection[key] = null;
+            }
+          });
+        }
+
         return res.status(200).send(newConnection);
       })
       .catch((error) => {
@@ -199,7 +222,20 @@ module.exports = (app) => {
         return connectionController.findByProject(req.params.project_id);
       })
       .then((connections) => {
-        return res.status(200).send(connections);
+        let filteredConnections = connections;
+        if (req.user.permittedFields) {
+          filteredConnections = connections.map((connection) => {
+            const newConnection = connection.toJSON();
+            Object.keys(newConnection).forEach((key) => {
+              if (!req.user.permittedFields.includes(key)) {
+                newConnection[key] = null;
+              }
+            });
+            return newConnection;
+          });
+        }
+
+        return res.status(200).send(filteredConnections);
       })
       .catch((error) => {
         if (error.message === "401") {

--- a/server/api/DataRequestRoute.js
+++ b/server/api/DataRequestRoute.js
@@ -27,7 +27,7 @@ module.exports = (app) => {
       return next();
     }
 
-    if (role === "projectAdmin" || role === "projectViewer") {
+    if (role === "projectAdmin" || role === "projectEditor" || role === "projectViewer") {
       const connections = await datasetController.findByProjects(team_id, projects);
       if (!connections || connections.length === 0) {
         return res.status(404).json({ message: "No connections found" });

--- a/server/api/DatasetRoute.js
+++ b/server/api/DatasetRoute.js
@@ -37,7 +37,7 @@ module.exports = (app) => {
         return next();
       }
 
-      if (role === "projectAdmin" || role === "projectViewer") {
+      if (role === "projectAdmin" || role === "projectEditor" || role === "projectViewer") {
         const datasets = await datasetController.findByProjects(team_id, projects);
         if (!datasets || datasets.length === 0) {
           return res.status(404).json({ message: "No datasets found" });

--- a/server/api/DatasetRoute.js
+++ b/server/api/DatasetRoute.js
@@ -20,7 +20,7 @@ module.exports = (app) => {
       }
 
       let permission;
-      if (teamRole.role === "projectAdmin" && actionType.indexOf("Any") > -1) {
+      if ((teamRole.role === "projectAdmin" || teamRole.role === "projectEditor") && actionType.indexOf("Any") > -1) {
         permission = accessControl.can(teamRole.role)[actionType.replace("Any", "Own")]("dataset");
       } else {
         permission = accessControl.can(teamRole.role)[actionType]("dataset");

--- a/server/api/GoogleRoute.js
+++ b/server/api/GoogleRoute.js
@@ -36,7 +36,7 @@ module.exports = (app) => {
         return next();
       }
 
-      if (role === "projectAdmin" || role === "projectViewer") {
+      if (role === "projectAdmin" || role === "projectEditor" || role === "projectViewer") {
         const connections = await connectionController.findByProjects(team_id, projects);
         if (!connections || connections.length === 0) {
           return res.status(404).json({ message: "No connections found" });

--- a/server/api/TeamRoute.js
+++ b/server/api/TeamRoute.js
@@ -38,7 +38,7 @@ module.exports = (app) => {
         return next();
       }
 
-      if (role === "projectAdmin" || role === "projectViewer") {
+      if (role === "projectAdmin" || role === "projectViewer" || role === "projectEditor") {
         // const connections = await connectionController.findByProjects(projects);
         // if (!connections || connections.length === 0) {
         //   return res.status(404).json({ message: "No connections found" });

--- a/server/modules/accessControl.js
+++ b/server/modules/accessControl.js
@@ -446,20 +446,11 @@ const grantList = [
     role: "projectEditor", resource: "dataset", action: "read:own", attributes: "*",
   },
   {
-    role: "projectEditor", resource: "dataset", action: "update:own", attributes: ["*", "!query"],
+    role: "projectEditor", resource: "dataset", action: "update:own", attributes: "*",
   },
   // resource: request ---> Team Perspective
   {
-    role: "projectEditor", resource: "dataRequest", action: "create:own", attributes: "*",
-  },
-  {
     role: "projectEditor", resource: "dataRequest", action: "read:own", attributes: "*",
-  },
-  {
-    role: "projectEditor", resource: "dataRequest", action: "update:own", attributes: "*",
-  },
-  {
-    role: "projectEditor", resource: "dataRequest", action: "delete:own", attributes: "*",
   },
   // resource: apiKey ---> Team Perspective
   //

--- a/server/modules/accessControl.js
+++ b/server/modules/accessControl.js
@@ -398,6 +398,86 @@ const grantList = [
   },
   //
   // --------------------
+  //    PROJECT EDITOR
+  // --------------------
+  //
+  {
+    role: "projectEditor", resource: "team", action: "read:own", attributes: ["id", "name"],
+  },
+  // resource: project ---> Team Perspective
+  {
+    role: "projectEditor", resource: "project", action: "read:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "project", action: "update:own", attributes: "*",
+  },
+  // resource: connection ---> Team Perspective
+  {
+    role: "projectEditor", resource: "connection", action: "read:own", attributes: "*",
+  },
+  // resource: teamRole ---> Team Perspective
+  {
+    role: "projectEditor", resource: "teamRole", action: "read:own", attributes: "*",
+  },
+  // resource: teamInvite ---> Team Perspective
+  //
+  // resource: projectRole  ---> Team Perspective
+  //
+  // resource: chart
+  {
+    role: "projectEditor", resource: "chart", action: "create:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "chart", action: "read:any", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "chart", action: "update:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "chart", action: "delete:own", attributes: "*",
+  },
+  // resource: savedQuery ---> Team Perspective
+  //
+  // resource: dataset ---> Team Perspective
+  {
+    role: "projectEditor", resource: "dataset", action: "create:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "dataset", action: "read:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "dataset", action: "update:own", attributes: ["*", "!query"],
+  },
+  // resource: request ---> Team Perspective
+  {
+    role: "projectEditor", resource: "dataRequest", action: "create:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "dataRequest", action: "read:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "dataRequest", action: "update:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "dataRequest", action: "delete:own", attributes: "*",
+  },
+  // resource: apiKey ---> Team Perspective
+  //
+  // resource: integration ---> Team Perspective
+  {
+    role: "projectEditor", resource: "integration", action: "create:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "integration", action: "read:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "integration", action: "update:own", attributes: "*",
+  },
+  {
+    role: "projectEditor", resource: "integration", action: "delete:own", attributes: "*",
+  },
+  //
+  // --------------------
   //    PROJECT VIEWER
   // --------------------
   //

--- a/server/modules/accessControl.js
+++ b/server/modules/accessControl.js
@@ -333,7 +333,7 @@ const grantList = [
   },
   // resource: connection ---> Team Perspective
   {
-    role: "projectAdmin", resource: "connection", action: "read:own", attributes: "*",
+    role: "projectAdmin", resource: "connection", action: "read:own", attributes: ["id", "name", "type", "subType", "createdAt", "updatedAt"],
   },
   // resource: teamRole ---> Team Perspective
   {
@@ -413,7 +413,7 @@ const grantList = [
   },
   // resource: connection ---> Team Perspective
   {
-    role: "projectEditor", resource: "connection", action: "read:own", attributes: "*",
+    role: "projectEditor", resource: "connection", action: "read:own", attributes: ["id", "name", "type", "subType", "createdAt", "updatedAt"],
   },
   // resource: teamRole ---> Team Perspective
   {


### PR DESCRIPTION
**EDIT**
> adjusted the scope of the PR to not include the admin filters functionality. This functionality will require the filters to be de-coupled in their own table rather than in the `conditions` JSON field that is attached to the `Dataset` table

> The new scope of the PR will be to add the new `projectEditor` (Dashboard editor) role that is similar to the admin, minus the access to the dataset query menu

- [x] Add new role
- [x] Disallow Client Editor from accessing the Dataset Query UI and update Dataset query in the backend