### PR TITLE
:sparkles: Added the option to configure SSH tunnel connections for Mysql and Postgres-based connections

### DIFF
--- a/client/src/containers/Connections/components/MysqlConnectionForm.jsx
+++ b/client/src/containers/Connections/components/MysqlConnectionForm.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import {
   Button, Input, Link, Spacer, Chip, Tabs, Tab, Divider, Switch, Select, SelectItem,
-  CircularProgress,
+  CircularProgress, Alert,
 } from "@heroui/react";
 import { FaExternalLinkSquareAlt } from "react-icons/fa";
 import AceEditor from "react-ace";
@@ -58,6 +58,12 @@ function MysqlConnectionForm(props) {
     sslCert: null,
     sslKey: null,
   });
+  const [sshFiles, setSshFiles] = useState({
+    sshPrivateKey: null,
+  });
+  const [sshFilesErrors, setSshFilesErrors] = useState({
+    sshPrivateKey: null,
+  });
 
   const { isDark } = useTheme();
   const dispatch = useDispatch();
@@ -90,12 +96,20 @@ function MysqlConnectionForm(props) {
   const _onTestRequest = async (data) => {
     const newTestResult = {};
     let response;
+    
+    const files = {
+      ...sslCerts
+    };
+    
+    if (data.useSsh && sshFiles.sshPrivateKey) {
+      files.sshPrivateKey = sshFiles.sshPrivateKey;
+    }
 
-    if (data.ssl && sslCerts.sslCa) {
+    if ((data.ssl && sslCerts.sslCa) || (data.useSsh && sshFiles.sshPrivateKey)) {
       response = await dispatch(testRequestWithFiles({
         team_id: params.teamId,
         connection: data,
-        files: sslCerts
+        files
       }));
     } else {
       response = await dispatch(testRequest({ team_id: params.teamId, connection: data }));
@@ -136,6 +150,28 @@ function MysqlConnectionForm(props) {
       }, 100);
       return;
     }
+    
+    // Validate SSH tunnel settings if enabled
+    if (connection.useSsh) {
+      if (!connection.sshHost) {
+        setTimeout(() => {
+          setErrors({ ...errors, sshHost: "Please enter the SSH host" });
+        }, 100);
+        return;
+      }
+      if (!connection.sshUsername) {
+        setTimeout(() => {
+          setErrors({ ...errors, sshUsername: "Please enter the SSH username" });
+        }, 100);
+        return;
+      }
+      if (!connection.sshPassword && !sshFiles.sshPrivateKey) {
+        setTimeout(() => {
+          setErrors({ ...errors, sshPassword: "Please provide either a password or a private key" });
+        }, 100);
+        return;
+      }
+    }
 
     const newConnection = connection;
     // Clean the connection string if the form style is Form
@@ -152,7 +188,16 @@ function MysqlConnectionForm(props) {
           .catch(() => setTestLoading(false));
       } else {
         setLoading(true);
-        onComplete(newConnection, sslCerts)
+        
+        const files = {
+          ...sslCerts
+        };
+        
+        if (connection.useSsh && sshFiles.sshPrivateKey) {
+          files.sshPrivateKey = sshFiles.sshPrivateKey;
+        }
+        
+        onComplete(newConnection, files)
           .then(() => setLoading(false))
           .catch(() => setLoading(false));
       }
@@ -205,6 +250,22 @@ function MysqlConnectionForm(props) {
       return;
     }
     setSslCerts({ ...sslCerts, sslKey: file });
+  };
+
+  const _selectSshPrivateKey = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    
+    // Reset errors
+    setSshFilesErrors({ ...sshFilesErrors, sshPrivateKey: null });
+    
+    // Validate file size (32KB max for SSH keys)
+    if (file.size > 32768) {
+      setSshFilesErrors({ ...sshFilesErrors, sshPrivateKey: "File size is too large. Max size is 32KB" });
+      return;
+    }
+    
+    setSshFiles({ ...sshFiles, sshPrivateKey: file });
   };
 
   const _onChangeSSL = (checked) => {
@@ -501,6 +562,178 @@ function MysqlConnectionForm(props) {
                 {"Certificates are accepted in .crt, .pem, and .key formats"}
               </span>
             </Row>
+          </>
+        )}
+
+        <Spacer y={4} />
+        <Row align="center">
+          <Switch
+            label="SSH Tunnel"
+            isSelected={connection.useSsh || false}
+            checked={connection.useSsh || false}
+            onChange={(e) => setConnection({ ...connection, useSsh: e.target.checked })}
+            size="sm"
+          >
+            <div className="flex items-center gap-2">
+              {"Use SSH Tunnel"}
+              <Chip color="secondary" size="sm" radius="sm" variant="flat">{"New!"}</Chip>
+            </div>
+          </Switch>
+        </Row>
+        {connection.useSsh && (
+          <>
+            <Spacer y={2} />
+            <div className="grid grid-cols-12 gap-2">
+              <div className="sm:col-span-12 md:col-span-8">
+                <Input
+                  label="SSH Host"
+                  placeholder="ssh.example.com"
+                  value={connection.sshHost || ""}
+                  onChange={(e) => {
+                    setConnection({ ...connection, sshHost: e.target.value });
+                  }}
+                  color={errors.sshHost ? "danger" : "default"}
+                  description={errors.sshHost}
+                  variant="bordered"
+                  fullWidth
+                />
+              </div>
+              <div className="sm:col-span-12 md:col-span-4">
+                <Input
+                  label="SSH Port"
+                  placeholder="22"
+                  value={connection.sshPort || ""}
+                  onChange={(e) => {
+                    setConnection({ ...connection, sshPort: e.target.value });
+                  }}
+                  variant="bordered"
+                  fullWidth
+                />
+              </div>
+              <div className="sm:col-span-12 md:col-span-6">
+                <Input
+                  label="SSH Username"
+                  placeholder="username"
+                  value={connection.sshUsername || ""}
+                  onChange={(e) => {
+                    setConnection({ ...connection, sshUsername: e.target.value });
+                  }}
+                  color={errors.sshUsername ? "danger" : "default"}
+                  description={errors.sshUsername}
+                  variant="bordered"
+                  fullWidth
+                />
+              </div>
+              <div className="sm:col-span-12 md:col-span-6">
+                <Input
+                  type="password"
+                  label="SSH Password"
+                  placeholder="Leave empty if using private key"
+                  value={connection.sshPassword || ""}
+                  onChange={(e) => {
+                    setConnection({ ...connection, sshPassword: e.target.value });
+                  }}
+                  color={errors.sshPassword ? "danger" : "default"}
+                  description={errors.sshPassword}
+                  variant="bordered"
+                  fullWidth
+                />
+              </div>
+            </div>
+            <Spacer y={2} />
+            <Row align="center">
+              <input
+                type="file"
+                id="sshPrivateKeyInput"
+                style={{ display: "none" }}
+                onChange={_selectSshPrivateKey}
+              />
+              <Button
+                variant="ghost"
+                startContent={<LuUpload />}
+                onClick={() => document.getElementById("sshPrivateKeyInput").click()}
+              >
+                {"SSH Private Key"}
+              </Button>
+              <Spacer x={2} />
+              {sshFiles.sshPrivateKey && (
+                <span className="text-sm">{sshFiles.sshPrivateKey.name}</span>
+              )}
+              {sshFilesErrors.sshPrivateKey && (
+                <span className="text-sm text-danger">
+                  {sshFilesErrors.sshPrivateKey}
+                </span>
+              )}
+              {!sshFilesErrors.sshPrivateKey && connection.sshPrivateKey && (
+                <LuCircleCheck className="text-success" size={20} />
+              )}
+            </Row>
+            <Spacer y={2} />
+            <Row align="center">
+              <Input
+                type="password"
+                label="Private Key Passphrase"
+                placeholder="Leave empty if not needed"
+                value={connection.sshPassphrase || ""}
+                onChange={(e) => {
+                  setConnection({ ...connection, sshPassphrase: e.target.value });
+                }}
+                variant="bordered"
+                className="w-full md:w-1/2"
+              />
+            </Row>
+            <Spacer y={2} />
+            <div className="grid grid-cols-12 gap-2">
+              <div className="sm:col-span-12 md:col-span-8">
+                <Input
+                  label="Jump Host (Bastion Server)"
+                  placeholder="bastion.example.com (optional)"
+                  value={connection.sshJumpHost || ""}
+                  onChange={(e) => {
+                    setConnection({ ...connection, sshJumpHost: e.target.value });
+                  }}
+                  variant="bordered"
+                  fullWidth
+                />
+              </div>
+              <div className="sm:col-span-12 md:col-span-4">
+                <Input
+                  label="Jump Host Port"
+                  placeholder="22"
+                  value={connection.sshJumpPort || ""}
+                  onChange={(e) => {
+                    setConnection({ ...connection, sshJumpPort: e.target.value });
+                  }}
+                  variant="bordered"
+                  fullWidth
+                />
+              </div>
+            </div>
+            <Spacer y={2} />
+            <div>
+              <Alert
+                title="Something not working?"
+                color="default"
+                variant="flat"
+              >
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm">
+                    {"SSH tunneling is a new feature and some things might not work as expected. If you're having trouble, please contact support."}
+                  </span>
+                  <div>
+                    <Button
+                      variant="bordered"
+                      size="sm"
+                      as={"a"}
+                      href="mailto:support@chartbrew.com"
+                      target="_blank"
+                    >
+                      {"Contact support"}
+                    </Button>
+                  </div>
+                </div>
+              </Alert>
+            </div>
           </>
         )}
 

--- a/client/src/slices/connection.js
+++ b/client/src/slices/connection.js
@@ -129,10 +129,21 @@ export const testRequestWithFiles = createAsyncThunk(
     const url = `${API_HOST}/team/${team_id}/connections/${connection.type}/test/files`;
     const formData = new FormData();
     formData.append("connection", JSON.stringify(connection));
-    if (files) {
+    
+    // Add SSL certificate files if they exist
+    if (files.sslCa) {
       formData.append("sslCa", files.sslCa);
+    }
+    if (files.sslCert) {
       formData.append("sslCert", files.sslCert);
+    }
+    if (files.sslKey) {
       formData.append("sslKey", files.sslKey);
+    }
+    
+    // Add SSH private key file if it exists
+    if (files.sshPrivateKey) {
+      formData.append("sshPrivateKey", files.sshPrivateKey);
     }
 
     const headers = new Headers({

--- a/server/api/ConnectionRoute.js
+++ b/server/api/ConnectionRoute.js
@@ -291,7 +291,7 @@ module.exports = (app) => {
     });
 
     // Wait for all files to be encrypted before updating the connection
-    Promise.all(encryptionPromises)
+    return Promise.all(encryptionPromises)
       .then(() => {
         return connectionController.update(req.params.connection_id, files);
       })
@@ -398,7 +398,7 @@ module.exports = (app) => {
     }
 
     // Wait for all files to be encrypted before testing the connection
-    Promise.all(encryptionPromises)
+    return Promise.all(encryptionPromises)
       .then(() => {
         return connectionController.testRequest(connectionParams, { files: req.files });
       })

--- a/server/controllers/ConnectionController.js
+++ b/server/controllers/ConnectionController.js
@@ -243,6 +243,9 @@ class ConnectionController {
       if (connection.sslKey) {
         fs.unlink(connection.sslKey, () => {});
       }
+      if (connection.sshPrivateKey) {
+        fs.unlink(connection.sshPrivateKey, () => {});
+      }
     } catch (e) {
       //
     }
@@ -293,16 +296,20 @@ class ConnectionController {
   testRequest(data, extras) {
     const certificates = {};
     if (extras?.files?.length > 0) {
-      extras.files.forEach((file) => {
-        // Handle SSL certificates
-        if (file.fieldname === "sslCa" || file.fieldname === "sslCert" || file.fieldname === "sslKey") {
-          certificates[file.fieldname] = file.path; // Use the temporary file path for testing
-        }
-        // Handle SSH private key
-        if (file.fieldname === "sshPrivateKey") {
-          certificates.sshPrivateKey = file.path;
-        }
-      });
+      try {
+        extras.files.forEach((file) => {
+          // Handle SSL certificates
+          if (file.fieldname === "sslCa" || file.fieldname === "sslCert" || file.fieldname === "sslKey") {
+            certificates[file.fieldname] = file.path; // Use the temporary file path for testing
+          }
+          // Handle SSH private key
+          if (file.fieldname === "sshPrivateKey") {
+            certificates.sshPrivateKey = file.path;
+          }
+        });
+      } catch (error) {
+        return Promise.reject(new Error(`Error processing certificate files: ${error.message}`));
+      }
     }
 
     let connectionParams = { ...data };

--- a/server/models/migrations/20250225064300-add-ssh-fields-connection.js
+++ b/server/models/migrations/20250225064300-add-ssh-fields-connection.js
@@ -1,0 +1,47 @@
+const Sequelize = require("sequelize");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addColumn("Connection", "useSsh", {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+    });
+    await queryInterface.addColumn("Connection", "sshHost", {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn("Connection", "sshPort", {
+      type: Sequelize.INTEGER,
+    });
+    await queryInterface.addColumn("Connection", "sshUsername", {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn("Connection", "sshPassword", {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn("Connection", "sshPrivateKey", {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn("Connection", "sshPassphrase", {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn("Connection", "sshJumpHost", {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn("Connection", "sshJumpPort", {
+      type: Sequelize.INTEGER,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn("Connection", "useSsh");
+    await queryInterface.removeColumn("Connection", "sshHost");
+    await queryInterface.removeColumn("Connection", "sshPort");
+    await queryInterface.removeColumn("Connection", "sshUsername");
+    await queryInterface.removeColumn("Connection", "sshPassword");
+    await queryInterface.removeColumn("Connection", "sshPrivateKey");
+    await queryInterface.removeColumn("Connection", "sshPassphrase");
+    await queryInterface.removeColumn("Connection", "sshJumpHost");
+    await queryInterface.removeColumn("Connection", "sshJumpPort");
+  },
+};

--- a/server/models/models/connection.js
+++ b/server/models/models/connection.js
@@ -283,6 +283,34 @@ module.exports = (sequelize, DataTypes) => {
         }
       },
     },
+    useSsh: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    sshHost: {
+      type: DataTypes.STRING,
+    },
+    sshPort: {
+      type: DataTypes.INTEGER,
+    },
+    sshUsername: {
+      type: DataTypes.STRING,
+    },
+    sshPassword: {
+      type: DataTypes.STRING,
+    },
+    sshPrivateKey: {
+      type: DataTypes.STRING,
+    },
+    sshPassphrase: {
+      type: DataTypes.STRING,
+    },
+    sshJumpHost: {
+      type: DataTypes.STRING,
+    },
+    sshJumpPort: {
+      type: DataTypes.INTEGER,
+    },
   }, {
     freezeTableName: true,
   });

--- a/server/modules/externalDbConnection.js
+++ b/server/modules/externalDbConnection.js
@@ -1,7 +1,67 @@
 const Sequelize = require("sequelize");
 const fs = require("fs");
+const { createTunnel } = require("tunnel-ssh");
 
-module.exports = (connection) => {
+// Create SSH tunnel function
+const createSshTunnel = async (sshConfig, dbConfig) => {
+  const tunnelOptions = {
+    autoClose: true,
+    keepAlive: true,
+    debug: true
+  };
+
+  const serverOptions = {
+    host: "127.0.0.1",
+    port: 0 // Let OS assign a local port dynamically
+  };
+
+  const sshOptions = {
+    host: sshConfig.host,
+    port: sshConfig.port || 22,
+    username: sshConfig.username
+  };
+
+  if (sshConfig.privateKey) {
+    sshOptions.privateKey = fs.readFileSync(sshConfig.privateKey);
+    if (sshConfig.passphrase) {
+      sshOptions.passphrase = sshConfig.passphrase;
+    }
+  } else if (sshConfig.password) {
+    sshOptions.password = sshConfig.password;
+  }
+
+  const forwardOptions = {
+    dstAddr: dbConfig.host, // Remote DB host
+    dstPort: dbConfig.port, // Remote DB port (from user settings)
+    srcAddr: "127.0.0.1", // Local forwarded address
+    srcPort: 0 // OS will assign a free port dynamically
+  };
+
+  try {
+    const [server] = await createTunnel(
+      tunnelOptions,
+      serverOptions,
+      sshOptions,
+      forwardOptions
+    );
+
+    server.on("error", (err) => {
+      throw err;
+    });
+
+    const assignedPort = server.address().port;
+
+    return {
+      server,
+      port: assignedPort // The port we must use in Sequelize
+    };
+  } catch (error) {
+    console.error("SSH tunnel error:", error); // eslint-disable-line no-console
+    throw error;
+  }
+};
+
+module.exports = async (connection) => {
   const name = connection.dbName;
   const username = connection.username || "";
   const password = connection.password || "";
@@ -10,6 +70,7 @@ module.exports = (connection) => {
   const dialect = connection.type;
 
   let sequelize;
+  let sshTunnel = null;
 
   const connectionConfig = {
     host,
@@ -74,6 +135,33 @@ module.exports = (connection) => {
     }
   }
 
+  // Setup SSH tunnel if enabled
+  if (connection.useSsh) {
+    try {
+      const sshConfig = {
+        host: connection.sshHost,
+        port: parseInt(connection.sshPort, 10) || 22,
+        username: connection.sshUsername,
+        password: connection.sshPassword,
+        privateKey: connection.sshPrivateKey,
+        passphrase: connection.sshPassphrase,
+        jumpHost: connection.sshJumpHost,
+        jumpPort: connection.sshJumpPort
+      };
+
+      const dbConfig = {
+        host,
+        port
+      };
+
+      // Create SSH tunnel
+      sshTunnel = await createSshTunnel(sshConfig, dbConfig);
+    } catch (error) {
+      console.error("Failed to establish SSH tunnel:", error); // eslint-disable-line no-console
+      throw new Error(`SSH tunnel error: ${error.message}`);
+    }
+  }
+
   if (connectionString) {
     // extract each element from the string so that we can encode the password
     // this is needed when the password contains symbols that are not URI-friendly
@@ -116,15 +204,24 @@ module.exports = (connection) => {
         ssl: sslOptions,
       };
     }
+
     sequelize = new Sequelize(name, username, password, connectionConfig);
   }
 
-  return sequelize
-    .authenticate()
-    .then(() => {
-      return new Promise((resolve) => resolve(sequelize));
-    })
-    .catch((err) => {
-      return new Promise((resolve, reject) => reject(err));
-    });
+  try {
+    await sequelize.authenticate();
+
+    // Add the SSH tunnel to the sequelize instance so we can close it later
+    if (sshTunnel) {
+      sequelize.sshTunnel = sshTunnel.server;
+    }
+
+    return sequelize;
+  } catch (err) {
+    // Close SSH tunnel if it exists
+    if (sshTunnel && sshTunnel.server) {
+      sshTunnel.server.close();
+    }
+    throw err;
+  }
 };

--- a/server/modules/fileEncryption.js
+++ b/server/modules/fileEncryption.js
@@ -1,0 +1,86 @@
+const fs = require("fs").promises;
+const fsSync = require("fs");
+
+const { encrypt, decrypt } = require("./cbCrypto");
+
+/**
+ * Encrypts a file and replaces the original with the encrypted version
+ * @param {string} filePath - Path to the file to encrypt
+ * @returns {Promise<string>} - Path to the encrypted file
+ */
+async function encryptFile(filePath) {
+  try {
+    // Read the file
+    const fileContent = await fs.readFile(filePath);
+
+    // Encrypt the content
+    const encryptedContent = encrypt(fileContent.toString("base64"));
+
+    // Write the encrypted content back to the file
+    await fs.writeFile(filePath, encryptedContent);
+
+    return filePath;
+  } catch (error) {
+    console.error(`Error encrypting file ${filePath}:`, error); // eslint-disable-line no-console
+    throw error;
+  }
+}
+
+/**
+ * Decrypts a file and returns the content
+ * Handles both encrypted and unencrypted (legacy) files
+ * @param {string} filePath - Path to the file
+ * @returns {Promise<Buffer>} - Decrypted file content as a Buffer
+ */
+async function decryptFile(filePath) {
+  try {
+    // Read the file
+    const fileContent = await fs.readFile(filePath, "utf8");
+
+    try {
+      // Try to decrypt assuming it's encrypted
+      const decryptedContent = decrypt(fileContent);
+      return Buffer.from(decryptedContent, "base64");
+    } catch (decryptError) {
+      // If decryption fails, assume it's an unencrypted legacy file
+      // and return the content directly as a buffer
+      return Buffer.from(fileContent);
+    }
+  } catch (error) {
+    console.error(`Error reading/decrypting file ${filePath}:`, error); // eslint-disable-line no-console
+    throw error;
+  }
+}
+
+/**
+ * Synchronously decrypts a file and returns the content
+ * Handles both encrypted and unencrypted (legacy) files
+ * For use in places where async/await cannot be used
+ * @param {string} filePath - Path to the file
+ * @returns {Buffer} - Decrypted file content as a Buffer
+ */
+function decryptFileSync(filePath) {
+  try {
+    // Read the file
+    const fileContent = fsSync.readFileSync(filePath, "utf8");
+
+    try {
+      // Try to decrypt assuming it's encrypted
+      const decryptedContent = decrypt(fileContent);
+      return Buffer.from(decryptedContent, "base64");
+    } catch (decryptError) {
+      // If decryption fails, assume it's an unencrypted legacy file
+      // and return the content directly as a buffer
+      return Buffer.from(fileContent);
+    }
+  } catch (error) {
+    console.error(`Error reading/decrypting file ${filePath}:`, error); // eslint-disable-line no-console
+    throw error;
+  }
+}
+
+module.exports = {
+  encryptFile,
+  decryptFile,
+  decryptFileSync
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "server",
-  "version": "v3.11.1",
+  "version": "v3.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "server",
-      "version": "v3.11.1",
+      "version": "v3.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -59,6 +59,8 @@
         "request-promise": "^4.2.6",
         "sequelize": "^6.3.5",
         "simplecrypt": "^0.1.0",
+        "ssh2": "^1.16.0",
+        "tunnel-ssh": "^5.2.0",
         "umzug": "^3.7.0",
         "uninstall": "*",
         "uuid": "^9.0.1"
@@ -2056,6 +2058,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bullmq": {
       "version": "5.41.5",
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.41.5.tgz",
@@ -2447,6 +2458,20 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/cron-parser": {
@@ -5831,6 +5856,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.1.tgz",
+      "integrity": "sha512-pfRR4ZcNTSm2ZFHaztuvbICf+hyiG6ecA06SfAxoPmuHjvMu0KUIae7Y8GyVkbBqeEIidsmXeYooWIX9+qjfRQ==",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -7681,6 +7712,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.20.0"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -8049,6 +8097,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-ssh": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-5.2.0.tgz",
+      "integrity": "sha512-IGiyhE2RSt3NVvZ7aKH3ykziAxKNPe/z97Rab/lrIXslif/cq7J/m6EXfERlDITiFyGGYMqqi5SSrt/mk1VbEg==",
+      "dependencies": {
+        "ssh2": "^1.15.0"
       }
     },
     "node_modules/tweetnacl": {

--- a/server/package.json
+++ b/server/package.json
@@ -66,6 +66,8 @@
     "request": "^2.88.2",
     "request-promise": "^4.2.6",
     "sequelize": "^6.3.5",
+    "ssh2": "^1.16.0",
+    "tunnel-ssh": "^5.2.0",
     "simplecrypt": "^0.1.0",
     "umzug": "^3.7.0",
     "uninstall": "*",


### PR DESCRIPTION
Connections like Postgres, Mysql, Supabase, Amazon RDS, and TimescaleDB support connections through SSH tunnels.

Also added a module to encrypt and decrypt certificate files.

![CleanShot 2025-02-26 at 12 24 19@2x](https://github.com/user-attachments/assets/d2c4b014-f4e3-4e84-812c-2434c618a703)

When connecting the Users can now:
* Enable SSH tunnel
* Configure: `SSH Host`, `SSH Port`, `SSH username`, `SSH password`, `SSH private key`, `Private key passphrase`, `Jump Host`, `Jump port`