### PR TITLE
✨ Introducing the new dashboard update schedule

### DIFF
--- a/client/src/containers/ProjectDashboard/ProjectDashboard.jsx
+++ b/client/src/containers/ProjectDashboard/ProjectDashboard.jsx
@@ -13,6 +13,7 @@ import { ToastContainer, toast, Flip } from "react-toastify";
 import "react-toastify/dist/ReactToastify.min.css";
 import moment from "moment";
 import {
+  LuCalendarClock,
   LuCopyPlus, LuFileDown, LuLayoutDashboard, LuListFilter,
   LuPlusCircle, LuRefreshCw, LuUser, LuUsers2, LuVariable, LuXCircle,
 } from "react-icons/lu";
@@ -38,6 +39,8 @@ import { TbChevronDownRight } from "react-icons/tb";
 import { widthSize } from "../../modules/layoutBreakpoints";
 import { selectUser } from "../../slices/user";
 import gridBreakpoints from "../../config/gridBreakpoints";
+import UpdateSchedule from "./components/UpdateSchedule";
+import { selectProject } from "../../slices/project";
 
 const ResponsiveGridLayout = WidthProvider(Responsive, { measureBeforeMount: true });
 
@@ -94,6 +97,7 @@ function ProjectDashboard(props) {
   const [layouts, setLayouts] = useState(null);
   const [editingLayout, setEditingLayout] = useState(false);
   const [variables, setVariables] = useState(getVariablesFromStorage());
+  const [scheduleVisible, setScheduleVisible] = useState(false);
 
   const params = useParams();
   const dispatch = useDispatch();
@@ -102,6 +106,7 @@ function ProjectDashboard(props) {
   const team = useSelector(selectTeam);
   const user = useSelector(selectUser);
   const charts = useSelector(selectCharts);
+  const project = useSelector(selectProject);
   const chartsLoading = useSelector((state) => state.chart.loading);
   const projectMembers = useSelector((state) => selectProjectMembers(state, params.projectId));
 
@@ -706,8 +711,23 @@ function ProjectDashboard(props) {
                   </div>
                 </Row>
                 <Row justify="flex-end" align="center">
+                  {_canAccess("projectEditor") && (
+                    <>
+                      <Tooltip content="Schedule data updates for this dashboard" placement="bottom">
+                        <Button
+                          variant="light"
+                          isIconOnly
+                          onClick={() => setScheduleVisible(true)}
+                          size="sm"
+                        >
+                          <LuCalendarClock size={22} />
+                        </Button>
+                      </Tooltip>
+                    </>
+                  )}
                   {_canAccess("teamAdmin") && (
                     <>
+                      <Spacer x={0.5} />
                       <Tooltip content="Create a template from this dashboard" placement="bottom">
                         <Button
                           variant="light"
@@ -880,6 +900,12 @@ function ProjectDashboard(props) {
           </ModalBody>
         </ModalContent>
       </Modal>
+
+      <UpdateSchedule
+        isOpen={scheduleVisible}
+        onClose={() => setScheduleVisible(false)}
+        timezone={project.timezone}
+      />
 
       <CreateTemplateForm
         teamId={params.teamId}

--- a/client/src/containers/ProjectDashboard/components/UpdateSchedule.jsx
+++ b/client/src/containers/ProjectDashboard/components/UpdateSchedule.jsx
@@ -1,0 +1,155 @@
+import React, { useState } from "react"
+import PropTypes from "prop-types";
+import { Autocomplete, AutocompleteItem, Button, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Select, SelectItem, TimeInput } from "@nextui-org/react";
+import timezones from "../../../modules/timezones";
+import { LuMapPin } from "react-icons/lu";
+
+const getMachineTimezone = () => {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+};
+
+function UpdateSchedule({ isOpen, onClose, timezone }) {
+  const [schedule, setSchedule] = useState({
+    timezone: timezone || getMachineTimezone(),
+  });
+
+  const frequencies = [
+    { label: "Daily", value: "daily" },
+    { label: "Weekly", value: "weekly" },
+    { label: "Every X days", value: "every_x_days" },
+    { label: "Every X hours", value: "every_x_hours" },
+    { label: "Every X minutes", value: "every_x_minutes" },
+  ];
+
+  const daysOfWeek = [
+    { label: "Monday", value: "monday" },
+    { label: "Tuesday", value: "tuesday" },
+    { label: "Wednesday", value: "wednesday" },
+    { label: "Thursday", value: "thursday" },
+    { label: "Friday", value: "friday" },
+    { label: "Saturday", value: "saturday" },
+    { label: "Sunday", value: "sunday" },
+  ];
+
+  const _onSave = () => {
+    // console.log("schedule", schedule);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="2xl">
+      <ModalContent>
+        <ModalHeader>
+          <div className='text-lg font-bold'>Schedule dashboard updates</div>
+        </ModalHeader>
+        <ModalBody>
+          <div className="flex flex-row flex-wrap sm:flex-nowrap items-center gap-2">
+            <Select
+              placeholder="Select update frequency"
+              aria-label="Update frequency"
+              variant="bordered"
+              selectedKeys={[schedule.frequency]}
+              onSelectionChange={(keys) => setSchedule({ ...schedule, frequency: keys.currentKey })}
+            >
+              {frequencies.map((frequency) => (
+                <SelectItem key={frequency.value} textValue={frequency.label}>
+                  {frequency.label}
+                </SelectItem>
+              ))}
+            </Select>
+
+            {schedule.frequency === "weekly" && (
+              <>
+                <div>{"on"}</div>
+                <Select
+                  placeholder="Select day"
+                  aria-label="Update day of week"
+                  variant="bordered"
+                  selectedKeys={[schedule.dayOfWeek]}
+                  onSelectionChange={(keys) => setSchedule({ ...schedule, dayOfWeek: keys.currentKey })}
+                >
+                  {daysOfWeek.map((day) => (
+                    <SelectItem key={day.value} textValue={day.label}>
+                      {day.label}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </>
+            )}
+
+            {(schedule.frequency === "every_x_days" || schedule.frequency === "every_x_hours" || schedule.frequency === "every_x_minutes") && (
+              <Input
+                placeholder="X"
+                type="number"
+                aria-label="Update frequency"
+                variant="bordered"
+                value={schedule.frequencyNumber}
+                onChange={(e) => setSchedule({ ...schedule, frequencyNumber: e.target.value })}
+              />
+            )}
+
+            {(schedule.frequency === "every_x_days" || schedule.frequency === "daily" || schedule.frequency === "weekly") && (
+              <>
+                <div>{"at"}</div>
+                <TimeInput
+                  aria-label="Update time"
+                  variant="bordered"
+                  value={schedule.time}
+                  hourCycle={12}
+                  onChange={(time) => {
+                    setSchedule({ ...schedule, time })
+                  }}
+                />
+              </>
+            )}
+          </div>
+          {(schedule.frequency === "every_x_days" || schedule.frequency === "daily" || schedule.frequency === "weekly") && (
+            <div className="flex flex-row items-center gap-2">
+              <Autocomplete
+                placeholder="Select a timezone"
+                variant="bordered"
+                onSelectionChange={(key) => {
+                  setSchedule({ ...schedule, timezone: key });
+                }}
+                selectedKey={schedule.timezone}
+                defaultValue={schedule.timezone}
+                fullWidth
+                aria-label="Timezone"
+              >
+                {timezones.map((timezone) => (
+                  <AutocompleteItem key={timezone} textValue={timezone}>
+                    {timezone}
+                  </AutocompleteItem>
+                ))}
+              </Autocomplete>
+
+              <Button
+                color="primary"
+                variant="light"
+                size="sm"
+                onClick={() => setSchedule({ ...schedule, timezone: getMachineTimezone() })}
+              >
+                <LuMapPin />
+              </Button>
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="bordered" onClick={onClose}>
+            {"Cancel"}
+          </Button>
+          <Button onClick={_onSave} color="primary">
+            {"Save"}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+UpdateSchedule.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  timezone: PropTypes.string.isRequired,
+};
+
+export default UpdateSchedule


### PR DESCRIPTION
The new feature will allow users to schedule updates for the entire dashboard (e.g. daily, weekly, every x hours, etc).

The update will affect all charts in a dashboard eliminating the need to set the auto-update for each chart one by one.

The menu to change each individual chart will only be visible if already set, otherwise it will not be able to set the auto-update from the chart menu anymore.

![CleanShot 2024-07-18 at 21 15 08@2x](https://github.com/user-attachments/assets/32e567c6-b2db-4cb3-9d0e-c1b96884dcb7)
