### PR TITLE
fix: support named/numeric weekdays

### DIFF
--- a/server/crons/updateDashboards.js
+++ b/server/crons/updateDashboards.js
@@ -52,7 +52,33 @@ async function updateDashboards(queue) {
         const updateTime = DateTime.fromFormat(formattedTime, "HH:mm", { zone: timezone });
         shouldUpdate = now > updateTime && now.diff(lastUpdated, "days").as("days") >= 1;
       } else if (frequency === "weekly") {
-        const updateTime = DateTime.fromFormat(formattedTime, "HH:mm", { zone: timezone }).set({ weekday: dayOfWeek });
+        const weekdays = {
+          1: 'monday',
+          2: 'tuesday',
+          3: 'wednesday',
+          4: 'thursday',
+          5: 'friday',
+          6: 'saturday',
+          7: 'sunday'
+        };
+
+        let luxonWeekday;
+
+        if (typeof dayOfWeek === 'string') {
+          const lowerDayOfWeek = dayOfWeek.toLowerCase();
+          luxonWeekday = Object.keys(weekdays).find(
+            key => weekdays[key] === lowerDayOfWeek
+          );
+        }
+
+        if (!luxonWeekday) {
+          luxonWeekday = Number(dayOfWeek);
+          if (isNaN(luxonWeekday) || luxonWeekday < 1 || luxonWeekday > 7) {
+            throw new Error("Invalid weekday. Must be a number (1-7) or a valid day name (e.g., 'monday').");
+          }
+        }
+
+        const updateTime = DateTime.fromFormat(formattedTime, "HH:mm", { zone: timezone }).set({ weekday: luxonWeekday });
         shouldUpdate = now > updateTime && now.diff(lastUpdated, "weeks").as("weeks") >= 1;
       } else if (frequency === "every_x_days") {
         shouldUpdate = now.diff(lastUpdated, "days").as("days") >= frequencyNumber;


### PR DESCRIPTION
Fixes: #272 
- Supports both named ("sunday","monday", etc) and 1to7. 1 being monday. The reason is to handle possible existing data.

Server crashes on this error

![image](https://github.com/user-attachments/assets/79867c38-bb4d-4a44-8c1e-ae4b65f95e83)

