### PR TITLE
Redesign the homepage to ensure pages are served on different routes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,15 @@ const router = createBrowserRouter([
         }]
       },
       {
+        path: "dashboards",
+      },
+      {
+        path: "connections",
+      },
+      {
+        path: "datasets",
+      },
+      {
         path: "chart/:chartId/embedded",
       },
       {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,6 +35,9 @@ const router = createBrowserRouter([
         path: "datasets",
       },
       {
+        path: "integrations",
+      },
+      {
         path: "chart/:chartId/embedded",
       },
       {

--- a/client/src/components/Container.jsx
+++ b/client/src/components/Container.jsx
@@ -7,7 +7,7 @@ const container = tv({
 })
 
 function Container(props) {
-  const { children, size, className } = props;
+  const { children, size = "md", className = "" } = props;
   return (
     <div className={`${container({ size })} ${className}`}>
       {children}
@@ -19,11 +19,6 @@ Container.propTypes = {
   children: PropTypes.node.isRequired,
   size: PropTypes.oneOf(["sm", "md", "lg", "xl", "fluid"]),
   className: PropTypes.string,
-};
-
-Container.defaultProps = {
-  size: "md",
-  className: "",
 };
 
 export default Container;

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -101,7 +101,7 @@ function LoginForm() {
           return;
         }
         setLoading(false);
-        navigate("/user");
+        navigate("/");
       })
       .catch((err) => {
         setErrors({ ...errors, login: err.message });
@@ -132,7 +132,7 @@ function LoginForm() {
       })
       .then(() => {
         setLoading(false);
-        navigate("/user");
+        navigate("/");
       })
       .catch(() => {
         setErrors({ ...errors, otpToken: "Invalid token" });

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -136,19 +136,19 @@ function NavbarContainer() {
     <>
       <Navbar isBordered maxWidth="full" height={"3rem"} style={{ zIndex: 999 }}>
         <NavbarBrand>
-          <Link to="/user">
+          <Link to="/">
             <img src={isDark ? cbLogoInverted : cbLogo} alt="Chartbrew Logo" width={30}  />
           </Link>
           <Spacer x={4} />
           <Row align="center" className={"gap-1 hidden sm:flex"}>
             <Breadcrumbs variant="solid">
               {!params.teamId && (
-                <BreadcrumbItem key="home" onClick={() => navigate("/user")}>
+                <BreadcrumbItem key="home" onClick={() => navigate("/")}>
                   <Text>{"Home"}</Text>
                 </BreadcrumbItem>
               )}
               {params.teamId && (
-                <BreadcrumbItem key="team" onClick={() => navigate("/user")} isCurrent={!params.projectId}>
+                <BreadcrumbItem key="team" onClick={() => navigate("/")} isCurrent={!params.projectId}>
                   {team.name}
                 </BreadcrumbItem>
               )}

--- a/client/src/components/ProjectForm.jsx
+++ b/client/src/components/ProjectForm.jsx
@@ -24,7 +24,10 @@ import PlausibleTemplate from "../containers/Connections/Plausible/PlausibleTemp
 */
 function ProjectForm(props) {
   const {
-    onComplete, hideType, onClose, open,
+    onComplete = () => {},
+    hideType = false,
+    onClose,
+    open,
   } = props;
 
   const [loading, setLoading] = useState(false);
@@ -241,11 +244,6 @@ function ProjectForm(props) {
     </Modal>
   );
 }
-
-ProjectForm.defaultProps = {
-  onComplete: () => {},
-  hideType: false,
-};
 
 ProjectForm.propTypes = {
   onComplete: PropTypes.func,

--- a/client/src/components/Row.jsx
+++ b/client/src/components/Row.jsx
@@ -49,7 +49,14 @@ const row = tv({
 });
 
 function Row(props) {
-  const { children, align, justify, content, wrap, className } = props;
+  const {
+    children,
+    align = "start",
+    justify = "start",
+    content = "start",
+    wrap = "none",
+    className = ""
+  } = props;
   return (
     <div className={`${row({ align, justify, content, wrap })} ${className}`}>
       {children}
@@ -64,14 +71,6 @@ Row.propTypes = {
   content: PropTypes.oneOf(["start", "center", "end", "between", "around", "evenly", "stretch"]),
   wrap: PropTypes.oneOf(["none", "reverse", "wrap"]),
   className: PropTypes.string,
-};
-
-Row.defaultProps = {
-  align: "start",
-  justify: "start",
-  content: "start",
-  wrap: "none",
-  className: "",
 };
 
 export default Row

--- a/client/src/components/Segment.jsx
+++ b/client/src/components/Segment.jsx
@@ -7,7 +7,7 @@ const segment = tv({
 })
 
 function Segment(props) {
-  const { children, size, className } = props;
+  const { children, size = "md", className = "" } = props;
   return (
     <div className={`${segment({ size })} ${className}`}>
       {children}
@@ -19,11 +19,6 @@ Segment.propTypes = {
   children: PropTypes.node.isRequired,
   size: PropTypes.oneOf(["sm", "md", "lg", "xl", "fluid"]),
   className: PropTypes.string,
-};
-
-Segment.defaultProps = {
-  size: "md",
-  className: "",
 };
 
 export default Segment;

--- a/client/src/components/Text.jsx
+++ b/client/src/components/Text.jsx
@@ -61,7 +61,17 @@ const text = tv({
 
 function Text(props) {
   const {
-    children, size, color, h1, h2, h3, h4, small, b, variant, className,
+    children,
+    size = "md",
+    color = "default",
+    h1 = false,
+    h2 = false,
+    h3 = false,
+    h4 = false,
+    small = false,
+    b = false,
+    variant = "",
+    className = "",
   } = props;
   return (
     <span className={`${text({ size, color, h1, h2, h3, h4, small, b, variant })} ${className}`}>
@@ -82,19 +92,6 @@ Text.propTypes = {
   b: PropTypes.bool,
   className: PropTypes.string,
   variant: PropTypes.oneOf(["", "b", "i", "small"]),
-};
-
-Text.defaultProps = {
-  size: "md",
-  color: "default",
-  h1: false,
-  h2: false,
-  h3: false,
-  h4: false,
-  small: false,
-  b: false,
-  className: "",
-  variant: "",
 };
 
 export default Text

--- a/client/src/containers/Connections/ConnectionWizard.jsx
+++ b/client/src/containers/Connections/ConnectionWizard.jsx
@@ -231,7 +231,7 @@ function ConnectionWizard() {
 
           {newConnection && (
             <div className="flex flex-row items-center gap-2">
-              <Link to="/user" className="text-xl text-secondary font-semibold">
+              <Link to="/connections" className="text-xl text-secondary font-semibold">
                 <LuArrowLeftCircle size={24} />
               </Link>
               <span className="text-xl font-semibold">Edit your connection</span>
@@ -425,7 +425,7 @@ function ConnectionWizard() {
               <Button
                 variant="bordered"
                 fullWidth
-                onClick={() => navigate("/user")}
+                onClick={() => navigate("/")}
                 startContent={<LuLayoutDashboard />}
               >
                 Return to dashboard

--- a/client/src/containers/Dataset/Dataset.jsx
+++ b/client/src/containers/Dataset/Dataset.jsx
@@ -257,7 +257,7 @@ function Dataset() {
     }
 
     if (completeProjects.length === 0) {
-      navigate("/user");
+      navigate("/");
       return;
     }
 
@@ -323,7 +323,7 @@ function Dataset() {
             if (completeProjects.length === 1) {
               navigate(`/${params.teamId}/${completeProjects[0]}/dashboard`);
             } else {
-              navigate("/user");
+              navigate("/");
             }
           }
         })
@@ -335,7 +335,7 @@ function Dataset() {
               toast.error("Could not create chart. Please try again");
               setCompleteModal(false);
             } else {
-              navigate("/user");
+              navigate("/");
             }
           }
         });

--- a/client/src/containers/GoogleAuth.jsx
+++ b/client/src/containers/GoogleAuth.jsx
@@ -93,7 +93,7 @@ function GoogleAuth() {
           </Row>
           <Spacer y={1} />
           <Row>
-            <Link to="/user">
+            <Link to="/connections">
               <Button
                 color="success"
                 endContent={<LuArrowRight />}
@@ -119,7 +119,7 @@ function GoogleAuth() {
           </Row>
           <Spacer y={1} />
           <Row>
-            <Link to="/user">
+            <Link to="/connections">
               <Button
                 color="secondary"
                 endContent={<LuArrowRight />}

--- a/client/src/containers/Integrations/Integrations.jsx
+++ b/client/src/containers/Integrations/Integrations.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import { connect, useSelector } from "react-redux";
 import {
   Spacer,
 } from "@nextui-org/react";
@@ -13,20 +13,23 @@ import {
 import Text from "../../components/Text";
 import Row from "../../components/Row";
 import Segment from "../../components/Segment";
-import { useParams } from "react-router";
+import { selectTeam } from "../../slices/team";
 
 function Integrations(props) {
   const { integrations, getTeamIntegrations } = props;
 
-  const params = useParams();
+  const team = useSelector(selectTeam);
+  const initRef = useRef(false);
 
   useEffect(() => {
-    getTeamIntegrations(params.teamId);
-  }, []);
+    if (team?.id && !initRef.current) {
+      getTeamIntegrations(team?.id);
+      initRef.current = true;
+    }
+  }, [team]);
 
   return (
     <div>
-      <Spacer y={4} />
       <Segment className="container mx-auto bg-background">
         <Row>
           <Text size="h3">Integrations</Text>
@@ -42,7 +45,7 @@ function Integrations(props) {
         <Row>
           <WebhookIntegrations
             integrations={integrations ? integrations.filter((i) => i.type === "webhook") : []}
-            teamId={params.teamId}
+            teamId={team?.id}
           />
         </Row>
         <Spacer y={4} />

--- a/client/src/containers/Integrations/components/WebhookIntegrations.jsx
+++ b/client/src/containers/Integrations/components/WebhookIntegrations.jsx
@@ -217,7 +217,7 @@ function WebhookIntegrations(props) {
         )}
       </Container>
 
-      <Modal isOpen={createOpen} onClose={() => setCreateOpen(false)} size="2xl">
+      <Modal isOpen={createOpen} onClose={() => setCreateOpen(false)} size="xl">
         <ModalContent>
           <ModalHeader>
             <Text size="h4">
@@ -240,7 +240,6 @@ function WebhookIntegrations(props) {
                 description={`${newIntegration.name?.length || 0}/20 characters`}
               />
             </Row>
-            <Spacer y={1} />
             <Row>
               <Input
                 label="The URL where Chartbrew sends a POST request to"
@@ -263,14 +262,12 @@ function WebhookIntegrations(props) {
               >
                 {"This is a Slack webhook"}
               </Checkbox>
-              <Spacer x={1} />
-              <Text size="small">
-                <Link onClick={() => setSlackModalOpen(true)}>
-                  <LuInfo />
-                  <Spacer x={1} />
-                  {"What is this?"}
-                </Link>
-              </Text>
+              <Spacer x={3} />
+              <Link onClick={() => setSlackModalOpen(true)} className="text-sm cursor-pointer">
+                <LuInfo size={16} />
+                <Spacer x={1} />
+                {"What is this?"}
+              </Link>
             </Row>
             {error && (
               <Row>
@@ -282,8 +279,7 @@ function WebhookIntegrations(props) {
             <Button
               auto
               onClick={() => setCreateOpen(false)}
-              color="warning"
-              variant="flat"
+              variant="bordered"
             >
               Close
             </Button>
@@ -343,7 +339,7 @@ function WebhookIntegrations(props) {
         </ModalContent>
       </Modal>
 
-      <Modal isOpen={slackModalOpen} size="full" onClose={() => setSlackModalOpen(false)}>
+      <Modal isOpen={slackModalOpen} size="5xl" onClose={() => setSlackModalOpen(false)}>
         <ModalContent>
           <ModalHeader>
             <Text size="h4">How to set up Slack alerts</Text>

--- a/client/src/containers/Main.jsx
+++ b/client/src/containers/Main.jsx
@@ -29,6 +29,9 @@ import ConnectionWizard from "./Connections/ConnectionWizard";
 import LoadingScreen from "../components/LoadingScreen";
 import Variables from "./Variables/Variables";
 import { Toaster } from "react-hot-toast";
+import ConnectionList from "./UserDashboard/ConnectionList";
+import DatasetList from "./UserDashboard/DatasetList";
+import DashboardList from "./UserDashboard/DashboardList";
 
 const ProjectBoard = lazy(() => import("./ProjectBoard/ProjectBoard"));
 const Signup = lazy(() => import("./Signup"));
@@ -176,7 +179,11 @@ function Main(props) {
         <div>
           <Suspense fallback={<SuspenseLoader />}>
             <Routes>
-              <Route exact path="/" element={<UserDashboard />} />
+              <Route path="/" element={<UserDashboard />}>
+                <Route index element={<DashboardList />} />
+                <Route path="connections" element={<ConnectionList />} />
+                <Route path="datasets" element={<DatasetList />} />
+              </Route>
               <Route exact path="/b/:brewName" element={<PublicDashboard />} />
               <Route
                 exact

--- a/client/src/containers/Main.jsx
+++ b/client/src/containers/Main.jsx
@@ -183,6 +183,7 @@ function Main(props) {
                 <Route index element={<DashboardList />} />
                 <Route path="connections" element={<ConnectionList />} />
                 <Route path="datasets" element={<DatasetList />} />
+                <Route path="integrations" element={<Integrations />} />
               </Route>
               <Route exact path="/b/:brewName" element={<PublicDashboard />} />
               <Route

--- a/client/src/containers/ProjectRedirect.jsx
+++ b/client/src/containers/ProjectRedirect.jsx
@@ -21,7 +21,7 @@ function ProjectRedirect() {
         navigate(`/${project.team_id}/${project.id}/dashboard`);
       })
       .catch(() => {
-        navigate("/user");
+        navigate("/");
       });
   }, []);
 

--- a/client/src/containers/ProjectSettings.jsx
+++ b/client/src/containers/ProjectSettings.jsx
@@ -85,7 +85,7 @@ function ProjectSettings(props) {
     setRemoveError(false);
     dispatch(removeProject({ project_id: project.id }))
       .then(() => {
-        navigate("/user");
+        navigate("/");
       })
       .catch(() => {
         setRemoveLoading(false);

--- a/client/src/containers/Signup.jsx
+++ b/client/src/containers/Signup.jsx
@@ -65,7 +65,7 @@ function Signup() {
       dispatch(createUser({ name, email, password }))
         .then(() => {
           setLoading(false);
-          navigate("/user?welcome=true");
+          navigate("/?welcome=true");
         })
         .catch((err) => {
           setLoading(false);
@@ -84,7 +84,7 @@ function Signup() {
             setLoading(false);
             setAddedToTeam(true);
             setTimeout(() => {
-              navigate("/user");
+              navigate("/");
             }, 3000);
           });
       })

--- a/client/src/containers/UserDashboard/ConnectionList.jsx
+++ b/client/src/containers/UserDashboard/ConnectionList.jsx
@@ -1,0 +1,352 @@
+import { Avatar, Button, Checkbox, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownTrigger, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Spacer, Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from "@nextui-org/react"
+import React, { useState } from "react"
+import { LuCalendarDays, LuInfo, LuMoreHorizontal, LuPencilLine, LuPlus, LuSearch, LuTags, LuTrash } from "react-icons/lu"
+import { useDispatch, useSelector } from "react-redux"
+import { Link, useNavigate } from "react-router-dom"
+
+import { selectTeam } from "../../slices/team"
+import canAccess from "../../config/canAccess"
+import { selectUser } from "../../slices/user"
+import connectionImages from "../../config/connectionImages"
+import { removeConnection, saveConnection, selectConnections } from "../../slices/connection"
+import { useTheme } from "../../modules/ThemeContext"
+import { selectProjects } from "../../slices/project"
+import { selectDatasets } from "../../slices/dataset"
+
+function ConnectionList() {
+  const [connectionSearch, setConnectionSearch] = useState("");
+  const [connectionToEdit, setConnectionToEdit] = useState(null);
+  const [connectionToDelete, setConnectionToDelete] = useState(null);
+  const [modifyingConnection, setModifyingConnection] = useState(false);
+  const [deletingConnection, setDeletingConnection] = useState(false);
+  const [deleteRelatedDatasets, setDeleteRelatedDatasets] = useState(false);
+
+  const team = useSelector(selectTeam);
+  const user = useSelector(selectUser);
+  const connections = useSelector(selectConnections);
+  const projects = useSelector(selectProjects);
+  const datasets = useSelector(selectDatasets);
+  
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { isDark } = useTheme();
+
+  const _canAccess = (role, teamRoles) => {
+    return canAccess(role, user.id, teamRoles);
+  };
+
+  const _getFilteredConnections = () => {
+    if (!connectionSearch) return connections || [];
+
+    const filteredConnections = connections.filter((c) => {
+      return c.name.toLowerCase().indexOf(connectionSearch.toLowerCase()) > -1;
+    });
+
+    return filteredConnections || [];
+  };
+
+  const _onEditConnectionTags = async () => {
+    setModifyingConnection(true);
+
+    const projectIds = connectionToEdit.project_ids || [];
+
+    await dispatch(saveConnection({
+      team_id: team.id,
+      connection: { id: connectionToEdit.id, project_ids: projectIds },
+    }));
+
+    setModifyingConnection(false);
+    setConnectionToEdit(null);
+  };
+
+  const _getConnectionTags = (projectIds) => {
+    const tags = [];
+    if (!projects || !projectIds) return tags;
+    projectIds.forEach((projectId) => {
+      const project = projects.find((p) => p.id === projectId);
+      if (project) {
+        tags.push(project.name);
+      }
+    });
+
+    return tags;
+  };
+
+  const _onDeleteConnection = () => {
+    setDeletingConnection(true);
+    dispatch(removeConnection({
+      team_id: team.id,
+      connection_id: connectionToDelete.id,
+      removeDatasets: deleteRelatedDatasets
+    }))
+      .then(() => {
+        setDeletingConnection(false);
+        setConnectionToDelete(null);
+      })
+      .catch(() => {
+        setDeletingConnection(false);
+      });
+  };
+
+  const _getRelatedDatasets = (connectionId) => {
+    return datasets.filter((d) => d.DataRequests?.find((dr) => dr.connection_id === connectionId));
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className={"flex flex-row items-center gap-4"}>
+        {_canAccess("teamAdmin", team.TeamRoles) && (
+          <Button
+            color="primary"
+            endContent={<LuPlus />}
+            onClick={() => navigate(`/${team.id}/connection/new`)}
+          >
+            Create connection
+          </Button>
+        )}
+        <Input
+          type="text"
+          placeholder="Search connections"
+          variant="bordered"
+          endContent={<LuSearch />}
+          className="max-w-[300px]"
+          labelPlacement="outside"
+          onChange={(e) => setConnectionSearch(e.target.value)}
+        />
+      </div>
+      <Spacer y={4} />
+      <Table shadow="none" isStriped className="border-1 border-solid border-content3 rounded-xl" aria-label="Connection list">
+        <TableHeader>
+          <TableColumn key="name">Connection</TableColumn>
+          <TableColumn key="tags" className="tutorial-tags">
+            <div className="flex flex-row items-center gap-1">
+              <LuTags />
+              <span>Tags</span>
+            </div>
+          </TableColumn>
+          <TableColumn key="created" textValue="Created">
+            <div className="flex flex-row items-center gap-1">
+              <LuCalendarDays />
+              <span>Created</span>
+            </div>
+          </TableColumn>
+          <TableColumn key="actions" align="center" hideHeader>Actions</TableColumn>
+        </TableHeader>
+        <TableBody>
+          {_getFilteredConnections()?.map((connection) => (
+            <TableRow key={connection.id}>
+              <TableCell key="name">
+                <div className="flex flex-row items-center gap-4">
+                  <Avatar
+                    src={connectionImages(isDark)[connection.subType]}
+                    size="sm"
+                    isBordered
+                  />
+                  <Link to={`/${team.id}/connection/${connection.id}`} className="cursor-pointer">
+                    <span className="text-foreground font-medium">{connection.name}</span>
+                  </Link>
+                </div>
+              </TableCell>
+              <TableCell key="tags">
+                {_getConnectionTags(connection.project_ids).length > 0 && (
+                  <div
+                    className="flex flex-row flex-wrap items-center gap-1 cursor-pointer hover:saturate-200 transition-all"
+                    onClick={() => setConnectionToEdit(connection)}
+                  >
+                    {_getConnectionTags(connection.project_ids).slice(0, 3).map((tag) => (
+                      <Chip
+                        key={tag}
+                        size="sm"
+                        variant="flat"
+                        color="primary"
+                      >
+                        {tag}
+                      </Chip>
+                    ))}
+                    {_getConnectionTags(connection.project_ids).length > 3 && (
+                      <span className="text-xs">{`+${_getConnectionTags(connection.project_ids).length - 3} more`}</span>
+                    )}
+                  </div>
+                )}
+                {_getConnectionTags(connection.project_ids).length === 0 && (
+                  <Button
+                    variant="light"
+                    startContent={<LuPlus size={18} />}
+                    size="sm"
+                    className="opacity-0 hover:opacity-100"
+                    onClick={() => setConnectionToEdit(connection)}
+                  >
+                    Add tag
+                  </Button>
+                )}
+              </TableCell>
+              <TableCell key="created">
+                <div>{new Date(connection.createdAt).toLocaleDateString()}</div>
+              </TableCell>
+              <TableCell key="actions">
+                {_canAccess("teamAdmin", team.TeamRoles) && (
+                  <div className="flex flex-row justify-end items-center">
+                    <Dropdown aria-label="Select a connection option">
+                      <DropdownTrigger>
+                        <Button
+                          isIconOnly
+                          variant="light"
+                          size="sm"
+                        >
+                          <LuMoreHorizontal />
+                        </Button>
+                      </DropdownTrigger>
+                      <DropdownMenu variant="flat">
+                        <DropdownItem
+                          onClick={() => navigate(`/${team.id}/connection/${connection.id}`)}
+                          startContent={<LuPencilLine />}
+                        >
+                          Edit connection
+                        </DropdownItem>
+                        <DropdownItem
+                          onClick={() => setConnectionToEdit(connection)}
+                          startContent={<LuTags />}
+                          showDivider
+                        >
+                          Edit tags
+                        </DropdownItem>
+                        <DropdownItem
+                          onClick={() => setConnectionToDelete(connection)}
+                          startContent={<LuTrash />}
+                          color="danger"
+                        >
+                          Delete
+                        </DropdownItem>
+                      </DropdownMenu>
+                    </Dropdown>
+                  </div>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <Spacer y={2} />
+
+      <Modal isOpen={connectionToDelete?.id} onClose={() => setConnectionToDelete(null)}>
+        <ModalContent>
+          <ModalHeader>
+            <div className="font-bold">Are you sure you want to delete this connection?</div>
+          </ModalHeader>
+          <ModalBody>
+            <div>
+              {"Just a heads-up that all the datasets and charts that use this connection will stop working. This action cannot be undone."}
+            </div>
+            {_getRelatedDatasets(connectionToDelete?.id).length === 0 && (
+              <div className="flex flex-row items-center">
+                <div className="italic">No related datasets found</div>
+              </div>
+            )}
+            {_getRelatedDatasets(connectionToDelete?.id).length > 0 && (
+              <div className="flex flex-row items-center">
+                <div>Related datasets:</div>
+              </div>
+            )}
+            <div className="flex flex-row flex-wrap items-center gap-1">
+              {_getRelatedDatasets(connectionToDelete?.id).slice(0, 10).map((dataset) => (
+                <Chip
+                  key={dataset.id}
+                  size="sm"
+                  variant="flat"
+                  color="primary"
+                >
+                  {dataset.legend}
+                </Chip>
+              ))}
+              {_getRelatedDatasets(connectionToDelete?.id).length > 10 && (
+                <span className="text-xs">{`+${_getRelatedDatasets(connectionToDelete?.id).length - 10} more`}</span>
+              )}
+            </div>
+          </ModalBody>
+          <ModalFooter className="justify-between">
+            <Checkbox
+              onChange={() => setDeleteRelatedDatasets(!deleteRelatedDatasets)}
+              isSelected={deleteRelatedDatasets}
+              size="sm"
+            >
+              Delete related datasets
+            </Checkbox>
+            <div className="flex flex-row items-center gap-1">
+              <Button
+                variant="bordered"
+                onClick={() => setConnectionToDelete(null)}
+                size="sm"
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                color="danger"
+                endContent={<LuTrash />}
+                onClick={() => _onDeleteConnection()}
+                isLoading={deletingConnection}
+              >
+                Delete
+              </Button>
+            </div>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal isOpen={!!connectionToEdit} onClose={() => setConnectionToEdit(null)} size="xl">
+        <ModalContent>
+          <ModalHeader>
+            <div className="font-bold">Edit tags</div>
+          </ModalHeader>
+          <ModalBody>
+            <div className="flex flex-row flex-wrap items-center gap-2">
+              {projects.filter((p) => !p.ghost).map((project) => (
+                <Chip
+                  key={project.id}
+                  radius="sm"
+                  variant={connectionToEdit?.project_ids?.includes(project.id) ? "solid" : "flat"}
+                  color="primary"
+                  className="cursor-pointer"
+                  onClick={() => {
+                    if (connectionToEdit?.project_ids?.includes(project.id)) {
+                      setConnectionToEdit({ ...connectionToEdit, project_ids: connectionToEdit?.project_ids?.filter((p) => p !== project.id) });
+                    }
+                    else {
+                      setConnectionToEdit({ ...connectionToEdit, project_ids: [...connectionToEdit?.project_ids || [], project.id] });
+                    }
+                  }}
+                >
+                  {project.name}
+                </Chip>
+              ))}
+            </div>
+            <Spacer y={1} />
+            <div className="flex gap-1 bg-content2 p-2 mb-2 rounded-lg text-foreground-500 text-sm">
+              <div>
+                <LuInfo />
+              </div>
+              {"Use tags to grant dashboard members access to these connections. Tagged connections can be used by members to create their own datasets within the associated dashboards."}
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="bordered"
+              onClick={() => setConnectionToEdit(null)}
+            >
+              Close
+            </Button>
+            <Button
+              color="primary"
+              onClick={() => _onEditConnectionTags()}
+              isLoading={modifyingConnection}
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  )
+}
+
+export default ConnectionList

--- a/client/src/containers/UserDashboard/DashboardList.jsx
+++ b/client/src/containers/UserDashboard/DashboardList.jsx
@@ -1,0 +1,447 @@
+import {
+  Button, Card, CardHeader, Dropdown, DropdownTrigger, Input, Spacer,
+  Link as LinkNext, DropdownMenu, DropdownItem, Divider, CardBody, AvatarGroup,
+  Avatar, Chip, Table, TableHeader, TableColumn, TableBody, TableRow, TableCell,
+  Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Tooltip
+} from "@nextui-org/react";
+import React, { useEffect, useState } from "react";
+import { LuBarChart, LuLayoutGrid, LuMoreHorizontal, LuPencilLine, LuPlus, LuSearch, LuTable, LuTrash, LuUsers2 } from "react-icons/lu";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router";
+
+import { getTeams, saveActiveTeam, selectTeam, selectTeamMembers } from "../../slices/team";
+import canAccess from "../../config/canAccess";
+import { selectUser } from "../../slices/user";
+import { getTemplates } from "../../slices/template";
+import { removeProject, selectProjects, updateProject } from "../../slices/project";
+import ProjectForm from "../../components/ProjectForm";
+
+function DashboardList() {
+  const [addProject, setAddProject] = useState(false);
+  const [search, setSearch] = useState({});
+  const [viewMode, setViewMode] = useState("grid");
+  const [projectToEdit, setProjectToEdit] = useState(null);
+  const [projectToDelete, setProjectToDelete] = useState(null);
+  const [modifyingProject, setModifyingProject] = useState(false);
+
+  const team = useSelector(selectTeam);
+  const user = useSelector(selectUser);
+  const projects = useSelector(selectProjects);
+  const teamMembers = useSelector(selectTeamMembers);
+
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const storageViewMode = window.localStorage.getItem("__cb_view_mode");
+    if (storageViewMode) setViewMode(storageViewMode);
+  }, []);
+
+  const _canAccess = (role, teamRoles) => {
+    return canAccess(role, user.id, teamRoles);
+  };
+
+  const _onNewProject = (team) => {
+    setAddProject(true);
+    dispatch(saveActiveTeam(team));
+    dispatch(getTemplates(team.id));
+  };
+
+  const _changeViewMode = (mode) => {
+    setViewMode(mode);
+    window.localStorage.setItem("__cb_view_mode", mode);
+  };
+
+  const _getFilteredProjects = () => {
+    if (!search[team.id]) return projects.filter((p) => !p.ghost && p.team_id === team.id);
+    const filteredProjects = projects.filter((p) => {
+      return p.name.toLowerCase().indexOf(search[team.id].toLowerCase()) > -1 && !p.ghost && p.team_id === team.id;
+    });
+
+    // now add the team members to each project
+    const formattedProjects = filteredProjects.map((p) => {
+      const projectMembers = _getProjectMembers(p, teamMembers);
+      return {
+        ...p,
+        members: projectMembers,
+      };
+    });
+
+    return formattedProjects;
+  };
+
+  const _getProjectMembers = (project) => {
+    if (!teamMembers) return [];
+    const projectMembers = teamMembers.filter((tm) => {
+      return tm.TeamRoles.find((tr) => tr?.projects?.length > 0 && tr.projects.includes(project.id) && tr.role !== "teamOwner" && tr.role !== "teamAdmin");
+    });
+
+    return projectMembers;
+  };
+
+  const directToProject = (projectId) => {
+    dispatch(saveActiveTeam(team));
+    // window.location.href = `/${team.id}/${projectId}/dashboard`;
+    navigate(`/${team.id}/${projectId}/dashboard`);
+  };
+
+  const _onEditProject = (project) => {
+    setProjectToEdit(project);
+  };
+
+  const _onEditProjectSubmit = () => {
+    if (projectToEdit && projectToEdit.id) {
+      setModifyingProject(true);
+      dispatch(updateProject({ project_id: projectToEdit.id, data: { name: projectToEdit.name } }))
+        .then(() => {
+          return dispatch(getTeams(user.id))
+        })
+        .then(() => {
+          setModifyingProject(false);
+          setProjectToEdit(null);
+        })
+        .catch(() => {
+          setModifyingProject(false);
+        });
+    }
+  };
+
+  const _onDeleteProject = (project) => {
+    setProjectToDelete(project);
+  };
+
+  const _onDeleteProjectSubmit = () => {
+    if (projectToDelete && projectToDelete.id) {
+      setModifyingProject(true);
+      dispatch(removeProject({ project_id: projectToDelete.id }))
+        .then(() => {
+          return dispatch(getTeams(user.id))
+        })
+        .then(() => {
+          setProjectToDelete(null);
+          setModifyingProject(false);
+        })
+        .catch(() => {
+          setModifyingProject(false);
+        });
+    }
+  };
+
+  const _onProjectCreated = (project, isNew = true) => {
+    dispatch(getTeams(user.id));
+    setAddProject(false);
+
+    let url = `/${project.team_id}/${project.id}/dashboard`;
+    if (isNew) url += "?new=true";
+    window.location.href = url;
+  };
+
+  return (
+    <div className="flex flex-col">
+      <ProjectForm
+        onComplete={_onProjectCreated}
+        open={addProject}
+        onClose={() => setAddProject(false)}
+      />
+      <div className="flex flex-row justify-between items-center">
+        <div className="flex flex-row items-center gap-2">
+          {_canAccess("teamAdmin", team.TeamRoles) && (
+            <div>
+              <Button
+                color="primary"
+                onClick={() => _onNewProject(team)}
+                endContent={<LuPlus />}
+                className="create-dashboard-tutorial"
+              >
+                <span className="hidden md:block">Create dashboard</span>
+                <span className="md:hidden">Create</span>
+              </Button>
+            </div>
+          )}
+          <Input
+            type="text"
+            placeholder="Search dashboards"
+            variant="bordered"
+            endContent={<LuSearch />}
+            onChange={(e) => setSearch({ ...search, [team.id]: e.target.value })}
+            className="max-w-[300px]"
+            labelPlacement="outside"
+          />
+        </div>
+        <div className="flex flex-row">
+          <Button
+            variant="light"
+            isIconOnly
+            color={viewMode === "grid" ? "primary" : "default"}
+            onClick={() => _changeViewMode("grid")}
+          >
+            <LuLayoutGrid />
+          </Button>
+          <Button
+            variant="light"
+            isIconOnly
+            color={viewMode === "table" ? "primary" : "default"}
+            onClick={() => _changeViewMode("table")}
+          >
+            <LuTable />
+          </Button>
+        </div>
+      </div>
+      <Spacer y={4} />
+      {projects && viewMode === "grid" && (
+        <div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+          {_getFilteredProjects().map((project) => (
+            <Card
+              key={project.id}
+              isPressable
+              shadow="none"
+              className="border-1 border-solid border-content3"
+              radius="sm"
+              onClick={() => directToProject(project.id)}
+            >
+              <CardHeader className="flex flex-row justify-between items-center">
+                <span className="text-sm font-medium">{project.name}</span>
+                {_canAccess("teamAdmin", team.TeamRoles) && (
+                  <Dropdown size="sm">
+                    <DropdownTrigger>
+                      <LinkNext className="text-foreground-400">
+                        <LuMoreHorizontal />
+                      </LinkNext>
+                    </DropdownTrigger>
+                    <DropdownMenu>
+                      <DropdownItem
+                        onClick={() => _onEditProject(project)}
+                        startContent={<LuPencilLine />}
+                        showDivider
+                        textValue="Rename"
+                      >
+                        Rename
+                      </DropdownItem>
+                      <DropdownItem
+                        onClick={() => _onDeleteProject(project)}
+                        startContent={<LuTrash />}
+                        color="danger"
+                        textValue="Delete"
+                      >
+                        Delete
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </Dropdown>
+                )}
+              </CardHeader>
+              <Divider />
+              <CardBody>
+                <div className="flex flex-row justify-between items-center">
+                  {_getProjectMembers(project)?.length > 0 && (
+                    <AvatarGroup max={3} isBordered size="sm">
+                      {_getProjectMembers(project)?.map((pr) => (
+                        <Avatar
+                          key={pr.id}
+                          name={pr.name}
+                        />
+                      ))}
+                    </AvatarGroup>
+                  )}
+                  {_getProjectMembers(project)?.length === 0 && (
+                    <Chip variant="flat" size="sm">
+                      Team only
+                    </Chip>
+                  )}
+                  <div className="flex flex-row items-center gap-1 text-sm">
+                    <LuBarChart />
+                    <span>{project?.Charts?.length || 0}</span>
+                  </div>
+                </div>
+              </CardBody>
+            </Card>
+          ))}
+
+          {_getFilteredProjects().length === 0 && (
+            <div>
+              <span className="text-foreground-400 italic">
+                {"No dashboards here"}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+      {projects && viewMode === "table" && (
+        <Table
+          aria-label="Dashboard list"
+          className="h-auto min-w-full border-1 border-solid border-content3 rounded-xl"
+          radius="md"
+          shadow="none"
+          isStriped
+        >
+          <TableHeader>
+            <TableColumn key="name">Dashboard name</TableColumn>
+            <TableColumn key="members">
+              <div className="flex flex-row items-end gap-1">
+                <LuUsers2 />
+                <span>Dashboard members</span>
+              </div>
+            </TableColumn>
+            <TableColumn key="charts">
+              <div className="flex flex-row items-end justify-center gap-1">
+                <LuBarChart />
+                <span>Charts</span>
+              </div>
+            </TableColumn>
+            <TableColumn key="actions" align="center" hideHeader />
+          </TableHeader>
+          <TableBody>
+            {_getFilteredProjects().map((project) => (
+              <TableRow key={project.id}>
+                <TableCell key="name">
+                  <LinkNext onClick={() => directToProject(project.id)} className="cursor-pointer flex flex-col items-start">
+                    <span className={"text-foreground font-medium"}>{project.name}</span>
+                  </LinkNext>
+                </TableCell>
+                <TableCell key="members">
+                  <div className="flex flex-row items-center justify-center">
+                    {_getProjectMembers(project)?.length > 0 && (
+                      <AvatarGroup max={3} isBordered size="sm">
+                        {_getProjectMembers(project)?.map((pr) => (
+                          <Avatar
+                            key={pr.id}
+                            name={pr.name}
+                          />
+                        ))}
+                      </AvatarGroup>
+                    )}
+                    {_getProjectMembers(project)?.length === 0 && (
+                      <Chip variant="flat" size="sm">
+                        Team only
+                      </Chip>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell key="charts">
+                  <div className="flex flex-row items-center justify-center">
+                    <span className="font-bold">
+                      {project?.Charts?.length || 0}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell key="actions">
+                  {_canAccess("teamAdmin", team.TeamRoles) && (
+                    <div className="flex flex-row items-center justify-end gap-1">
+                      <Tooltip content="Rename dashboard">
+                        <Button
+                          isIconOnly
+                          variant="light"
+                          size="sm"
+                          className={"min-w-fit"}
+                          onClick={() => _onEditProject(project)}
+                        >
+                          <LuPencilLine />
+                        </Button>
+                      </Tooltip>
+                      <Tooltip content="Delete dashboard">
+                        <Button
+                          isIconOnly
+                          color="danger"
+                          variant="light"
+                          size="sm"
+                          className={"min-w-fit"}
+                          onClick={() => _onDeleteProject(project)}
+                        >
+                          <LuTrash />
+                        </Button>
+                      </Tooltip>
+                    </div>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+          {_getFilteredProjects().length === 0 && (
+            <TableBody>
+              <TableRow>
+                <TableCell key="name" className="p-0 pt-2">
+                  <span className="italic text-default-500">No dashboards here</span>
+                </TableCell>
+                <TableCell key="members" align="center" />
+                <TableCell key="charts" align="center" />
+                <TableCell key="actions" align="center" />
+              </TableRow>
+            </TableBody>
+          )}
+        </Table>
+      )}
+      {projects && projects.length === 0 && !_canAccess("projectEditor", team.TeamRoles) && (
+        <div className="container mx-auto">
+          <h3 className="text-lg font-medium">
+            {"No project over here"}
+          </h3>
+        </div>
+      )}
+
+      <Modal isOpen={!!projectToEdit} onClose={() => setProjectToEdit(null)}>
+        <ModalContent>
+          <ModalHeader>
+            <div className="font-bold">Rename your dashboard</div>
+          </ModalHeader>
+          <ModalBody>
+            <Input
+              label="Dashboard name"
+              placeholder="Enter the dashboard name"
+              value={projectToEdit?.name || ""}
+              onChange={(e) => setProjectToEdit({ ...projectToEdit, name: e.target.value })}
+              variant="bordered"
+              fullWidth
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="bordered"
+              onClick={() => setProjectToEdit(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="primary"
+              onClick={() => _onEditProjectSubmit()}
+              disabled={!projectToEdit?.name || modifyingProject}
+              isLoading={modifyingProject}
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal isOpen={!!projectToDelete} onClose={() => setProjectToDelete(null)}>
+        <ModalContent>
+          <ModalHeader>
+            <div className="font-bold">Are you sure you want to delete the dashboard?</div>
+          </ModalHeader>
+          <ModalBody>
+            <p>
+              {"Deleting a dashboard will delete all the charts and make the report unavailable. This action cannot be undone."}
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="bordered"
+              onClick={() => setProjectToDelete(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              auto
+              color="danger"
+              endContent={<LuTrash />}
+              onClick={() => _onDeleteProjectSubmit()}
+              isLoading={modifyingProject}
+            >
+              Delete
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  )
+}
+
+export default DashboardList

--- a/client/src/containers/UserDashboard/DatasetList.jsx
+++ b/client/src/containers/UserDashboard/DatasetList.jsx
@@ -1,0 +1,394 @@
+import { Avatar, AvatarGroup, Button, Chip, CircularProgress, Dropdown, DropdownItem, DropdownMenu, DropdownTrigger, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Spacer, Switch, Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from "@nextui-org/react";
+import React, { useState } from "react"
+import { LuInfo, LuMoreHorizontal, LuPencilLine, LuPlug, LuPlus, LuSearch, LuTags, LuTrash } from "react-icons/lu";
+import { Link, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+
+import connectionImages from "../../config/connectionImages";
+import { selectTeam } from "../../slices/team";
+import { selectConnections } from "../../slices/connection";
+import { deleteDataset, getRelatedCharts, selectDatasets, updateDataset } from "../../slices/dataset";
+import { useTheme } from "../../modules/ThemeContext";
+import canAccess from "../../config/canAccess";
+import { selectUser } from "../../slices/user";
+import { selectProjects } from "../../slices/project";
+
+function DatasetList() {
+  const [datasetSearch, setDatasetSearch] = useState("");
+  const [showDatasetDrafts, setShowDatasetDrafts] = useState(false);
+  const [modifyingDataset, setModifyingDataset] = useState(false);
+  const [datasetToEdit, setDatasetToEdit] = useState(null);
+  const [deletingDataset, setDeletingDataset] = useState(false);
+  const [datasetToDelete, setDatasetToDelete] = useState(null);
+  const [fetchingRelatedCharts, setFetchingRelatedCharts] = useState(false);
+  const [relatedCharts, setRelatedCharts] = useState([]);
+
+  const team = useSelector(selectTeam);
+  const connections = useSelector(selectConnections);
+  const datasets = useSelector(selectDatasets);
+  const user = useSelector(selectUser);
+  const projects = useSelector(selectProjects);
+  const { isDark } = useTheme();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const _onCreateDataset = () => {
+    navigate(`/${team.id}/dataset/new`);
+  };
+
+  const _getFilteredDatasets = () => {
+    if (!datasetSearch) return datasets.filter((d) => !d.draft || showDatasetDrafts);
+
+    const filteredDatasets = datasets.filter((d) => {
+      return d.legend.toLowerCase().indexOf(datasetSearch.toLowerCase()) > -1 && (!d.draft || showDatasetDrafts);
+    });
+
+    return filteredDatasets;
+  };
+
+  const _canAccess = (role, teamRoles) => {
+    return canAccess(role, user.id, teamRoles);
+  };
+
+  const _getDatasetTags = (projectIds) => {
+    const tags = [];
+    if (!projects || !projectIds) return tags;
+    projectIds.forEach((projectId) => {
+      const project = projects.find((p) => p.id === projectId);
+      if (project) {
+        tags.push(project.name);
+      }
+    });
+
+    return tags;
+  };
+
+  const _onEditDatasetTags = async () => {
+    setModifyingDataset(true);
+
+    const projectIds = datasetToEdit.project_ids || [];
+
+    await dispatch(updateDataset({
+      team_id: team.id,
+      dataset_id: datasetToEdit.id,
+      data: { project_ids: projectIds },
+    }));
+
+    setModifyingDataset(false);
+    setDatasetToEdit(null);
+  };
+
+  const _onPressDeleteDataset = (dataset) => {
+    setFetchingRelatedCharts(true);
+    setDatasetToDelete(dataset);
+    setRelatedCharts([]);
+
+    dispatch(getRelatedCharts({ team_id: team.id, dataset_id: dataset.id }))
+      .then((charts) => {
+        setRelatedCharts(charts.payload);
+        setFetchingRelatedCharts(false);
+      })
+      .catch(() => {
+        setFetchingRelatedCharts(false);
+      });
+  };
+
+  const _onDeleteDataset = () => {
+    setDeletingDataset(true);
+    dispatch(deleteDataset({ team_id: team.id, dataset_id: datasetToDelete.id }))
+      .then(() => {
+        setDeletingDataset(false);
+        setDatasetToDelete(null);
+      })
+      .catch(() => {
+        setDeletingDataset(false);
+      });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-row items-center gap-4">
+        {connections.length > 0 && (
+          <Button
+            color="primary"
+            endContent={<LuPlus />}
+            onClick={() => _onCreateDataset()}
+          >
+            Create dataset
+          </Button>
+        )}
+        <Input
+          type="text"
+          placeholder="Search datasets"
+          variant="bordered"
+          endContent={<LuSearch />}
+          className="max-w-[300px]"
+          labelPlacement="outside"
+          onChange={(e) => setDatasetSearch(e.target.value)}
+        />
+        <Switch
+          isSelected={showDatasetDrafts}
+          onChange={() => setShowDatasetDrafts(!showDatasetDrafts)}
+          size="sm"
+        >
+          <span className="text-sm">Show drafts</span>
+        </Switch>
+      </div>
+      <Spacer y={4} />
+      <Table shadow="none" isStriped className="border-1 border-solid border-content3 rounded-xl" aria-label="Dataset list">
+        <TableHeader>
+          <TableColumn key="name">Dataset name</TableColumn>
+          <TableColumn key="connections" textValue="Connections" align="center" justify="center">
+            <div className="flex flex-row items-center justify-center gap-1">
+              <LuPlug />
+              <span>Connections</span>
+            </div>
+          </TableColumn>
+          <TableColumn key="tags" textValue="Tags">
+            <div className="flex flex-row items-center gap-1">
+              <LuTags />
+              <span>Tags</span>
+            </div>
+          </TableColumn>
+          <TableColumn key="actions" align="center" hideHeader />
+        </TableHeader>
+        <TableBody>
+          {_getFilteredDatasets().map((dataset) => (
+            <TableRow key={dataset.id}>
+              <TableCell key="name">
+                <div className="flex flex-row items-center gap-2">
+                  <Link to={`/${team.id}/dataset/${dataset.id}`} className="cursor-pointer">
+                    <span className="text-foreground font-medium">{dataset.legend}</span>
+                  </Link>
+                  {dataset.draft && (
+                    <Chip size="sm" variant="flat" color="secondary">
+                      Draft
+                    </Chip>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell key="connections">
+                <div className="flex flex-row items-center">
+                  <AvatarGroup max={3} isBordered size="sm">
+                    {dataset?.DataRequests?.map((dr) => (
+                      <Avatar
+                        src={connectionImages(isDark)[dr?.Connection?.subType]}
+                        showFallback={<LuPlug />}
+                        size="sm"
+                        isBordered
+                        key={dr.id}
+                      />
+                    ))}
+                  </AvatarGroup>
+                </div>
+              </TableCell>
+              <TableCell key="tags">
+                {_getDatasetTags(dataset.project_ids).length > 0 && (
+                  <div
+                    className="flex flex-row flex-wrap items-center gap-1 cursor-pointer hover:saturate-200 transition-all"
+                    onClick={() => {
+                      if (_canAccess("teamAdmin", team.TeamRoles)) {
+                        setDatasetToEdit(dataset);
+                      }
+                    }}
+                  >
+                    {_getDatasetTags(dataset.project_ids).slice(0, 3).map((tag) => (
+                      <Chip
+                        key={tag}
+                        size="sm"
+                        variant="flat"
+                        color="primary"
+                      >
+                        {tag}
+                      </Chip>
+                    ))}
+                    {_getDatasetTags(dataset.project_ids).length > 3 && (
+                      <span className="text-xs">{`+${_getDatasetTags(dataset.project_ids).length - 3} more`}</span>
+                    )}
+                  </div>
+                )}
+                {_getDatasetTags(dataset.project_ids).length === 0 && (
+                  <Button
+                    variant="light"
+                    startContent={<LuPlus size={18} />}
+                    size="sm"
+                    className="opacity-0 hover:opacity-100"
+                    onClick={() => {
+                      if (_canAccess("teamAdmin", team.TeamRoles)) {
+                        setDatasetToEdit(dataset);
+                      }
+                    }}
+                  >
+                    Add tag
+                  </Button>
+                )}
+              </TableCell>
+              <TableCell key="actions">
+                <div className="flex flex-row items-center justify-end">
+                  <Dropdown aria-label="Select a dataset option">
+                    <DropdownTrigger>
+                      <Button
+                        isIconOnly
+                        variant="light"
+                        size="sm"
+                      >
+                        <LuMoreHorizontal />
+                      </Button>
+                    </DropdownTrigger>
+                    <DropdownMenu
+                      variant="flat"
+                      disabledKeys={!_canAccess("teamAdmin", team.TeamRoles) ? ["tags", "delete"] : []}
+                    >
+                      <DropdownItem
+                        onClick={() => navigate(`/${team.id}/dataset/${dataset.id}`)}
+                        startContent={<LuPencilLine />}
+                        key="dataset"
+                        textValue="Edit dataset"
+                      >
+                        Edit dataset
+                      </DropdownItem>
+                      <DropdownItem
+                        key="tags"
+                        onClick={() => setDatasetToEdit(dataset)}
+                        startContent={<LuTags />}
+                        showDivider
+                        textValue="Edit tags"
+                      >
+                        Edit tags
+                      </DropdownItem>
+                      <DropdownItem
+                        key="delete"
+                        onClick={() => _onPressDeleteDataset(dataset)}
+                        startContent={<LuTrash />}
+                        color="danger"
+                        textValue="Delete"
+                      >
+                        Delete
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </Dropdown>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Modal isOpen={datasetToDelete?.id} onClose={() => setDatasetToDelete(null)}>
+        <ModalContent>
+          <ModalHeader>
+            <div className="font-bold">Are you sure you want to delete this dataset?</div>
+          </ModalHeader>
+          <ModalBody>
+            <div>
+              {"Just a heads-up that all the charts that use this dataset will stop working. This action cannot be undone."}
+            </div>
+            {fetchingRelatedCharts && (
+              <div className="flex flex-row items-center gap-1">
+                <CircularProgress size="sm" aria-label="Checking related charts" />
+                <span className="italic">Checking related charts...</span>
+              </div>
+            )}
+            {!fetchingRelatedCharts && relatedCharts.length === 0 && (
+              <div className="flex flex-row items-center">
+                <span className="italic">No related charts found</span>
+              </div>
+            )}
+            {!fetchingRelatedCharts && relatedCharts.length > 0 && (
+              <div className="flex flex-row items-center">
+                <span>Related charts:</span>
+              </div>
+            )}
+            <div className="flex flex-row flex-wrap items-center gap-1">
+              {relatedCharts.slice(0, 10).map((chart) => (
+                <Chip
+                  key={chart.id}
+                  size="sm"
+                  variant="flat"
+                  color="primary"
+                >
+                  {chart.name}
+                </Chip>
+              ))}
+              {relatedCharts.length > 10 && (
+                <span className="text-xs">{`+${relatedCharts.length - 10} more`}</span>
+              )}
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="bordered"
+              onClick={() => setDatasetToDelete(null)}
+              auto
+            >
+              Cancel
+            </Button>
+            <Button
+              auto
+              color="danger"
+              endContent={<LuTrash />}
+              onClick={() => _onDeleteDataset()}
+              isLoading={deletingDataset}
+            >
+              Delete
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal isOpen={!!datasetToEdit} onClose={() => setDatasetToEdit(null)} size="xl">
+        <ModalContent>
+          <ModalHeader>
+            <div className="font-bold">Edit tags</div>
+          </ModalHeader>
+          <ModalBody>
+            <div className="flex flex-row flex-wrap items-center gap-2">
+              {projects.filter((p) => !p.ghost).map((project) => (
+                <Chip
+                  key={project.id}
+                  radius="sm"
+                  variant={datasetToEdit?.project_ids?.includes(project.id) ? "solid" : "flat"}
+                  color="primary"
+                  className="cursor-pointer"
+                  onClick={() => {
+                    if (datasetToEdit?.project_ids?.includes(project.id)) {
+                      setDatasetToEdit({ ...datasetToEdit, project_ids: datasetToEdit?.project_ids?.filter((p) => p !== project.id) });
+                    } else {
+                      setDatasetToEdit({ ...datasetToEdit, project_ids: [...datasetToEdit?.project_ids || [], project.id] });
+                    }
+                  }}
+                >
+                  {project.name}
+                </Chip>
+              ))}
+            </div>
+            <Spacer y={1} />
+            <div className="flex gap-1 bg-content2 p-2 mb-2 rounded-lg text-foreground-500 text-sm">
+              <div>
+                <LuInfo />
+              </div>
+              {"Assign tags to datasets to control which dashboards can use them. Members can create charts from these datasets within dashboards associated with the selected tags."}
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="bordered"
+              onClick={() => setDatasetToEdit(null)}
+            >
+              Close
+            </Button>
+            <Button
+              color="primary"
+              onClick={() => _onEditDatasetTags()}
+              isLoading={modifyingDataset}
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}
+
+export default DatasetList

--- a/client/src/containers/UserDashboard/UserDashboard.jsx
+++ b/client/src/containers/UserDashboard/UserDashboard.jsx
@@ -1,48 +1,32 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { connect, useDispatch, useSelector } from "react-redux";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, Outlet, useNavigate } from "react-router-dom";
 import { useWindowSize } from "react-use";
 import {
-  Button, Input, Spacer, Table, Tooltip, Link as LinkNext, Chip, Modal,
-  CircularProgress, TableHeader, TableColumn, TableCell, TableBody, TableRow,
-  ModalHeader, ModalBody, ModalFooter, ModalContent, DropdownTrigger, Dropdown,
-  DropdownMenu, DropdownItem, Avatar, AvatarGroup, Listbox, ListboxItem, Switch,
-  Checkbox, Card, CardHeader, Divider, CardBody,
+  Button, Spacer, Chip, CircularProgress,
+  DropdownTrigger, Dropdown, DropdownMenu, DropdownItem, Listbox, ListboxItem,
 } from "@nextui-org/react";
 import {
-  LuBarChart, LuCalendarDays, LuChevronDown, LuDatabase, LuInfo, LuLayoutGrid, LuMoreHorizontal, LuPencilLine,
-  LuPlug, LuPlus, LuSearch, LuSettings, LuTable, LuTags, LuTrash, LuUsers2,
+  LuChevronDown, LuDatabase, LuLayoutGrid, LuPlug, LuSettings, LuUsers2,
 } from "react-icons/lu";
 
 import { relog } from "../../slices/user";
 import { cleanErrors as cleanErrorsAction } from "../../actions/error";
-import { getTemplates } from "../../slices/template";
-import {
-  updateProject, removeProject, selectProjects, getProjects,
-} from "../../slices/project";
-import {
-  clearConnections,
-  getTeamConnections, removeConnection, saveConnection, selectConnections,
-} from "../../slices/connection";
-import ProjectForm from "../../components/ProjectForm";
+import { getProjects } from "../../slices/project";
+import { clearConnections, getTeamConnections } from "../../slices/connection";
 import Navbar from "../../components/Navbar";
 import canAccess from "../../config/canAccess";
 import Container from "../../components/Container";
 import Row from "../../components/Row";
 import Text from "../../components/Text";
-import connectionImages from "../../config/connectionImages";
-import { useTheme } from "../../modules/ThemeContext";
 import {
-  selectTeam, selectTeams, getTeams, saveActiveTeam, getTeamMembers, selectTeamMembers,
+  selectTeam, selectTeams, getTeams, saveActiveTeam, getTeamMembers,
 } from "../../slices/team";
-import {
-  clearDatasets,
-  deleteDataset,
-  getDatasets, getRelatedCharts, selectDatasets, updateDataset,
-} from "../../slices/dataset";
+import { clearDatasets, getDatasets } from "../../slices/dataset";
 import Segment from "../../components/Segment";
 import NoticeBoard from "./components/NoticeBoard";
+import DashboardList from "./DashboardList";
 
 /*
   The user dashboard with all the teams and projects
@@ -52,42 +36,12 @@ function UserDashboard(props) {
 
   const team = useSelector(selectTeam);
   const teams = useSelector(selectTeams);
-  const teamMembers = useSelector(selectTeamMembers);
-  const datasets = useSelector(selectDatasets);
-  const connections = useSelector(selectConnections);
-  const projects = useSelector(selectProjects);
-
-  const [addProject, setAddProject] = useState(false);
-  const [search, setSearch] = useState({});
-  const [projectToEdit, setProjectToEdit] = useState(null);
-  const [projectToDelete, setProjectToDelete] = useState(null);
-  const [modifyingProject, setModifyingProject] = useState(false);
-  const [activeMenu, setActiveMenu] = useState("projects");
-  
-  const [datasetToDelete, setDatasetToDelete] = useState(null);
-  const [relatedCharts, setRelatedCharts] = useState([]);
-  const [fetchingRelatedCharts, setFetchingRelatedCharts] = useState(false);
-  const [deletingDataset, setDeletingDataset] = useState(false);
-  const [datasetSearch, setDatasetSearch] = useState("");
-  const [showDatasetDrafts, setShowDatasetDrafts] = useState(false);
-  const [datasetToEdit, setDatasetToEdit] = useState(null);
-  const [modifyingDataset, setModifyingDataset] = useState(false);
-
-  const [connectionToDelete, setConnectionToDelete] = useState(null);
-  const [deletingConnection, setDeletingConnection] = useState(false);
-  const [connectionSearch, setConnectionSearch] = useState("");
-  const [deleteRelatedDatasets, setDeleteRelatedDatasets] = useState(false);
-  const [connectionToEdit, setConnectionToEdit] = useState(null);
-  const [modifyingConnection, setModifyingConnection] = useState(false);
-  
-  const [viewMode, setViewMode] = useState("grid");
 
   const user = useSelector((state) => state.user);
 
   const teamsRef = useRef(null);
   const initRef = useRef(null);
   const { height } = useWindowSize();
-  const { isDark } = useTheme();
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
@@ -108,9 +62,6 @@ function UserDashboard(props) {
           navigate("/login");
         });
     }
-
-    const storageViewMode = window.localStorage.getItem("__cb_view_mode");
-    if (storageViewMode) setViewMode(storageViewMode);
   }, []);
 
   useEffect(() => {
@@ -160,27 +111,6 @@ function UserDashboard(props) {
     }
   };
 
-  const _onNewProject = (team) => {
-    setAddProject(true);
-    dispatch(saveActiveTeam(team));
-    dispatch(getTemplates(team.id));
-  };
-
-  const _onProjectCreated = (project, isNew = true) => {
-    dispatch(getTeams(user.data.id));
-    setAddProject(false);
-
-    let url = `/${project.team_id}/${project.id}/dashboard`;
-    if (isNew) url += "?new=true";
-    window.location.href = url;
-  };
-
-  const directToProject = (projectId) => {
-    dispatch(saveActiveTeam(team));
-    // window.location.href = `/${team.id}/${projectId}/dashboard`;
-    navigate(`/${team.id}/${projectId}/dashboard`);
-  };
-
   const _canAccess = (role, teamRoles) => {
     return canAccess(role, user.data.id, teamRoles);
   };
@@ -189,228 +119,19 @@ function UserDashboard(props) {
     return teamRoles.filter((o) => o.user_id === user.data.id)[0].role;
   };
 
-  const _getFilteredProjects = () => {
-    if (!search[team.id]) return projects.filter((p) => !p.ghost && p.team_id === team.id);
-    const filteredProjects = projects.filter((p) => {
-      return p.name.toLowerCase().indexOf(search[team.id].toLowerCase()) > -1 && !p.ghost && p.team_id === team.id;
-    });
-
-    // now add the team members to each project
-    const formattedProjects = filteredProjects.map((p) => {
-      const projectMembers = _getProjectMembers(p, teamMembers);
-      return {
-        ...p,
-        members: projectMembers,
-      };
-    });
-
-    return formattedProjects;
-  };
-
-  const _onEditProject = (project) => {
-    setProjectToEdit(project);
-  };
-
-  const _onEditProjectSubmit = () => {
-    if (projectToEdit && projectToEdit.id) {
-      setModifyingProject(true);
-      dispatch(updateProject({ project_id: projectToEdit.id, data: { name: projectToEdit.name } }))
-        .then(() => {
-          return dispatch(getTeams(user.data.id))
-        })
-        .then(() => {
-          setModifyingProject(false);
-          setProjectToEdit(null);
-        })
-        .catch(() => {
-          setModifyingProject(false);
-        });
-    }
-  };
-
-  const _onDeleteProject = (project) => {
-    setProjectToDelete(project);
-  };
-
-  const _onDeleteProjectSubmit = () => {
-    if (projectToDelete && projectToDelete.id) {
-      setModifyingProject(true);
-      dispatch(removeProject({ project_id: projectToDelete.id }))
-        .then(() => {
-          return dispatch(getTeams(user.data.id))
-        })
-        .then(() => {
-          setProjectToDelete(null);
-          setModifyingProject(false);
-        })
-        .catch(() => {
-          setModifyingProject(false);
-        });
-    }
-  };
-
-  const _getProjectMembers = (project) => {
-    if (!teamMembers) return [];
-    const projectMembers = teamMembers.filter((tm) => {
-      return tm.TeamRoles.find((tr) => tr?.projects?.length > 0 && tr.projects.includes(project.id) && tr.role !== "teamOwner" && tr.role !== "teamAdmin");
-    });
-
-    return projectMembers;
-  };
-
   const _onChangeTeam = (teamId) => {
     const team = teams.find((t) => `${t.id}` === `${teamId}`);
     if (!team) return;
 
-    setActiveMenu("projects");
     dispatch(saveActiveTeam(team));
     dispatch(clearConnections());
     dispatch(clearDatasets());
     dispatch(getTeamMembers({ team_id: team.id }));
     dispatch(getDatasets({ team_id: team.id }));
 
+    navigate("/");
+
     window.localStorage.setItem("__cb_active_team", team.id);
-  };
-
-  const newProjectModal = () => {
-    return (
-      <ProjectForm
-        onComplete={_onProjectCreated}
-        open={addProject}
-        onClose={() => setAddProject(false)}
-      />
-    );
-  };
-
-  const _onPressDeleteDataset = (dataset) => {
-    setFetchingRelatedCharts(true);
-    setDatasetToDelete(dataset);
-    setRelatedCharts([]);
-
-    dispatch(getRelatedCharts({ team_id: team.id, dataset_id: dataset.id }))
-      .then((charts) => {
-        setRelatedCharts(charts.payload);
-        setFetchingRelatedCharts(false);
-      })
-      .catch(() => {
-        setFetchingRelatedCharts(false);
-      });
-  };
-
-  const _onDeleteDataset = () => {
-    setDeletingDataset(true);
-    dispatch(deleteDataset({ team_id: team.id, dataset_id: datasetToDelete.id }))
-      .then(() => {
-        setDeletingDataset(false);
-        setDatasetToDelete(null);
-      })
-      .catch(() => {
-        setDeletingDataset(false);
-      });
-  };
-
-  const _onCreateDataset = () => {
-    navigate(`/${team.id}/dataset/new`);
-  };
-
-  const _getFilteredDatasets = () => {
-    if (!datasetSearch) return datasets.filter((d) => !d.draft || showDatasetDrafts);
-
-    const filteredDatasets = datasets.filter((d) => {
-      return d.legend.toLowerCase().indexOf(datasetSearch.toLowerCase()) > -1 && (!d.draft || showDatasetDrafts);
-    });
-
-    return filteredDatasets;
-  };
-
-  const _getRelatedDatasets = (connectionId) => {
-    return datasets.filter((d) => d.DataRequests?.find((dr) => dr.connection_id === connectionId));
-  };
-
-  const _onDeleteConnection = () => {
-    setDeletingConnection(true);
-    dispatch(removeConnection({
-      team_id: team.id,
-      connection_id: connectionToDelete.id,
-      removeDatasets: deleteRelatedDatasets
-    }))
-      .then(() => {
-        setDeletingConnection(false);
-        setConnectionToDelete(null);
-      })
-      .catch(() => {
-        setDeletingConnection(false);
-      });
-  };
-
-  const _getConnectionTags = (projectIds) => {
-    const tags = [];
-    if (!projects || !projectIds) return tags;
-    projectIds.forEach((projectId) => {
-      const project = projects.find((p) => p.id === projectId);
-      if (project) {
-        tags.push(project.name);
-      }
-    });
-
-    return tags;
-  };
-
-  const _getDatasetTags = (projectIds) => {
-    const tags = [];
-    if (!projects || !projectIds) return tags;
-    projectIds.forEach((projectId) => {
-      const project = projects.find((p) => p.id === projectId);
-      if (project) {
-        tags.push(project.name);
-      }
-    });
-
-    return tags;
-  };
-
-  const _getFilteredConnections = () => {
-    if (!connectionSearch) return connections || [];
-
-    const filteredConnections = connections.filter((c) => {
-      return c.name.toLowerCase().indexOf(connectionSearch.toLowerCase()) > -1;
-    });
-
-    return filteredConnections || [];
-  };
-
-  const _onEditConnectionTags = async () => {
-    setModifyingConnection(true);
-
-    const projectIds = connectionToEdit.project_ids || [];
-
-    await dispatch(saveConnection({
-      team_id: team.id,
-      connection: { id: connectionToEdit.id, project_ids: projectIds },
-    }));
-
-    setModifyingConnection(false);
-    setConnectionToEdit(null);
-  };
-
-  const _onEditDatasetTags = async () => {
-    setModifyingDataset(true);
-
-    const projectIds = datasetToEdit.project_ids || [];
-
-    await dispatch(updateDataset({
-      team_id: team.id,
-      dataset_id: datasetToEdit.id,
-      data: { project_ids: projectIds },
-    }));
-
-    setModifyingDataset(false);
-    setDatasetToEdit(null);
-  };
-
-  const _changeViewMode = (mode) => {
-    setViewMode(mode);
-    window.localStorage.setItem("__cb_view_mode", mode);
   };
 
   if (!user.data.id) {
@@ -425,10 +146,13 @@ function UserDashboard(props) {
     );
   }
 
+  const _getActiveMenu = () => {
+    return window.location.pathname.split("/")[1];
+  };
+
   return (
     <div className="dashboard bg-content2" style={styles.container(height)}>
       <Navbar hideTeam transparent />
-      {newProjectModal()}
       <div className="container mx-auto">
         <Spacer y={4} />
 
@@ -479,17 +203,14 @@ function UserDashboard(props) {
 
               <Spacer y={4} />
               <Segment className={"p-1 sm:p-1 md:p-1 bg-content1 rounded-xl"}>
-                <Listbox
-                  aria-label="Actions"
-                  onAction={(key) => setActiveMenu(key)}
-                  variant="faded"
-                >
+                <Listbox aria-label="Actions" variant="faded">
                   <ListboxItem
                     key="projects"
                     startContent={<LuLayoutGrid size={24} />}
                     textValue="Dashboards"
-                    color={activeMenu === "projects" ? "primary" : "default"}
-                    className={activeMenu === "projects" ? "bg-content2 text-primary" : ""}
+                    color={_getActiveMenu() === "" ? "primary" : "default"}
+                    className={_getActiveMenu() === "" ? "bg-content2 text-primary" : "text-foreground"}
+                    onClick={() => navigate("/")}
                   >
                     <span className="text-lg">Dashboards</span>
                   </ListboxItem>
@@ -498,8 +219,9 @@ function UserDashboard(props) {
                       key="connections"
                       startContent={<LuPlug size={24} />}
                       textValue="Connections"
-                      color={activeMenu === "connections" ? "primary" : "default"}
-                      className={activeMenu === "connections" ? "bg-content2 text-primary connection-tutorial" : "connection-tutorial"}
+                      color={_getActiveMenu() === "connections" ? "primary" : "default"}
+                      className={_getActiveMenu() === "connections" ? "bg-content2 text-primary connection-tutorial" : "connection-tutorial"}
+                      onClick={() => navigate("/connections")}
                     >
                       <span className="text-lg">Connections</span>
                     </ListboxItem>
@@ -510,8 +232,9 @@ function UserDashboard(props) {
                       showDivider={_canAccess("teamAdmin", team.TeamRoles)}
                       startContent={<LuDatabase size={24} />}
                       textValue="Datasets"
-                      color={activeMenu === "datasets" ? "primary" : "default"}
-                      className={activeMenu === "datasets" ? "bg-content2 text-primary dataset-tutorial" : "dataset-tutorial"}
+                      color={_getActiveMenu() === "datasets" ? "primary" : "default"}
+                      className={_getActiveMenu() === "datasets" ? "bg-content2 text-primary dataset-tutorial" : "dataset-tutorial"}
+                      onClick={() => navigate("/datasets")}
                     >
                       <span className="text-lg">Datasets</span>
                     </ListboxItem>
@@ -523,8 +246,8 @@ function UserDashboard(props) {
                       key="teamSettings"
                       startContent={<LuSettings size={24} />}
                       textValue="Team settings"
-                      color={activeMenu === "teamSettings" ? "primary" : "default"}
-                      className={activeMenu === "teamSettings" ? "bg-content2 text-primary team-settings-tutorial" : "text-foreground team-settings-tutorial"}
+                      color={"default"}
+                      className={"text-foreground team-settings-tutorial"}
                     >
                       <span className="text-lg">Team settings</span>
                     </ListboxItem>
@@ -536,857 +259,16 @@ function UserDashboard(props) {
             </div>
 
             <div className="col-span-12 sm:col-span-7 md:col-span-8 lg:col-span-9">
-              {activeMenu === "projects" && (
-                <>
-                  <Row justify="space-between" align="center">
-                    <Row className={"gap-2"} justify="flex-start" align="center">
-                      {_canAccess("teamAdmin", team.TeamRoles) && (
-                        <div>
-                          <Button
-                            color="primary"
-                            onClick={() => _onNewProject(team)}
-                            endContent={<LuPlus />}
-                            className="create-dashboard-tutorial"
-                          >
-                            <span className="hidden md:block">Create dashboard</span>
-                            <span className="md:hidden">Create</span>
-                          </Button>
-                        </div>
-                      )}
-                      <Input
-                        type="text"
-                        placeholder="Search dashboards"
-                        variant="bordered"
-                        endContent={<LuSearch />}
-                        onChange={(e) => setSearch({ ...search, [team.id]: e.target.value })}
-                        className="max-w-[300px]"
-                        labelPlacement="outside"
-                      />
-                    </Row>
-                    <div className="flex flex-row">
-                      <Button
-                        variant="light"
-                        isIconOnly
-                        color={viewMode === "grid" ? "primary" : "default"}
-                        onClick={() => _changeViewMode("grid")}
-                      >
-                        <LuLayoutGrid />
-                      </Button>
-                      <Button
-                        variant="light"
-                        isIconOnly
-                        color={viewMode === "table" ? "primary" : "default"}
-                        onClick={() => _changeViewMode("table")}
-                      >
-                        <LuTable />
-                      </Button>
-                    </div>
-                  </Row>
-                  <Spacer y={4} />
-                  {projects && viewMode === "grid" && (
-                    <div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                      {_getFilteredProjects().map((project) => (
-                        <Card
-                          key={project.id}
-                          isPressable
-                          shadow="none"
-                          className="border-1 border-solid border-content3"
-                          radius="sm"
-                          onClick={() => directToProject(project.id)}
-                        >
-                          <CardHeader className="flex flex-row justify-between items-center">
-                            <span className="text-sm font-medium">{project.name}</span>
-                            {_canAccess("teamAdmin", team.TeamRoles) && (
-                              <Dropdown size="sm">
-                                <DropdownTrigger>
-                                  <LinkNext className="text-foreground-400">
-                                    <LuMoreHorizontal />
-                                  </LinkNext>
-                                </DropdownTrigger>
-                                <DropdownMenu>
-                                  <DropdownItem
-                                    onClick={() => _onEditProject(project)}
-                                    startContent={<LuPencilLine />}
-                                    showDivider
-                                    textValue="Rename"
-                                  >
-                                    Rename
-                                  </DropdownItem>
-                                  <DropdownItem
-                                    onClick={() => _onDeleteProject(project)}
-                                    startContent={<LuTrash />}
-                                    color="danger"
-                                    textValue="Delete"
-                                  >
-                                    Delete
-                                  </DropdownItem>
-                                </DropdownMenu>
-                              </Dropdown>
-                            )}
-                          </CardHeader>
-                          <Divider />
-                          <CardBody>
-                            <Row justify="space-between" align="center">
-                              {_getProjectMembers(project)?.length > 0 && (
-                                <AvatarGroup max={3} isBordered size="sm">
-                                  {_getProjectMembers(project)?.map((pr) => (
-                                    <Avatar
-                                      key={pr.id}
-                                      name={pr.name}
-                                    />
-                                  ))}
-                                </AvatarGroup>
-                              )}
-                              {_getProjectMembers(project)?.length === 0 && (
-                                <Chip variant="flat" size="sm">
-                                  Team only
-                                </Chip>
-                              )}
-                              <div className="flex flex-row items-center gap-1 text-sm">
-                                <LuBarChart />
-                                <span>{project?.Charts?.length || 0}</span>
-                              </div>
-                            </Row>
-                          </CardBody>
-                        </Card>
-                      ))}
+              <Outlet />
 
-                      {_getFilteredProjects().length === 0 && (
-                        <div>
-                          <span className="text-foreground-400 italic">
-                            {"No dashboards here"}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  {projects && viewMode === "table" && (
-                    <Table
-                      aria-label="Dashboard list"
-                      className="h-auto min-w-full border-1 border-solid border-content3 rounded-xl"
-                      radius="md"
-                      shadow="none"
-                      isStriped
-                    >
-                      <TableHeader>
-                        <TableColumn key="name">Dashboard name</TableColumn>
-                        <TableColumn key="members">
-                          <Row align="end" justify="center" className={"gap-1"}>
-                            <LuUsers2 />
-                            <Text>Dashboard members</Text>
-                          </Row>
-                        </TableColumn>
-                        <TableColumn key="charts">
-                          <Row align="end" justify="center" className={"gap-1"}>
-                            <LuBarChart />
-                            <Text>Charts</Text>
-                          </Row>
-                        </TableColumn>
-                        <TableColumn key="actions" align="center" hideHeader>Actions</TableColumn>
-                      </TableHeader>
-                      <TableBody>
-                        {_getFilteredProjects().map((project) => (
-                          <TableRow key={project.id}>
-                            <TableCell key="name">
-                              <LinkNext onClick={() => directToProject(project.id)} className="cursor-pointer flex flex-col items-start">
-                                <span className={"text-foreground font-medium"}>{project.name}</span>
-                              </LinkNext>
-                            </TableCell>
-                            <TableCell key="members">
-                              <Row justify="center" align="center">
-                                {_getProjectMembers(project)?.length > 0 && (
-                                  <AvatarGroup max={3} isBordered size="sm">
-                                    {_getProjectMembers(project)?.map((pr) => (
-                                      <Avatar
-                                        key={pr.id}
-                                        name={pr.name}
-                                      />
-                                    ))}
-                                  </AvatarGroup>
-                                )}
-                                {_getProjectMembers(project)?.length === 0 && (
-                                  <Chip variant="flat" size="sm">
-                                    Team only
-                                  </Chip>
-                                )}
-                              </Row>
-                            </TableCell>
-                            <TableCell key="charts">
-                              <Row justify="center" align="center">
-                                <Text b>
-                                  {project?.Charts?.length || 0}
-                                </Text>
-                              </Row>
-                            </TableCell>
-                            <TableCell key="actions">
-                              {_canAccess("teamAdmin", team.TeamRoles) && (
-                                <Row justify="flex-end" align="center">
-                                  <Tooltip content="Rename the dashboard">
-                                    <Button
-                                      startContent={<LuPencilLine />}
-                                      variant="light"
-                                      size="sm"
-                                      className={"min-w-fit"}
-                                      onClick={() => _onEditProject(project)}
-                                    />
-                                  </Tooltip>
-                                  <Tooltip
-                                    content="Delete project"
-                                    color="danger"
-                                  >
-                                    <Button
-                                      color="danger"
-                                      startContent={<LuTrash />}
-                                      variant="light"
-                                      size="sm"
-                                      className={"min-w-fit"}
-                                      onClick={() => _onDeleteProject(project)}
-                                    />
-                                  </Tooltip>
-                                  <Spacer x={0.5} />
-                                </Row>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                      {_getFilteredProjects().length === 0 && (
-                        <TableBody>
-                          <TableRow>
-                            <TableCell key="name" className="p-0 pt-2">
-                              <span className="italic text-default-500">No dashboards here</span>
-                            </TableCell>
-                            <TableCell key="members" align="center" />
-                            <TableCell key="charts" align="center" />
-                            <TableCell key="actions" align="center" />
-                          </TableRow>
-                        </TableBody>
-                      )}
-                    </Table>
-                  )}
-                  {projects && projects.length === 0 && !_canAccess("projectEditor", team.TeamRoles) && (
-                    <Container>
-                    <Text size="h3">
-                        {"No project over here"}
-                      </Text>
-                    </Container>
-                  )}
-                </>
-              )}
-
-              {activeMenu === "connections" && (
-                <div className="max-h-full overflow-y-auto">
-                  <Row className={"gap-4"}>
-                    {_canAccess("teamAdmin", team.TeamRoles) && (
-                      <Button
-                        color="primary"
-                        endContent={<LuPlus />}
-                        onClick={() => navigate(`/${team.id}/connection/new`)}
-                      >
-                        Create connection
-                      </Button>
-                    )}
-                    <Input
-                      type="text"
-                      placeholder="Search connections"
-                      variant="bordered"
-                      endContent={<LuSearch />}
-                      className="max-w-[300px]"
-                      labelPlacement="outside"
-                      onChange={(e) => setConnectionSearch(e.target.value)}
-                    />
-                  </Row>
-                  <Spacer y={4} />
-                  <Table shadow="none" isStriped className="border-1 border-solid border-content3 rounded-xl" aria-label="Connection list">
-                    <TableHeader>
-                      <TableColumn key="name">Connection</TableColumn>
-                      <TableColumn key="tags" className="tutorial-tags">
-                        <div className="flex flex-row items-center gap-1">
-                          <LuTags />
-                          <span>Tags</span>
-                        </div>
-                      </TableColumn>
-                      <TableColumn key="created" textValue="Created">
-                        <div className="flex flex-row items-center gap-1">
-                          <LuCalendarDays />
-                          <span>Created</span>
-                        </div>
-                      </TableColumn>
-                      <TableColumn key="actions" align="center" hideHeader>Actions</TableColumn>
-                    </TableHeader>
-                    <TableBody>
-                      {_getFilteredConnections()?.map((connection) => (
-                        <TableRow key={connection.id}>
-                          <TableCell key="name">
-                            <Row align={"center"} className={"gap-4"}>
-                              <Avatar
-                                src={connectionImages(isDark)[connection.subType]}
-                                size="sm"
-                                isBordered
-                              />
-                              <Link to={`/${team.id}/connection/${connection.id}`} className="cursor-pointer">
-                                <span className="text-foreground font-medium">{connection.name}</span>
-                              </Link>
-                            </Row>
-                          </TableCell>
-                          <TableCell key="tags">
-                            {_getConnectionTags(connection.project_ids).length > 0 && (
-                              <div
-                                className="flex flex-row flex-wrap items-center gap-1 cursor-pointer hover:saturate-200 transition-all"
-                                onClick={() => setConnectionToEdit(connection)}
-                              >
-                                {_getConnectionTags(connection.project_ids).slice(0, 3).map((tag) => (
-                                  <Chip
-                                    key={tag}
-                                    size="sm"
-                                    variant="flat"
-                                    color="primary"
-                                  >
-                                    {tag}
-                                  </Chip>
-                                ))}
-                                {_getConnectionTags(connection.project_ids).length > 3 && (
-                                  <span className="text-xs">{`+${_getConnectionTags(connection.project_ids).length - 3} more`}</span>
-                                )}
-                              </div>
-                            )}
-                            {_getConnectionTags(connection.project_ids).length === 0 && (
-                              <Button
-                                variant="light"
-                                startContent={<LuPlus size={18} />}
-                                size="sm"
-                                className="opacity-0 hover:opacity-100"
-                                onClick={() => setConnectionToEdit(connection)}
-                              >
-                                Add tag
-                              </Button>
-                            )}
-                          </TableCell>
-                          <TableCell key="created">
-                            <Text>{new Date(connection.createdAt).toLocaleDateString()}</Text>
-                          </TableCell>
-                          <TableCell key="actions">
-                            {_canAccess("teamAdmin", team.TeamRoles) && (
-                              <Row justify="flex-end" align="center">
-                                <Dropdown aria-label="Select a connection option">
-                                  <DropdownTrigger>
-                                    <Button
-                                      isIconOnly
-                                      variant="light"
-                                      size="sm"
-                                    >
-                                      <LuMoreHorizontal />
-                                    </Button>
-                                  </DropdownTrigger>
-                                  <DropdownMenu variant="flat">
-                                    <DropdownItem
-                                      onClick={() => navigate(`/${team.id}/connection/${connection.id}`)}
-                                      startContent={<LuPencilLine />}
-                                    >
-                                      Edit connection
-                                    </DropdownItem>
-                                    <DropdownItem
-                                      onClick={() => setConnectionToEdit(connection)}
-                                      startContent={<LuTags />}
-                                      showDivider
-                                    >
-                                      Edit tags
-                                    </DropdownItem>
-                                    <DropdownItem
-                                      onClick={() => setConnectionToDelete(connection)}
-                                      startContent={<LuTrash />}
-                                      color="danger"
-                                    >
-                                      Delete
-                                    </DropdownItem>
-                                  </DropdownMenu>
-                                </Dropdown>
-                              </Row>
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                  <Spacer y={2} />
-                </div>
-              )}
-
-              {activeMenu === "datasets" && (
-                <div className="max-h-full overflow-y-auto">
-                  <Row className={"gap-4"} align="center">
-                    {connections.length > 0 && (
-                      <Button
-                        color="primary"
-                        endContent={<LuPlus />}
-                        onClick={() => _onCreateDataset()}
-                      >
-                        Create dataset
-                      </Button>
-                    )}
-                    <Input
-                      type="text"
-                      placeholder="Search datasets"
-                      variant="bordered"
-                      endContent={<LuSearch />}
-                      className="max-w-[300px]"
-                      labelPlacement="outside"
-                      onChange={(e) => setDatasetSearch(e.target.value)}
-                    />
-                    <Switch
-                      isSelected={showDatasetDrafts}
-                      onChange={() => setShowDatasetDrafts(!showDatasetDrafts)}
-                      size="sm"
-                    >
-                      <span className="text-sm">Show drafts</span>
-                    </Switch>
-                  </Row>
-                  <Spacer y={4} />
-                  <Table shadow="none" isStriped className="border-1 border-solid border-content3 rounded-xl" aria-label="Dataset list">
-                    <TableHeader>
-                      <TableColumn key="name">Dataset name</TableColumn>
-                      <TableColumn key="connections" textValue="Connections" align="center" justify="center">
-                        <div className="flex flex-row items-center justify-center gap-1">
-                          <LuPlug />
-                          <span>Connections</span>
-                        </div>
-                      </TableColumn>
-                      <TableColumn key="tags" textValue="Tags">
-                        <div className="flex flex-row items-center gap-1">
-                          <LuTags />
-                          <span>Tags</span>
-                        </div>
-                      </TableColumn>
-                      <TableColumn key="actions" align="center" hideHeader>Actions</TableColumn>
-                    </TableHeader>
-                    <TableBody>
-                      {_getFilteredDatasets().map((dataset) => (
-                        <TableRow key={dataset.id}>
-                          <TableCell key="name">
-                            <div className="flex flex-row items-center gap-2">
-                              <Link to={`/${team.id}/dataset/${dataset.id}`} className="cursor-pointer">
-                                <span className="text-foreground font-medium">{dataset.legend}</span>
-                              </Link>
-                              {dataset.draft && (
-                                <Chip size="sm" variant="flat" color="secondary">
-                                  Draft
-                                </Chip>
-                              )}
-                            </div>
-                          </TableCell>
-                          <TableCell key="connections">
-                            <Row justify={"center"}>
-                              <AvatarGroup max={3} isBordered size="sm">
-                                {dataset?.DataRequests?.map((dr) => (
-                                  <Avatar
-                                    src={connectionImages(isDark)[dr?.Connection?.subType]}
-                                    showFallback={<LuPlug />}
-                                    size="sm"
-                                    isBordered
-                                    key={dr.id}
-                                  />
-                                ))}
-                              </AvatarGroup>
-                            </Row>
-                          </TableCell>
-                          <TableCell key="tags">
-                            {_getDatasetTags(dataset.project_ids).length > 0 && (
-                              <div
-                                className="flex flex-row flex-wrap items-center gap-1 cursor-pointer hover:saturate-200 transition-all"
-                                onClick={() => {
-                                  if (_canAccess("teamAdmin", team.TeamRoles)) {
-                                    setDatasetToEdit(dataset);
-                                  }
-                                }}
-                              >
-                                {_getDatasetTags(dataset.project_ids).slice(0, 3).map((tag) => (
-                                  <Chip
-                                    key={tag}
-                                    size="sm"
-                                    variant="flat"
-                                    color="primary"
-                                  >
-                                    {tag}
-                                  </Chip>
-                                ))}
-                                {_getDatasetTags(dataset.project_ids).length > 3 && (
-                                  <span className="text-xs">{`+${_getDatasetTags(dataset.project_ids).length - 3} more`}</span>
-                                )}
-                              </div>
-                            )}
-                            {_getDatasetTags(dataset.project_ids).length === 0 && (
-                              <Button
-                                variant="light"
-                                startContent={<LuPlus size={18} />}
-                                size="sm"
-                                className="opacity-0 hover:opacity-100"
-                                onClick={() => {
-                                  if (_canAccess("teamAdmin", team.TeamRoles)) {
-                                    setDatasetToEdit(dataset);
-                                  }
-                                }}
-                              >
-                                Add tag
-                              </Button>
-                            )}
-                          </TableCell>
-                          <TableCell key="actions">
-                            <Row justify="flex-end" align="center">
-                              <Dropdown aria-label="Select a dataset option">
-                                <DropdownTrigger>
-                                  <Button
-                                    isIconOnly
-                                    variant="light"
-                                    size="sm"
-                                  >
-                                    <LuMoreHorizontal />
-                                  </Button>
-                                </DropdownTrigger>
-                                <DropdownMenu
-                                  variant="flat"
-                                  disabledKeys={!_canAccess("teamAdmin", team.TeamRoles) ? ["tags", "delete"] : []}
-                                >
-                                  <DropdownItem
-                                    onClick={() => navigate(`/${team.id}/dataset/${dataset.id}`)}
-                                    startContent={<LuPencilLine />}
-                                    key="dataset"
-                                    textValue="Edit dataset"
-                                  >
-                                    Edit dataset
-                                  </DropdownItem>
-                                  <DropdownItem
-                                    key="tags"
-                                    onClick={() => setDatasetToEdit(dataset)}
-                                    startContent={<LuTags />}
-                                    showDivider
-                                    textValue="Edit tags"
-                                  >
-                                    Edit tags
-                                  </DropdownItem>
-                                  <DropdownItem
-                                    key="delete"
-                                    onClick={() => _onPressDeleteDataset(dataset)}
-                                    startContent={<LuTrash />}
-                                    color="danger"
-                                    textValue="Delete"
-                                  >
-                                    Delete
-                                  </DropdownItem>
-                                </DropdownMenu>
-                              </Dropdown>
-                            </Row>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
+              {window.location.pathname === "/user" && (
+                <DashboardList />
               )}
             </div>
           </div>
         )}
 
         <Spacer y={4} />
-
-        <Modal isOpen={!!projectToEdit} onClose={() => setProjectToEdit(null)}>
-          <ModalContent>
-            <ModalHeader>
-              <Text size="h3">Rename your dashboard</Text>
-            </ModalHeader>
-            <ModalBody>
-              <Input
-                label="Dashboard name"
-                placeholder="Enter the dashboard name"
-                value={projectToEdit?.name || ""}
-                onChange={(e) => setProjectToEdit({ ...projectToEdit, name: e.target.value })}
-                variant="bordered"
-                fullWidth
-              />
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                variant="bordered"
-                onClick={() => setProjectToEdit(null)}
-              >
-                Cancel
-              </Button>
-              <Button
-                color="primary"
-                onClick={() => _onEditProjectSubmit()}
-                disabled={!projectToEdit?.name || modifyingProject}
-                isLoading={modifyingProject}
-              >
-                Save
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-
-        <Modal isOpen={!!projectToDelete} onClose={() => setProjectToDelete(null)}>
-          <ModalContent>
-            <ModalHeader>
-              <Text size="h4">Are you sure you want to delete the dashboard?</Text>
-            </ModalHeader>
-            <ModalBody>
-              <Text>
-                {"Deleting a dashboard will delete all the charts and make the report unavailable. This action cannot be undone."}
-              </Text>
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                variant="bordered"
-                onClick={() => setProjectToDelete(null)}
-              >
-                Cancel
-              </Button>
-              <Button
-                auto
-                color="danger"
-                endContent={<LuTrash />}
-                onClick={() => _onDeleteProjectSubmit()}
-                isLoading={modifyingProject}
-              >
-                Delete
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-
-        <Modal isOpen={datasetToDelete?.id} onClose={() => setDatasetToDelete(null)}>
-          <ModalContent>
-            <ModalHeader>
-              <Text size="h4">Are you sure you want to delete this dataset?</Text>
-            </ModalHeader>
-            <ModalBody>
-              <div>
-                <Text>
-                  {"Just a heads-up that all the charts that use this dataset will stop working. This action cannot be undone."}
-                </Text>
-              </div>
-              {fetchingRelatedCharts && (
-                <div className="flex flex-row items-center gap-1">
-                  <CircularProgress size="sm" aria-label="Checking related charts" />
-                  <Text className={"italic"}>Checking related charts...</Text>
-                </div>
-              )}
-              {!fetchingRelatedCharts && relatedCharts.length === 0 && (
-                <div className="flex flex-row items-center">
-                  <Text className={"italic"}>No related charts found</Text>
-                </div>
-              )}
-              {!fetchingRelatedCharts && relatedCharts.length > 0 && (
-                <div className="flex flex-row items-center">
-                  <Text>Related charts:</Text>
-                </div>
-              )}
-              <div className="flex flex-row flex-wrap items-center gap-1">
-                {relatedCharts.slice(0, 10).map((chart) => (
-                  <Chip
-                    key={chart.id}
-                    size="sm"
-                    variant="flat"
-                    color="primary"
-                  >
-                    {chart.name}
-                  </Chip>
-                ))}
-                {relatedCharts.length > 10 && (
-                  <span className="text-xs">{`+${relatedCharts.length - 10} more`}</span>
-                )}
-              </div>
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                variant="bordered"
-                onClick={() => setDatasetToDelete(null)}
-                auto
-              >
-                Cancel
-              </Button>
-              <Button
-                auto
-                color="danger"
-                endContent={<LuTrash />}
-                onClick={() => _onDeleteDataset()}
-                isLoading={deletingDataset}
-              >
-                Delete
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-
-        <Modal isOpen={connectionToDelete?.id} onClose={() => setConnectionToDelete(null)}>
-          <ModalContent>
-            <ModalHeader>
-              <Text size="h4">Are you sure you want to delete this connection?</Text>
-            </ModalHeader>
-            <ModalBody>
-              <div>
-                <Text>
-                  {"Just a heads-up that all the datasets and charts that use this connection will stop working. This action cannot be undone."}
-                </Text>
-              </div>
-              {_getRelatedDatasets(connectionToDelete?.id).length === 0 && (
-                <div className="flex flex-row items-center">
-                  <Text className={"italic"}>No related datasets found</Text>
-                </div>
-              )}
-              {_getRelatedDatasets(connectionToDelete?.id).length > 0 && (
-                <div className="flex flex-row items-center">
-                  <Text>Related datasets:</Text>
-                </div>
-              )}
-              <div className="flex flex-row flex-wrap items-center gap-1">
-                {_getRelatedDatasets(connectionToDelete?.id).slice(0, 10).map((dataset) => (
-                  <Chip
-                    key={dataset.id}
-                    size="sm"
-                    variant="flat"
-                    color="primary"
-                  >
-                    {dataset.legend}
-                  </Chip>
-                ))}
-                {_getRelatedDatasets(connectionToDelete?.id).length > 10 && (
-                  <span className="text-xs">{`+${_getRelatedDatasets(connectionToDelete?.id).length - 10} more`}</span>
-                )}
-              </div>
-            </ModalBody>
-            <ModalFooter className="justify-between">
-              <Checkbox
-                onChange={() => setDeleteRelatedDatasets(!deleteRelatedDatasets)}
-                isSelected={deleteRelatedDatasets}
-                size="sm"
-              >
-                Delete related datasets
-              </Checkbox>
-              <div className="flex flex-row items-center gap-1">
-                <Button
-                  variant="bordered"
-                  onClick={() => setConnectionToDelete(null)}
-                  size="sm"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  color="danger"
-                  endContent={<LuTrash />}
-                  onClick={() => _onDeleteConnection()}
-                  isLoading={deletingConnection}
-                >
-                  Delete
-                </Button>
-              </div>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-
-        <Modal isOpen={!!connectionToEdit} onClose={() => setConnectionToEdit(null)} size="xl">
-          <ModalContent>
-            <ModalHeader>
-              <Text size="h3">Edit tags</Text>
-            </ModalHeader>
-            <ModalBody>
-              <div className="flex flex-row flex-wrap items-center gap-2">
-                {projects.filter((p) => !p.ghost).map((project) => (
-                  <Chip
-                    key={project.id}
-                    radius="sm"
-                    variant={connectionToEdit?.project_ids?.includes(project.id) ? "solid" : "flat"}
-                    color="primary"
-                    className="cursor-pointer"
-                    onClick={() => {
-                      if (connectionToEdit?.project_ids?.includes(project.id)) {
-                        setConnectionToEdit({ ...connectionToEdit, project_ids: connectionToEdit?.project_ids?.filter((p) => p !== project.id) });
-                      }
-                      else {
-                        setConnectionToEdit({ ...connectionToEdit, project_ids: [...connectionToEdit?.project_ids || [], project.id] });
-                      }
-                    }}
-                  >
-                    {project.name}
-                  </Chip>
-                ))}
-              </div>
-              <Spacer y={1} />
-              <div className="flex gap-1 bg-content2 p-2 mb-2 rounded-lg text-foreground-500 text-sm">
-                <div>
-                  <LuInfo />
-                </div>
-                {"Use tags to grant dashboard members access to these connections. Tagged connections can be used by members to create their own datasets within the associated dashboards."}
-              </div>
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                variant="bordered"
-                onClick={() => setConnectionToEdit(null)}
-              >
-                Close
-              </Button>
-              <Button
-                color="primary"
-                onClick={() => _onEditConnectionTags()}
-                isLoading={modifyingConnection}
-              >
-                Save
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-
-        <Modal isOpen={!!datasetToEdit} onClose={() => setDatasetToEdit(null)} size="xl">
-          <ModalContent>
-            <ModalHeader>
-              <Text size="h3">Edit tags</Text>
-            </ModalHeader>
-            <ModalBody>
-              <div className="flex flex-row flex-wrap items-center gap-2">
-                {projects.filter((p) => !p.ghost).map((project) => (
-                  <Chip
-                    key={project.id}
-                    radius="sm"
-                    variant={datasetToEdit?.project_ids?.includes(project.id) ? "solid" : "flat"}
-                    color="primary"
-                    className="cursor-pointer"
-                    onClick={() => {
-                      if (datasetToEdit?.project_ids?.includes(project.id)) {
-                        setDatasetToEdit({ ...datasetToEdit, project_ids: datasetToEdit?.project_ids?.filter((p) => p !== project.id) });
-                      } else {
-                        setDatasetToEdit({ ...datasetToEdit, project_ids: [...datasetToEdit?.project_ids || [], project.id] });
-                      }
-                    }}
-                  >
-                    {project.name}
-                  </Chip>
-                ))}
-              </div>
-              <Spacer y={1} />
-              <div className="flex gap-1 bg-content2 p-2 mb-2 rounded-lg text-foreground-500 text-sm">
-                <div>
-                  <LuInfo />
-                </div>
-                {"Assign tags to datasets to control which dashboards can use them. Members can create charts from these datasets within dashboards associated with the selected tags."}
-              </div>
-            </ModalBody>
-            <ModalFooter>
-              <Button
-                variant="bordered"
-                onClick={() => setDatasetToEdit(null)}
-              >
-                Close
-              </Button>
-              <Button
-                color="primary"
-                onClick={() => _onEditDatasetTags()}
-                isLoading={modifyingDataset}
-              >
-                Save
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
 
         {(teams && teams.length === 0) && (
           <>

--- a/client/src/containers/UserDashboard/UserDashboard.jsx
+++ b/client/src/containers/UserDashboard/UserDashboard.jsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { connect, useDispatch, useSelector } from "react-redux";
-import { Link, Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router-dom";
 import { useWindowSize } from "react-use";
 import {
   Button, Spacer, Chip, CircularProgress,
   DropdownTrigger, Dropdown, DropdownMenu, DropdownItem, Listbox, ListboxItem,
 } from "@nextui-org/react";
 import {
-  LuChevronDown, LuDatabase, LuLayoutGrid, LuPlug, LuSettings, LuUsers2,
+  LuChevronDown, LuDatabase, LuLayoutGrid, LuPlug, LuPuzzle, LuSettings, LuUsers2,
 } from "react-icons/lu";
 
 import { relog } from "../../slices/user";
@@ -229,7 +229,6 @@ function UserDashboard(props) {
                   {_canAccess("projectEditor", team.TeamRoles) && (
                     <ListboxItem
                       key="datasets"
-                      showDivider={_canAccess("teamAdmin", team.TeamRoles)}
                       startContent={<LuDatabase size={24} />}
                       textValue="Datasets"
                       color={_getActiveMenu() === "datasets" ? "primary" : "default"}
@@ -241,13 +240,25 @@ function UserDashboard(props) {
                   )}
                   {_canAccess("teamAdmin", team.TeamRoles) && (
                     <ListboxItem
-                      as={Link}
-                      to={`/manage/${team.id}/settings`}
+                      key="integrations"
+                      showDivider={_canAccess("teamAdmin", team.TeamRoles)}
+                      startContent={<LuPuzzle size={24} />}
+                      textValue="Integrations"
+                      color={_getActiveMenu() === "integrations" ? "primary" : "default"}
+                      className={_getActiveMenu() === "integrations" ? "bg-content2 text-primary dataset-tutorial" : "dataset-tutorial"}
+                      onClick={() => navigate("/integrations")}
+                    >
+                      <span className="text-lg">Integrations</span>
+                    </ListboxItem>
+                  )}
+                  {_canAccess("teamAdmin", team.TeamRoles) && (
+                    <ListboxItem
                       key="teamSettings"
                       startContent={<LuSettings size={24} />}
                       textValue="Team settings"
                       color={"default"}
                       className={"text-foreground team-settings-tutorial"}
+                      onClick={() => navigate(`/manage/${team.id}/settings`)}
                     >
                       <span className="text-lg">Team settings</span>
                     </ListboxItem>

--- a/client/src/containers/UserDashboard/UserDashboard.jsx
+++ b/client/src/containers/UserDashboard/UserDashboard.jsx
@@ -151,9 +151,9 @@ function UserDashboard(props) {
   };
 
   return (
-    <div className="dashboard bg-content2" style={styles.container(height)}>
+    <div className="dashboard bg-content2 flex flex-col h-screen">
       <Navbar hideTeam transparent />
-      <div className="container mx-auto">
+      <div className="container mx-auto px-4">
         <Spacer y={4} />
 
         {team?.id && (


### PR DESCRIPTION
Currently, there is only one route for the homepage, but `connections` and `datasets` should be served on their own `/connections` and `/datasets` routes to make navigation easier.

Also moved the `integrations` on the homepage since they are team-based.