### PR TITLE
:sparkles: added the option to dash the last point in line charts

### DIFF
--- a/client/src/containers/AddChart/AddChart.jsx
+++ b/client/src/containers/AddChart/AddChart.jsx
@@ -149,7 +149,7 @@ function AddChart() {
   const _onChangeGlobalSettings = ({
     pointRadius, displayLegend, dateRange, includeZeros, timeInterval, currentEndDate,
     fixedStartDate, maxValue, minValue, xLabelTicks, stacked, horizontal, dataLabels,
-    dateVarsFormat, isLogarithmic,
+    dateVarsFormat, isLogarithmic, dashedLastPoint,
   }) => {
     const tempChart = {
       pointRadius: typeof pointRadius !== "undefined" ? pointRadius : newChart.pointRadius,
@@ -170,6 +170,7 @@ function AddChart() {
       dataLabels: typeof dataLabels !== "undefined" ? dataLabels : newChart.dataLabels,
       dateVarsFormat: dateVarsFormat !== "undefined" ? dateVarsFormat : newChart.dateVarsFormat,
       isLogarithmic: typeof isLogarithmic !== "undefined" ? isLogarithmic : newChart.isLogarithmic,
+      dashedLastPoint: typeof dashedLastPoint !== "undefined" ? dashedLastPoint : newChart.dashedLastPoint,
     };
 
     let skipParsing = false;
@@ -180,6 +181,7 @@ function AddChart() {
       || xLabelTicks
       || stacked
       || horizontal
+      || dashedLastPoint
     ) {
       skipParsing = true;
     }

--- a/client/src/containers/AddChart/components/ChartSettings.jsx
+++ b/client/src/containers/AddChart/components/ChartSettings.jsx
@@ -444,6 +444,17 @@ function ChartSettings({ chart, onChange, onComplete }) {
             </Checkbox>
           </div>
         )}
+        {chart.type === "line" && (
+          <div>
+            <Checkbox
+              isSelected={chart.dashedLastPoint}
+              onValueChange={(selected) => onChange({ dashedLastPoint: selected })}
+              size="sm"
+            >
+              Dashed last point
+            </Checkbox>
+          </div>
+        )}
       </div>
 
       <Spacer y={4} />

--- a/client/src/containers/Chart/components/LineChart.jsx
+++ b/client/src/containers/Chart/components/LineChart.jsx
@@ -141,6 +141,25 @@ function LineChart(props) {
     };
   }, []);
 
+  const getChartData = () => {
+    if (!chart.chartData?.data) return null;
+
+    const newData = cloneDeep(chart.chartData.data);
+    if (chart.dashedLastPoint) {
+      newData.datasets = newData.datasets.map(dataset => ({
+        ...dataset,
+        segment: {
+          borderDash: (ctx) => {
+            const dataLength = dataset.data?.length || 0;
+            if (dataLength === 0) return [];
+            return ctx.p1DataIndex === dataLength - 1 ? [5, 5] : [];
+          }
+        }
+      }));
+    }
+    return newData;
+  };
+
   return (
     <>
       {chart.chartData && chart.chartData.data && (
@@ -152,7 +171,7 @@ function LineChart(props) {
             <div className={chart.mode !== "kpichart" ? "h-full" : "h-full pb-[50px]"}>
               <ChartErrorBoundary>
                 <Line
-                  data={chart.chartData.data}
+                  data={getChartData()}
                   options={{
                     ..._getChartOptions(),
                     plugins: {

--- a/server/models/migrations/20250304150657-add-dashedlastpoint-chart.js
+++ b/server/models/migrations/20250304150657-add-dashedlastpoint-chart.js
@@ -1,0 +1,16 @@
+const Sequelize = require("sequelize");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addColumn("Chart", "dashedLastPoint", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn("Chart", "dashedLastPoint");
+  },
+};

--- a/server/models/models/chart.js
+++ b/server/models/models/chart.js
@@ -200,6 +200,10 @@ module.exports = (sequelize, DataTypes) => {
         }
       },
     },
+    dashedLastPoint: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
   }, {
     freezeTableName: true,
   });


### PR DESCRIPTION
Added a new chart setting for users to dash the last point in the line chart. Perfect for time series chart to show that the value is either forecasted or incomplete.