### PR TITLE
Move the visualization layer from Dataset to ChartDatasetConfigs

### DIFF
--- a/client/src/components/DatasetFilters.jsx
+++ b/client/src/components/DatasetFilters.jsx
@@ -236,11 +236,10 @@ function DatasetFilters(props) {
       {conditions && conditions.length === 0 && (
         <div className="datasetdata-filters-tut">
           <Button
-            variant="bordered"
             startContent={<LuListFilter />}
-            onClick={_onAddCondition}
-            auto
-            size={"sm"}
+            onPress={_onAddCondition}
+            variant="flat"
+            size="sm"
           >
             Add data filters
           </Button>
@@ -250,13 +249,12 @@ function DatasetFilters(props) {
         return (
           <Card key={condition.id} className="datasetdata-filters-tut shadow-none border-1 border-content3 border-solid rounded-lg">
             <CardHeader>
-              {index === 0 && (<Text>{"where "}</Text>)}
-              {index > 0 && (<Text>{"and "}</Text>)}
+              {index === 0 && (<div className="text-sm">{"where "}</div>)}
+              {index > 0 && (<div className="text-sm">{"and "}</div>)}
             </CardHeader>
             <Divider />
             <CardBody>
               <Autocomplete
-                variant="bordered"
                 placeholder="Field"
                 selectedKey={condition.field}
                 onSelectionChange={(key) => _updateCondition(condition.id, key, "field")}
@@ -288,7 +286,6 @@ function DatasetFilters(props) {
                         )
                         || "="
                       }
-                      variant="bordered"
                       labelPlacement="outside"
                       className="max-w-[100px]"
                       size="sm"
@@ -316,7 +313,6 @@ function DatasetFilters(props) {
                         onChange={(e) => _updateCondition(condition.id, e.target.value, "value", find(fieldOptions, { value: condition.field }))}
                         disabled={(condition.operator === "isNotNull" || condition.operator === "isNull")}
                         labelPlacement="outside"
-                        variant="bordered"
                         size="sm"
                         fullWidth
                       />
@@ -326,7 +322,6 @@ function DatasetFilters(props) {
                     && find(fieldOptions, { value: condition.field }).type === "date" && (
                       <I18nProvider locale="en-GB">
                         <DatePicker
-                          variant="bordered"
                           showMonthAndYearPickers
                           value={(
                             condition.value

--- a/client/src/components/FormulaTips.jsx
+++ b/client/src/components/FormulaTips.jsx
@@ -2,77 +2,65 @@ import React from "react"
 import { Code, Spacer } from "@heroui/react";
 import { LuChevronRight, LuExternalLink } from "react-icons/lu";
 
-import Text from "./Text";
-import Row from "./Row";
-
 function FormulaTips() {
   return (
     <div className={"p-4"}>
-      <Row>
-        <Text b>{"Formulas allow you to manipulate your final Metric results"}</Text>
-      </Row>
+      <div className="font-bold">{"Formulas allow you to manipulate your final Metric results"}</div>
       <Spacer y={1} />
-      <Row className={"items-center"}>
-        <Text>{"Example for"}</Text>
-        <Spacer x={0.5} />
+      <div className="flex items-center gap-2">
+        <div className="text-sm text-foreground">{"Example for"}</div>
         <Code>{"val = 12345"}</Code>
-      </Row>
+      </div>
       <Spacer y={1} />
-      <Row align="center">
+      <div className="flex items-center gap-2">
         <LuChevronRight />
-        <Spacer x={0.5} />
-        <Text>
+        <span>
           <Code>{"{val}"}</Code>
           {" => 12345"}
-        </Text>
-      </Row>
+        </span>
+      </div>
       <Spacer y={1} />
-      <Row align="center">
+      <div className="flex items-center gap-2">
         <LuChevronRight />
-        <Spacer x={0.5} />
-        <Text>
+        <span>
           <Code>{"{val / 100}"}</Code>
           {" => 123.45"}
-        </Text>
-      </Row>
+        </span>
+      </div>
       <Spacer y={1} />
-      <Row align="center">
+      <div className="flex items-center gap-2">
         <LuChevronRight />
-        <Spacer x={0.5} />
-        <Text>
+        <span>
           <Code>{"$ {val / 100}"}</Code>
           {" => $ 123.45"}
-        </Text>
-      </Row>
+        </span>
+      </div>
       <Spacer y={1} />
-      <Row align="center">
+      <div className="flex items-center gap-2">
         <LuChevronRight />
-        <Spacer x={0.5} />
-        <Text>
+        <span>
           <Code>{"{val / 100} USD"}</Code>
           {" => 123.45 USD"}
-        </Text>
-      </Row>
+        </span>
+      </div>
       <Spacer y={1} />
-      <Row align="center">
+      <div className="flex items-center gap-2">
         <LuChevronRight />
-        <Spacer x={0.5} />
-        <Text>
+        <span>
           <Code>{"{ROUND(val / 100, 0)}"}</Code>
           {" => 123"}
-        </Text>
-      </Row>
+        </span>
+      </div>
       <Spacer y={2} />
-      <Row align="center">
+      <div className="flex items-center gap-2">
         <div>
           {"For a full list of formulas, "}
-          <a href="https://github.com/handsontable/formula-parser/blob/develop/src/supported-formulas.js">
+          <a href="https://github.com/handsontable/formula-parser/blob/develop/src/supported-formulas.js" rel="noopener noreferrer" target="_blank">
             {"visit this page"}
           </a>
         </div>
-        <Spacer x={0.5} />
         <LuExternalLink size={16} />
-      </Row>
+      </div>
     </div>
   );
 }

--- a/client/src/components/InviteMembersForm.jsx
+++ b/client/src/components/InviteMembersForm.jsx
@@ -113,7 +113,7 @@ function InviteMembersForm(props) {
               </Radio>
               <Radio
                 value="projectEditor"
-                description={"Can view and edit all charts and reports in the selected dashboard. Can also edit tagged datasets but cannot edit data queries."}
+                description={"Can view and edit all charts and reports in the selected dashboard. Cannot view or edit any dataset queries."}
               >
                 Client Editor
               </Radio>

--- a/client/src/components/TopNav.jsx
+++ b/client/src/components/TopNav.jsx
@@ -12,6 +12,7 @@ import { selectTeam } from "../slices/team";
 import { selectProject } from "../slices/project";
 import { selectChart } from "../slices/chart";
 import { selectIntegrations } from "../slices/integration";
+import getDatasetDisplayName from "../modules/getDatasetDisplayName";
 
 function TopNav() {
   const dispatch = useDispatch();
@@ -148,8 +149,8 @@ function TopNav() {
               <BreadcrumbItem onPress={() => navigate("/datasets")}>
                 Datasets
               </BreadcrumbItem>
-              {dataset?.legend && (
-                <BreadcrumbItem isCurrent={true}>{dataset?.legend}</BreadcrumbItem>
+              {getDatasetDisplayName(dataset) && (
+                <BreadcrumbItem isCurrent={true}>{getDatasetDisplayName(dataset)}</BreadcrumbItem>
               )}
               {params.datasetId === "new" && (
                 <BreadcrumbItem isCurrent={true}>New dataset</BreadcrumbItem>

--- a/client/src/containers/AddChart/AddChart.jsx
+++ b/client/src/containers/AddChart/AddChart.jsx
@@ -15,8 +15,6 @@ import {
   createChart, createCdc, updateChart, runQuery, runQueryWithFilters, selectCharts,
 } from "../../slices/chart";
 import { getChartAlerts, clearAlerts } from "../../slices/alert";
-import Row from "../../components/Row";
-import Text from "../../components/Text";
 import ChartDatasets from "./components/ChartDatasets";
 import getDashboardLayout from "../../modules/getDashboardLayout";
 import { selectDatasetsNoDrafts } from "../../slices/dataset";
@@ -443,18 +441,22 @@ function AddChart() {
   return (
     <div className="flex flex-col">
       <div className="grid grid-cols-12 gap-4">
+        <div className="col-span-12 md:col-span-5 add-dataset-tut">
+          <div className={"bg-content1 rounded-lg mx-auto p-4 w-full border-1 border-solid border-divider"}>
+            <ChartDatasets chartId={newChart.id} />
+          </div>
+        </div>
         <div className="col-span-12 md:col-span-7">
-          <Row align="center" wrap="wrap" justify="space-between">
-            <Row className="chart-name-tut">
+          <div className="flex items-center justify-between flex-wrap gap-2 py-4 px-4 border-1 border-divider bg-content1 rounded-lg">
+            <div className="flex items-center gap-2">
               {!editingTitle
                 && (
                   <Tooltip content="Edit the chart name">
-                    <LinkNext onPress={() => setEditingTitle(true)} className="flex items-center" color="foreground">
-                      <LuPencilLine className="text-primary" />
-                      <Spacer x={0.5} />
-                      <Text b>
+                    <LinkNext onPress={() => setEditingTitle(true)} className="flex items-center gap-2 cursor-pointer" color="foreground">
+                      <div className="text-lg font-bold text-foreground">
                         {newChart.name}
-                      </Text>
+                      </div>
+                      <LuPencilLine size={18} className="text-foreground-500" />
                     </LinkNext>
                   </Tooltip>
                 )}
@@ -464,43 +466,40 @@ function AddChart() {
                   e.preventDefault();
                   _onSubmitNewName();
                 }}>
-                  <div style={{ display: "flex", alignItems: "center" }}>
+                  <div className="flex items-center gap-2">
                     <Input
                       placeholder="Enter a title"
                       value={chartName}
                       onChange={(e) => _onNameChange(e.target.value)}
-                      variant="bordered"
                       labelPlacement="outside"
+                      size="sm"
                     />
-                    <Spacer x={0.5} />
                     <Button
-                      color="success"
+                      color="primary"
                       type="submit"
-                      onClick={_onSubmitNewName}
+                      onPress={_onSubmitNewName}
                       size="sm"
                       isIconOnly
 
                     >
-                      <LuCheck />
+                      <LuCheck size={16} />
                     </Button>
                   </div>
                 </form>
               )}
-            </Row>
-            <Row className="chart-actions-tut" align="center" justify="flex-end">
-              <div style={{ display: "flex" }}>
+            </div>
+            <div className="flex items-center justify-end gap-4">
+              <div className="flex items-center gap-2">
+                <div className="text-sm text-foreground">Draft</div>
                 <Switch
                   isSelected={newChart.draft}
                   onChange={() => _onChangeChart({ draft: !newChart.draft })}
                   size="sm"
                 />
-                <Spacer x={0.5} />
-                <Text>Draft</Text>
               </div>
-              <Spacer x={4} />
               <Button
                 color={saveRequired ? "primary" : "success"}
-                onClick={() => _onChangeChart({})}
+                onPress={() => _onChangeChart({})}
                 isLoading={loading}
                 size="sm"
                 variant={saveRequired ? "solid" : "flat"}
@@ -508,10 +507,10 @@ function AddChart() {
                 {saveRequired && "Save chart"}
                 {!saveRequired && "Chart saved"}
               </Button>
-            </Row>
-          </Row>
+            </div>
+          </div>
           <Spacer y={2} />
-          <Row className="chart-type-tut bg-content1 rounded-lg border-1 border-solid border-content3">
+          <div className="bg-content1 rounded-lg border-1 border-solid border-divider">
             <ChartPreview
               chart={newChart}
               onChange={_onChangeChart}
@@ -523,9 +522,9 @@ function AddChart() {
               useCache={useCache}
               changeCache={() => setUseCache(!useCache)}
             />
-          </Row>
+          </div>
           <Spacer y={4} />
-          <Row className="bg-content1 rounded-lg border-1 border-solid border-content3">
+          <div className="bg-content1 rounded-lg border-1 border-solid border-divider">
             {params.chartId && newChart.type && newChart.ChartDatasetConfigs?.length > 0 && (
               <ChartSettings
                 chart={newChart}
@@ -533,12 +532,6 @@ function AddChart() {
                 onComplete={(skipParsing = false) => _onRefreshPreview(skipParsing)}
               />
             )}
-          </Row>
-        </div>
-
-        <div className="col-span-12 md:col-span-5 add-dataset-tut">
-          <div className={"bg-content1 rounded-lg mx-auto p-4 w-full border-1 border-solid border-content3"}>
-            <ChartDatasets chartId={newChart.id} />
           </div>
         </div>
       </div>

--- a/client/src/containers/AddChart/AddChart.jsx
+++ b/client/src/containers/AddChart/AddChart.jsx
@@ -22,6 +22,7 @@ import getDashboardLayout from "../../modules/getDashboardLayout";
 import { selectDatasetsNoDrafts } from "../../slices/dataset";
 import { placeNewWidget } from "../../modules/autoLayout";
 import { chartColors } from "../../config/colors";
+import getDatasetDisplayName from "../../modules/getDatasetDisplayName";
 
 const AUTO_NAME_PENDING_STORAGE_KEY = "__cb_pending_chart_dataset_name";
 const AUTO_NAME_PLACEHOLDER = "__cb_auto_name_chart__";
@@ -155,13 +156,15 @@ function AddChart() {
     setCreatingDatasetId(dataset.id);
 
     try {
-      const chart = await _createChart(dataset.legend);
+      const datasetName = getDatasetDisplayName(dataset) || "Untitled dataset";
+      const chart = await _createChart(datasetName);
 
       await dispatch(createCdc({
         project_id: chart.project_id,
         chart_id: chart.id,
         data: {
           dataset_id: dataset.id,
+          legend: datasetName,
           datasetColor: chartColors.blue.hex,
           fill: false,
           order: 0,

--- a/client/src/containers/AddChart/components/ChartDatasetConfig.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasetConfig.jsx
@@ -619,13 +619,13 @@ function ChartDatasetConfig(props) {
                   </Link>
                 )}
                 {formula && (
-                  <Row align={"center"} justify={"space-between"}>
+                  <div className="flex flex-col gap-2">
                     <div className="flex flex-col">
                       <Popover>
                         <PopoverTrigger>
-                          <div className="flex flex-row gap-1 items-center">
+                          <div className="flex flex-row gap-1 items-center cursor-pointer">
                             <div className="text-sm">{"Metric formula"}</div>
-                            <LuInfo size={18} />
+                            <LuInfo size={16} />
                           </div>
                         </PopoverTrigger>
                         <PopoverContent>
@@ -662,7 +662,7 @@ function ChartDatasetConfig(props) {
                         </Tooltip>
                       </div>
                     </div>
-                  </Row>
+                  </div>
                 )}
               </div>
 
@@ -681,15 +681,14 @@ function ChartDatasetConfig(props) {
                   </div>
                 )}
                 {goal && (
-                  <Row align={"center"} justify={"space-between"}>
-                    <Row align="center">
+                  <div className="flex flex-col gap-2">
+                    <div className="flex flex-row gap-2 items-center">
                       <div className="text-sm text-foreground">{"Goal"}</div>
-                      <Spacer x={1} />
-                      <Tooltip content="A goal can be displayed as a progress bar in your KPI charts. Enter a number without any other characters. (e.g. 1000 instead of 1k)">
-                        <div><LuInfo size={18} /></div>
+                      <Tooltip className="max-w-sm" content="A goal can be displayed as a progress bar in your KPI charts. Enter a number without any other characters. (e.g. 1000 instead of 1k)">
+                        <div><LuInfo size={16} /></div>
                       </Tooltip>
-                    </Row>
-                    <Row align="center" className={"gap-2"}>
+                    </div>
+                    <div className="flex flex-row gap-2 items-center">
                       <Input
                         placeholder="Enter your goal here"
                         value={goal}
@@ -712,8 +711,8 @@ function ChartDatasetConfig(props) {
                           <LuCircleX className="text-danger" />
                         </Link>
                       </Tooltip>
-                    </Row>
-                  </Row>
+                    </div>
+                  </div>
                 )}
               </div>
             </>

--- a/client/src/containers/AddChart/components/ChartDatasetConfig.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasetConfig.jsx
@@ -4,17 +4,14 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   Avatar,
   Button, Checkbox, Chip, Divider, Input, Link, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Popover, PopoverContent,
-  PopoverTrigger, ScrollShadow, Spacer, Spinner, Tooltip, commonColors,
+  PopoverTrigger, ScrollShadow, Spacer, Spinner, Tab, Tabs, Tooltip, commonColors,
 } from "@heroui/react";
 import { TbMathFunctionY, TbProgressCheck } from "react-icons/tb";
 import { TwitterPicker, SketchPicker } from "react-color";
 import { useNavigate, useParams } from "react-router";
-import { Link as LinkNext } from "react-router";
 import {
-  LuArrowDown01, LuArrowDown10, LuCheck, LuCircleCheck, LuInfo,
-  LuListFilter,
+  LuArrowDown01, LuArrowDown10, LuCircleCheck, LuInfo,
   LuPlug,
-  LuSettings,
   LuWandSparkles, LuCircleX,
   LuVariable,
 } from "react-icons/lu";
@@ -32,6 +29,8 @@ import { selectTeam } from "../../../slices/team";
 import { selectUser } from "../../../slices/user";
 import connectionImages from "../../../config/connectionImages";
 import { useTheme } from "../../../modules/ThemeContext";
+import ChartDatasetDataSetup from "./ChartDatasetDataSetup";
+import getDatasetDisplayName from "../../../modules/getDatasetDisplayName";
 
 function ChartDatasetConfig(props) {
   const { chartId, cdcId, dataRequests, onRemove } = props;
@@ -45,10 +44,15 @@ function ChartDatasetConfig(props) {
   const [editConfirmation, setEditConfirmation] = useState(false);
   const [variables, setVariables] = useState([]);
   const [variableValues, setVariableValues] = useState({});
+  const [activeTab, setActiveTab] = useState("data-setup");
 
   const cdc = useSelector((state) => selectCdc(state, chartId, cdcId));
-  const drs = useSelector((state) => cdc?.dataset_id ? state.dataset.data.find((d) => d.id === parseInt(cdc.dataset_id, 10))?.DataRequests : []);
-
+  const dataset = useSelector((state) => (
+    cdc?.dataset_id
+      ? state.dataset.data.find((d) => d.id === parseInt(cdc.dataset_id, 10))
+      : null
+  ));
+  const drs = dataset?.DataRequests || [];
   const chart = useSelector((state) => state.chart.data.find((c) => c.id === chartId));
   const team = useSelector(selectTeam);
   const user = useSelector(selectUser);
@@ -57,32 +61,21 @@ function ChartDatasetConfig(props) {
   const params = useParams();
   const navigate = useNavigate();
   const { isDark } = useTheme();
-  // removed initVars; variables are initialized per CDC change
 
   useEffect(() => {
-    if (cdc?.formula) {
-      setFormula(cdc.formula);
-    }
-    if (cdc?.legend) {
-      setLegend(cdc.legend);
-    }
-    if (cdc?.maxRecords) {
-      setMaxRecords(cdc.maxRecords);
-    }
-    if (cdc?.goal) {
-      setGoal(cdc.goal);
-    }
-  }, [cdc]);
+    setFormula(cdc?.formula || "");
+    setLegend(cdc?.legend || getDatasetDisplayName(dataset));
+    setMaxRecords(cdc?.maxRecords || "");
+    setGoal(cdc?.goal || "");
+  }, [cdc, dataset]);
 
   useEffect(() => {
-    // Build variables list from the dataset requests, but scope values per CDC
     let tempVariables = [];
     if (drs && Array.isArray(drs)) {
       const variableByName = {};
       drs.forEach((dr) => {
         if (dr?.VariableBindings && Array.isArray(dr.VariableBindings)) {
           dr.VariableBindings.forEach((vb) => {
-            // De-duplicate variables by name, keep the first occurrence
             if (vb?.name && !variableByName[vb.name]) {
               variableByName[vb.name] = vb;
             }
@@ -93,7 +86,6 @@ function ChartDatasetConfig(props) {
     }
     setVariables(tempVariables);
 
-    // Load existing variable values from CDC configuration
     const existingValues = {};
     if (cdc?.configuration?.variables) {
       cdc.configuration.variables.forEach((configVar) => {
@@ -101,7 +93,6 @@ function ChartDatasetConfig(props) {
       });
     }
 
-    // Initialize variable values with existing overrides or default values
     const initialValues = {};
     tempVariables.forEach((variable) => {
       initialValues[variable.name] = existingValues[variable.name] || variable.default_value || "";
@@ -112,12 +103,11 @@ function ChartDatasetConfig(props) {
 
   useEffect(() => {
     let tempDataItems;
-    if (cdc?.id && chart.chartData && chart.chartData.data && chart.chartData.data.datasets) {
-      // find the dataset in the chart data
+    if (cdc?.id && chart?.chartData?.data?.datasets) {
       let foundIndex;
       for (let i = 0; i < chart.ChartDatasetConfigs.length; i++) {
-        const d = chart.ChartDatasetConfigs[i];
-        if (d.id === cdc.id) {
+        const config = chart.ChartDatasetConfigs[i];
+        if (config.id === cdc.id) {
           foundIndex = i;
           break;
         }
@@ -127,7 +117,7 @@ function ChartDatasetConfig(props) {
         tempDataItems = chart.chartData.data.datasets[foundIndex];
         tempDataItems = {
           ...tempDataItems,
-          labels: chart.chartData.data && chart.chartData.data.labels
+          labels: chart.chartData.data.labels,
         };
 
         setDataItems(tempDataItems);
@@ -136,17 +126,16 @@ function ChartDatasetConfig(props) {
   }, [chart, cdc]);
 
   useEffect(() => {
-    // extract the table fields if table view is selected
-    if (cdc?.id && chart.type === "table" && chart.chartData && chart.chartData[cdc.legend]) {
+    if (cdc?.id && chart?.type === "table" && chart?.chartData && chart.chartData[cdc.legend]) {
       const datasetData = chart.chartData[cdc.legend];
-      const flatColumns = flatMap(datasetData.columns, (f) => {
-        if (f.columns) return [f, ...f.columns];
-        return f;
+      const flatColumns = flatMap(datasetData.columns, (field) => {
+        if (field.columns) return [field, ...field.columns];
+        return field;
       });
 
       setTableFields(flatColumns);
     }
-  }, [chart.chartData]);
+  }, [chart?.chartData, chart?.type, cdc?.id, cdc?.legend]);
 
   const _onRunQuery = (skipParsing = true) => {
     dispatch(runQuery({
@@ -155,34 +144,7 @@ function ChartDatasetConfig(props) {
       cdc_id: cdc.id,
       noSource: true,
       skipParsing: chart?.type === "matrix" ? false : skipParsing,
-      getCache: true
-    }));
-  };
-
-  const _onAddFormula = () => {
-    setFormula("{val}");
-  };
-
-  const _onExampleFormula = () => {
-    setFormula("${val / 100}");
-    _onUpdateCdc({ formula: "${val / 100}" });
-  };
-
-  const _onRemoveFormula = () => {
-    setFormula("");
-    _onUpdateCdc({ formula: "" });
-  };
-
-  const _onApplyFormula = () => {
-    _onUpdateCdc({ formula });
-  };
-
-  const _onSaveLegend = () => {
-    dispatch(updateCdc({
-      project_id: params.projectId,
-      chart_id: chartId,
-      cdc_id: cdc.id,
-      data: { legend },
+      getCache: true,
     }));
   };
 
@@ -190,7 +152,21 @@ function ChartDatasetConfig(props) {
     let skipParsing = true;
 
     Object.keys(data).forEach((key) => {
-      if (key === "formula" || key === "sort" || key === "maxRecords" || key === "goal" || key === "configuration" || key === "variables") {
+      if (
+        key === "xAxis"
+        || key === "xAxisOperation"
+        || key === "yAxis"
+        || key === "yAxisOperation"
+        || key === "dateField"
+        || key === "dateFormat"
+        || key === "conditions"
+        || key === "formula"
+        || key === "sort"
+        || key === "maxRecords"
+        || key === "goal"
+        || key === "configuration"
+        || key === "variables"
+      ) {
         skipParsing = false;
       }
     });
@@ -204,6 +180,17 @@ function ChartDatasetConfig(props) {
       .then(() => {
         _onRunQuery(skipParsing);
       });
+  };
+
+  const _onSaveLegend = () => {
+    dispatch(updateCdc({
+      project_id: params.projectId,
+      chart_id: chartId,
+      cdc_id: cdc.id,
+      data: { legend },
+    })).then(() => {
+      _onRunQuery(true);
+    });
   };
 
   const _getDatasetColor = (datasetColor) => ({
@@ -239,15 +226,13 @@ function ChartDatasetConfig(props) {
         newFillColor = [...newFillColor];
       }
 
-      // Replace any null/undefined values with colors
-      newFillColor = newFillColor.map((color, i) => {
+      newFillColor = newFillColor.map((color, index) => {
         if (!color) {
-          return Object.values(chartColors)[i % Object.values(chartColors).length].hex;
+          return Object.values(chartColors)[index % Object.values(chartColors).length].hex;
         }
         return color;
       });
 
-      // Add additional colors if needed
       if (dataItems?.labels && newFillColor.length < dataItems.labels.length) {
         for (let i = newFillColor.length; i < dataItems.labels.length; i++) {
           newFillColor.push(Object.values(chartColors)[i % Object.values(chartColors).length].hex);
@@ -256,7 +241,7 @@ function ChartDatasetConfig(props) {
 
       _onUpdateCdc({ multiFill: true, fillColor: newFillColor });
     } else {
-      const firstValidColor = cdc.fillColor.find(c => c) || Object.values(chartColors)[0].hex;
+      const firstValidColor = cdc.fillColor.find((color) => color) || Object.values(chartColors)[0].hex;
       _onUpdateCdc({ multiFill: false, fillColor: firstValidColor });
     }
   };
@@ -271,7 +256,7 @@ function ChartDatasetConfig(props) {
     }));
 
     await dispatch(runQuery({
-      project_id: params.projectId,
+      project_id: chart.project_id,
       chart_id: chartId,
       noSource: false,
       skipParsing: false,
@@ -283,34 +268,46 @@ function ChartDatasetConfig(props) {
     _onUpdateCdc(data);
   };
 
+  const _onAddFormula = () => {
+    setFormula("{val}");
+  };
+
+  const _onExampleFormula = () => {
+    setFormula("${val / 100}");
+    _onUpdateCdc({ formula: "${val / 100}" });
+  };
+
+  const _onRemoveFormula = () => {
+    setFormula("");
+    _onUpdateCdc({ formula: "" });
+  };
+
+  const _onApplyFormula = () => {
+    _onUpdateCdc({ formula });
+  };
+
   const _onSaveVariableValue = (variableName, value) => {
-    // Get current configuration or initialize empty object
     const currentConfig = cdc.configuration || {};
     const currentVariables = currentConfig.variables || [];
-    
-    // Update or add the variable value
     const updatedVariables = [...currentVariables];
-    const existingIndex = updatedVariables.findIndex(v => v.name === variableName);
-    
+    const existingIndex = updatedVariables.findIndex((variable) => variable.name === variableName);
+
     if (existingIndex >= 0) {
       updatedVariables[existingIndex] = { name: variableName, value };
     } else {
       updatedVariables.push({ name: variableName, value });
     }
-    
-    // Update the configuration
+
     const updatedConfig = {
       ...currentConfig,
-      variables: updatedVariables
+      variables: updatedVariables,
     };
-    
-    // Save to CDC
+
     _onUpdateCdc({ configuration: updatedConfig });
-    
-    // Update local state
-    setVariableValues(prev => ({
+
+    setVariableValues((prev) => ({
       ...prev,
-      [variableName]: value
+      [variableName]: value,
     }));
   };
 
@@ -319,8 +316,7 @@ function ChartDatasetConfig(props) {
   };
 
   const _getVariableOriginalValue = (variable) => {
-    // Check if there's an override in CDC configuration
-    const overrideValue = cdc.configuration?.variables?.find(v => v.name === variable.name)?.value;
+    const overrideValue = cdc.configuration?.variables?.find((item) => item.name === variable.name)?.value;
     return overrideValue !== undefined ? overrideValue : (variable.default_value || "");
   };
 
@@ -331,28 +327,26 @@ function ChartDatasetConfig(props) {
   };
 
   const _onClearVariableOverride = (variableName) => {
-    // Get current configuration
     const currentConfig = cdc.configuration || {};
     const currentVariables = currentConfig.variables || [];
-    
-    // Remove the variable override
-    const updatedVariables = currentVariables.filter(v => v.name !== variableName);
-    
-    // Update the configuration
+    const updatedVariables = currentVariables.filter((variable) => variable.name !== variableName);
+
     const updatedConfig = {
       ...currentConfig,
-      variables: updatedVariables
+      variables: updatedVariables,
     };
-    
-    // Save to CDC
+
     _onUpdateCdc({ configuration: updatedConfig });
-    
-    // Reset local state to default value
-    const variable = variables.find(v => v.name === variableName);
-    setVariableValues(prev => ({
+
+    const variable = variables.find((item) => item.name === variableName);
+    setVariableValues((prev) => ({
       ...prev,
-      [variableName]: variable?.default_value || ""
+      [variableName]: variable?.default_value || "",
     }));
+  };
+
+  const _onEditDataset = () => {
+    setEditConfirmation(true);
   };
 
   if (!cdc?.id) {
@@ -363,416 +357,370 @@ function ChartDatasetConfig(props) {
     );
   }
 
+  const seriesLabel = cdc.legend || getDatasetDisplayName(dataset) || "Untitled series";
+
   return (
     <div>
-      <Row align="center">
-        <Input
-          placeholder="Enter a name for your dataset"
-          label="Dataset name"
-          value={legend}
-          onChange={(e) => setLegend(e.target.value)}
-          variant="bordered"
-        />
-        {legend && legend !== cdc.legend && (
-          <>
-            <Spacer x={2} />
-            <Button
-              isIconOnly
-              color="primary"
-              isLoading={false}
-              size="sm"
-              onPress={_onSaveLegend}
-            >
-              <LuCheck />
-            </Button>
-          </>
-        )}
-      </Row>
+      <Tabs
+        selectedKey={activeTab}
+        onSelectionChange={(key) => setActiveTab(key)}
+        aria-label="Series configuration"
+        fullWidth
+      >
+        <Tab key="data-setup" title="Data setup">
+          <Spacer y={4} />
+          <ChartDatasetDataSetup
+            cdc={cdc}
+            dataset={dataset}
+            chart={chart}
+            teamId={team?.id}
+            legend={legend}
+            onSaveLegend={{
+              onChange: (event) => setLegend(event.target.value),
+              onSave: _onSaveLegend,
+            }}
+            onUpdateCdc={_onUpdateCdc}
+            onEditDataset={_onEditDataset}
+          />
+        </Tab>
 
-      {canAccess("teamAdmin", user.id, team.TeamRoles) && (
-        <>
-          <Spacer y={2} />
-          <div className="flex flex-row justify-between">
-            <Button
-              variant="ghost"
-              size="sm"
-              endContent={<LuSettings size={18} />}
-              onPress={() => setEditConfirmation(true)}
-            >
-              Edit dataset
-            </Button>
+        <Tab key="display" title="Display">
+          <Spacer y={4} />
 
-            <div className="flex flex-row gap-2 items-center">
-              {dataRequests?.map((dr) => (
-                <Tooltip content={dr?.Connection?.name} key={dr.id}>
-                  <Avatar
-                    key={dr.id}
-                    src={connectionImages(isDark)[dr?.Connection?.subType]}
-                    isBordered
-                    size="sm"
-                  />
-                </Tooltip>
-              ))}
-              <div><LuPlug /></div>
-            </div>
-          </div>
-        </>
-      )}
+          {chart.type !== "table" && (
+            <>
+              <div className="chart-cdc-colors">
+                <div className="font-bold">{"Series colors"}</div>
+                <Spacer y={2} />
 
-      <Spacer y={4} />
-      <Divider />
-      <Spacer y={2} />
-
-      {chart.type !== "table" && (
-        <>
-          <div className="chart-cdc-colors">
-            <div className="font-bold">{"Dataset colors"}</div>
-            <Spacer y={2} />
-
-            <div className="flex flex-row justify-between items-center">
-              <div className="text-sm">Primary color</div>
-              <div>
-                <Popover>
-                  <PopoverTrigger>
-                    <Chip
-                      style={_getDatasetColor(cdc.datasetColor)}
-                      size="lg"
-                      radius="sm"
-                      className="pl-[100px]"
-                    />
-                  </PopoverTrigger>
-                  <PopoverContent className="border-none bg-transparent shadow-none">
-                    <TwitterPicker
-                      triangle={"hide"}
-                      color={cdc.datasetColor}
-                      colors={Object.values(chartColors).map((c) => c.hex)}
-                      onChangeComplete={_onChangeDatasetColor}
-                    />
-                  </PopoverContent>
-                </Popover>
-              </div>
-            </div>
-            <Spacer y={2} />
-
-            {chart.type !== "matrix" && (
-              <Row align={"center"} justify={"space-between"}>
-                <Row align={"center"}>
-                  <Checkbox
-                    isSelected={cdc.fill}
-                    onChange={() => _onUpdateCdc({ fill: !cdc.fill, fillColor: ["transparent"] })}
-                    isDisabled={cdc.multiFill}
-                    size="sm"
-                  >
-                    Fill Color
-                  </Checkbox>
-                </Row>
-                {cdc.fill && !cdc.multiFill && (
+                <div className="flex flex-row justify-between items-center">
+                  <div className="text-sm">Primary color</div>
                   <div>
                     <Popover>
                       <PopoverTrigger>
                         <Chip
-                          style={_getDatasetColor(Array.isArray(cdc.fillColor) ? cdc.fillColor[0] : cdc.fillColor)}
+                          style={_getDatasetColor(cdc.datasetColor)}
                           size="lg"
                           radius="sm"
                           className="pl-[100px]"
                         />
                       </PopoverTrigger>
                       <PopoverContent className="border-none bg-transparent shadow-none">
-                        <SketchPicker
-                          color={Array.isArray(cdc.fillColor) ? cdc.fillColor[0] : cdc.fillColor}
-                          presetColors={Object.values(chartColors).map((c) => c.hex)}
-                          onChangeComplete={(color) => _onChangeFillColor(color)}
+                        <TwitterPicker
+                          triangle={"hide"}
+                          color={cdc.datasetColor}
+                          colors={Object.values(chartColors).map((color) => color.hex)}
+                          onChangeComplete={_onChangeDatasetColor}
                         />
                       </PopoverContent>
                     </Popover>
                   </div>
-                )}
-              </Row>
-            )}
-            <Spacer y={2} />
-
-            {chart.type !== "line" && chart.type !== "matrix" && (
-              <Row>
-                <Checkbox
-                  isSelected={cdc.multiFill}
-                  onChange={() => _onChangeMultiFill()}
-                  size="sm"
-                >
-                  Multiple colors
-                </Checkbox>
-              </Row>
-            )}
-
-            {chart.type !== "line" && chart.type !== "matrix" && cdc.multiFill && (
-              <>
+                </div>
                 <Spacer y={2} />
-                <ScrollShadow className="max-h-[300px] border-2 border-solid border-content3 rounded-md p-2">
-                  {dataItems?.labels?.map((label, index) => (
-                    <Row key={label} justify={"space-between"}>
-                      <Text size="sm">{label}</Text>
 
+                {chart.type !== "matrix" && (
+                  <Row align={"center"} justify={"space-between"}>
+                    <Row align={"center"}>
+                      <Checkbox
+                        isSelected={cdc.fill}
+                        onChange={() => _onUpdateCdc({ fill: !cdc.fill, fillColor: ["transparent"] })}
+                        isDisabled={cdc.multiFill}
+                        size="sm"
+                      >
+                        Fill Color
+                      </Checkbox>
+                    </Row>
+                    {cdc.fill && !cdc.multiFill && (
                       <div>
                         <Popover>
                           <PopoverTrigger>
                             <Chip
-                              style={_getDatasetColor(cdc.fillColor[index] || "white")}
+                              style={_getDatasetColor(Array.isArray(cdc.fillColor) ? cdc.fillColor[0] : cdc.fillColor)}
+                              size="lg"
                               radius="sm"
+                              className="pl-[100px]"
                             />
                           </PopoverTrigger>
                           <PopoverContent className="border-none bg-transparent shadow-none">
-                            <TwitterPicker
-                              triangle={"hide"}
-                              color={cdc.fillColor[index] || "white"}
-                              colors={Object.values(chartColors).map((c) => c.hex)}
-                              onChangeComplete={(color) => _onChangeFillColor(color, index)}
+                            <SketchPicker
+                              color={Array.isArray(cdc.fillColor) ? cdc.fillColor[0] : cdc.fillColor}
+                              presetColors={Object.values(chartColors).map((color) => color.hex)}
+                              onChangeComplete={(color) => _onChangeFillColor(color)}
                             />
                           </PopoverContent>
                         </Popover>
                       </div>
-                    </Row>
-                  ))}
-                </ScrollShadow>
-                <Spacer y={2} />
-              </>
-            )}
-          </div>
-
-          <Spacer y={4} />
-          <Divider />
-          <Spacer y={4} />
-        </>
-      )}
-
-      {chart.type !== "table" && chart.type !== "matrix" && (
-        <>
-          <Row>
-            <Text b>{"Dataset settings"}</Text>
-          </Row>
-          <Spacer y={1} />
-          <Row align="center" justify={"space-between"}>
-            <div className="text-sm">Sort records</div>
-            <Row align="center">
-              <Tooltip content="Sort the dataset in ascending order">
-                <Button
-                  color={cdc.sort === "asc" ? "secondary" : "default"}
-                  variant={cdc.sort !== "asc" ? "bordered" : "solid"}
-                  onPress={() => {
-                    if (cdc.sort === "asc") {
-                      _onUpdateCdc({ sort: "" });
-                    } else {
-                      _onUpdateCdc({ sort: "asc" });
-                    }
-                  }}
-                  isIconOnly
-                >
-                  <LuArrowDown01 />
-                </Button>
-              </Tooltip>
-              <Spacer x={1} />
-              <Tooltip content="Sort the dataset in descending order">
-                <Button
-                  color={cdc.sort === "desc" ? "secondary" : "default"}
-                  variant={cdc.sort !== "desc" ? "bordered" : "solid"}
-                  onPress={() => {
-                    if (cdc.sort === "desc") {
-                      _onUpdateCdc({ sort: "" });
-                    } else {
-                      _onUpdateCdc({ sort: "desc" });
-                    }
-                  }}
-                  isIconOnly
-                >
-                  <LuArrowDown10 />
-                </Button>
-              </Tooltip>
-              {cdc.sort && (
-                <>
-                  <Spacer x={1} />
-                  <Tooltip content="Clear sorting">
-                    <Link className="text-danger" onPress={() => _onUpdateCdc({ sort: "" })}>
-                      <LuCircleX className="text-danger" />
-                    </Link>
-                  </Tooltip>
-                </>
-              )}
-            </Row>
-          </Row>
-          <Spacer y={2} />
-
-          <Row align={"center"} justify={"space-between"}>
-            <div className="text-sm">Max records</div>
-            <Row align="center">
-              <Input
-                labelPlacement="outside"
-                placeholder="Max records"
-                value={maxRecords}
-                onChange={(e) => setMaxRecords(e.target.value)}
-                variant="bordered"
-                type="number"
-                min={1}
-              />
-              {maxRecords && (
-                <>
-                  <Spacer x={1} />
-                    {maxRecords !== cdc.maxRecords && (
-                      <>
-                        <Tooltip content="Save">
-                          <Link className="text-success" onPress={() => _onUpdateCdc({ maxRecords: maxRecords })}>
-                            <LuCircleCheck className="text-success" />
-                          </Link>
-                        </Tooltip>
-                        <Spacer x={1} />
-                      </>
                     )}
-                    <Tooltip content="Clear limit">
-                      <Link
-                        className="text-danger"
-                        onPress={() => {
-                          _onUpdateCdc({ maxRecords: null });
-                          setMaxRecords("");
-                        }}
-                      >
-                        <LuCircleX className="text-danger" />
-                      </Link>
-                    </Tooltip>
-                </>
-              )}
-            </Row>
-          </Row>
+                  </Row>
+                )}
+                <Spacer y={2} />
 
-          <Spacer y={4} />
-          <Divider />
-          <Spacer y={4} />
-        </>
-      )}
+                {chart.type !== "line" && chart.type !== "matrix" && (
+                  <Row>
+                    <Checkbox
+                      isSelected={cdc.multiFill}
+                      onChange={() => _onChangeMultiFill()}
+                      size="sm"
+                    >
+                      Multiple colors
+                    </Checkbox>
+                  </Row>
+                )}
 
-      {chart.type === "table" && (
-        <TableConfiguration
-          dataset={cdc}
-          chartData={chart.chartData}
-          tableFields={tableFields}
-          onUpdate={(data) => _onUpdateTableConfig(data)}
-          loading={false}
-        />
-      )}
+                {chart.type !== "line" && chart.type !== "matrix" && cdc.multiFill && (
+                  <>
+                    <Spacer y={2} />
+                    <ScrollShadow className="max-h-[300px] border-2 border-solid border-content3 rounded-md p-2">
+                      {dataItems?.labels?.map((label, index) => (
+                        <Row key={label} justify={"space-between"}>
+                          <Text size="sm">{label}</Text>
+                          <div>
+                            <Popover>
+                              <PopoverTrigger>
+                                <Chip
+                                  style={_getDatasetColor(cdc.fillColor[index] || "white")}
+                                  radius="sm"
+                                />
+                              </PopoverTrigger>
+                              <PopoverContent className="border-none bg-transparent shadow-none">
+                                <TwitterPicker
+                                  triangle={"hide"}
+                                  color={cdc.fillColor[index] || "white"}
+                                  colors={Object.values(chartColors).map((color) => color.hex)}
+                                  onChangeComplete={(color) => _onChangeFillColor(color, index)}
+                                />
+                              </PopoverContent>
+                            </Popover>
+                          </div>
+                        </Row>
+                      ))}
+                    </ScrollShadow>
+                    <Spacer y={2} />
+                  </>
+                )}
+              </div>
 
-      {chart.type !== "table" && (
-        <>
-          <div>
-            {!formula && (
-              <Link onPress={_onAddFormula} className="flex items-center cursor-pointer chart-cdc-formula">
-                <TbMathFunctionY size={24} />
-                <Spacer x={1} />
-                <div className="text-sm text-foreground">Apply formula on metrics</div>
-              </Link>
-            )}
-            {formula && (
-              <Row align={"center"} justify={"space-between"}>
-                <div className="flex flex-col">
-                  <Popover>
-                    <PopoverTrigger>
-                      <div className="flex flex-row gap-1 items-center">
-                        <div className="text-sm">
-                          {"Metric formula"}
-                        </div>
-                        <LuInfo size={18} />
-                      </div>
-                    </PopoverTrigger>
-                    <PopoverContent>
-                      <FormulaTips />
-                    </PopoverContent>
-                  </Popover>
-                </div>
-                <div className="flex flex-col">
-                  <div className="flex flex-row gap-3 items-center w-full">
-                    <Input
-                      labelPlacement="outside"
-                      placeholder="Enter your formula here: {val}"
-                      value={formula}
-                      onChange={(e) => setFormula(e.target.value)}
-                      variant="bordered"
+              <Spacer y={4} />
+              <Divider />
+              <Spacer y={4} />
+            </>
+          )}
+
+          {chart.type !== "table" && chart.type !== "matrix" && (
+            <>
+              <Row>
+                <Text b>{"Series settings"}</Text>
+              </Row>
+              <Spacer y={1} />
+              <div className="flex flex-col gap-2">
+                <div className="text-sm">Sort records</div>
+                <div className="flex flex-row gap-2">
+                  <Tooltip content="Sort the dataset in ascending order">
+                    <Button
+                      color={cdc.sort === "asc" ? "secondary" : "default"}
+                      variant="flat"
+                      onPress={() => _onUpdateCdc({ sort: cdc.sort === "asc" ? "" : "asc" })}
+                      startContent={<LuArrowDown01 />}
                       fullWidth
-                    />
-                    {formula !== cdc.formula && (
-                      <Tooltip
-                        content={"Apply the formula"}
-                      >
-                        <Link onPress={_onApplyFormula}>
-                          <LuCircleCheck className={"text-success"} />
+                      size="sm"
+                    >
+                      Asc
+                    </Button>
+                  </Tooltip>
+                  <Tooltip content="Sort the dataset in descending order">
+                    <Button
+                      color={cdc.sort === "desc" ? "secondary" : "default"}
+                      variant="flat"
+                      onPress={() => _onUpdateCdc({ sort: cdc.sort === "desc" ? "" : "desc" })}
+                      startContent={<LuArrowDown10 />}
+                      fullWidth
+                      size="sm"
+                    >
+                      Desc
+                    </Button>
+                  </Tooltip>
+                  {cdc.sort && (
+                    <>
+                      <Tooltip content="Clear sorting">
+                        <Link className="text-danger" onPress={() => _onUpdateCdc({ sort: "" })}>
+                          <LuCircleX className="text-danger" />
                         </Link>
                       </Tooltip>
-                    )}
-                    <Tooltip content="Remove formula">
-                      <Link onPress={_onRemoveFormula}>
-                        <LuCircleX className="text-danger" />
-                      </Link>
-                    </Tooltip>
-                    <Tooltip content="Click for an example">
-                      <Link onPress={_onExampleFormula}>
-                        <LuWandSparkles className="text-primary" />
-                      </Link>
-                    </Tooltip>
-                  </div>
-                </div>
-              </Row>
-            )}
-          </div>
-
-          <Spacer y={4} />
-          <Divider />
-          <Spacer y={4} />
-
-          <div>
-            {!goal && chart.type !== "table" && (
-              <div>
-                <Link onPress={() => setGoal(1000)} className="flex items-center cursor-pointer chart-cdc-goal">
-                  <TbProgressCheck size={24} />
-                  <Spacer x={1} />
-                  <div className="text-sm text-foreground">Set a goal</div>
-                </Link>
-              </div>
-            )}
-            {goal && chart.type !== "table" && (
-              <Row align={"center"} justify={"space-between"}>
-                <Row align="center">
-                  <div className="text-sm text-foreground">{"Goal"}</div>
-                  <Spacer x={1} />
-                  <Tooltip content="A goal can be displayed as a progress bar in your KPI charts. Enter a number without any other characters. (e.g. 1000 instead of 1k)">
-                    <div><LuInfo size={18} /></div>
-                  </Tooltip>
-                </Row>
-                <Row align="center" className={"gap-2"}>
-                  <Input
-                    placeholder="Enter your goal here"
-                    value={goal}
-                    onChange={(e) => setGoal(e.target.value)}
-                    variant="bordered"
-                    labelPlacement="outside"
-                  />
-                  {goal !== cdc.goal && (
-                    <Tooltip
-                      content={"Save goal"}
-                    >
-                      <Link onPress={() => _onUpdateCdc({ goal })}>
-                        <LuCircleCheck className={"text-success"} />
-                      </Link>
-                    </Tooltip>
+                    </>
                   )}
-                  <Tooltip content="Remove goal">
-                    <Link onPress={() => {
-                      _onUpdateCdc({ goal: null });
-                      setGoal("");
-                    }}>
-                      <LuCircleX className="text-danger" />
-                    </Link>
-                  </Tooltip>
-                </Row>
-              </Row>
-            )}
-          </div>
+                </div>
+              </div>
+              <Spacer y={4} />
 
-          <Spacer y={4} />
-          <Divider />
+              <div className="flex flex-col gap-2">
+                <div className="text-sm">Max records</div>
+                <div className="flex flex-row gap-2">
+                  <Input
+                    labelPlacement="outside"
+                    placeholder="Max records"
+                    value={maxRecords}
+                    onChange={(event) => setMaxRecords(event.target.value)}
+                    type="number"
+                    min={1}
+                    fullWidth
+                    description="Limit the number of records shown"
+                  />
+                  {maxRecords && (
+                    <>
+                      {`${maxRecords}` !== `${cdc.maxRecords || ""}` && (
+                        <>
+                          <Tooltip content="Save">
+                            <Link className="text-success" onPress={() => _onUpdateCdc({ maxRecords })}>
+                              <LuCircleCheck className="text-success" />
+                            </Link>
+                          </Tooltip>
+                        </>
+                      )}
+                      <Tooltip content="Clear limit">
+                        <Link
+                          className="text-danger"
+                          onPress={() => {
+                            _onUpdateCdc({ maxRecords: null });
+                            setMaxRecords("");
+                          }}
+                        >
+                          <LuCircleX className="text-danger" />
+                        </Link>
+                      </Tooltip>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              <Spacer y={4} />
+              <Divider />
+              <Spacer y={4} />
+            </>
+          )}
+
+          {chart.type === "table" && (
+            <TableConfiguration
+              dataset={cdc}
+              chartData={chart.chartData}
+              tableFields={tableFields}
+              onUpdate={_onUpdateTableConfig}
+              loading={false}
+            />
+          )}
+
+          {chart.type !== "table" && (
+            <>
+              <div>
+                {!formula && (
+                  <Link onPress={_onAddFormula} className="flex items-center cursor-pointer chart-cdc-formula">
+                    <TbMathFunctionY size={24} />
+                    <Spacer x={1} />
+                    <div className="text-sm text-foreground">Apply formula on metrics</div>
+                  </Link>
+                )}
+                {formula && (
+                  <Row align={"center"} justify={"space-between"}>
+                    <div className="flex flex-col">
+                      <Popover>
+                        <PopoverTrigger>
+                          <div className="flex flex-row gap-1 items-center">
+                            <div className="text-sm">{"Metric formula"}</div>
+                            <LuInfo size={18} />
+                          </div>
+                        </PopoverTrigger>
+                        <PopoverContent>
+                          <FormulaTips />
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+                    <div className="flex flex-col">
+                      <div className="flex flex-row gap-3 items-center w-full">
+                        <Input
+                          labelPlacement="outside"
+                          placeholder="Enter your formula here: {val}"
+                          value={formula}
+                          onChange={(event) => setFormula(event.target.value)}
+                          variant="bordered"
+                          fullWidth
+                        />
+                        {formula !== cdc.formula && (
+                          <Tooltip content={"Apply the formula"}>
+                            <Link onPress={_onApplyFormula}>
+                              <LuCircleCheck className={"text-success"} />
+                            </Link>
+                          </Tooltip>
+                        )}
+                        <Tooltip content="Remove formula">
+                          <Link onPress={_onRemoveFormula}>
+                            <LuCircleX className="text-danger" />
+                          </Link>
+                        </Tooltip>
+                        <Tooltip content="Click for an example">
+                          <Link onPress={_onExampleFormula}>
+                            <LuWandSparkles className="text-primary" />
+                          </Link>
+                        </Tooltip>
+                      </div>
+                    </div>
+                  </Row>
+                )}
+              </div>
+
+              <Spacer y={4} />
+              <Divider />
+              <Spacer y={4} />
+
+              <div>
+                {!goal && (
+                  <div>
+                    <Link onPress={() => setGoal(1000)} className="flex items-center cursor-pointer chart-cdc-goal">
+                      <TbProgressCheck size={24} />
+                      <Spacer x={1} />
+                      <div className="text-sm text-foreground">Set a goal</div>
+                    </Link>
+                  </div>
+                )}
+                {goal && (
+                  <Row align={"center"} justify={"space-between"}>
+                    <Row align="center">
+                      <div className="text-sm text-foreground">{"Goal"}</div>
+                      <Spacer x={1} />
+                      <Tooltip content="A goal can be displayed as a progress bar in your KPI charts. Enter a number without any other characters. (e.g. 1000 instead of 1k)">
+                        <div><LuInfo size={18} /></div>
+                      </Tooltip>
+                    </Row>
+                    <Row align="center" className={"gap-2"}>
+                      <Input
+                        placeholder="Enter your goal here"
+                        value={goal}
+                        onChange={(event) => setGoal(event.target.value)}
+                        variant="bordered"
+                        labelPlacement="outside"
+                      />
+                      {`${goal}` !== `${cdc.goal || ""}` && (
+                        <Tooltip content={"Save goal"}>
+                          <Link onPress={() => _onUpdateCdc({ goal })}>
+                            <LuCircleCheck className={"text-success"} />
+                          </Link>
+                        </Tooltip>
+                      )}
+                      <Tooltip content="Remove goal">
+                        <Link onPress={() => {
+                          _onUpdateCdc({ goal: null });
+                          setGoal("");
+                        }}>
+                          <LuCircleX className="text-danger" />
+                        </Link>
+                      </Tooltip>
+                    </Row>
+                  </Row>
+                )}
+              </div>
+            </>
+          )}
+        </Tab>
+
+        <Tab key="automation" title="Automation">
           <Spacer y={4} />
 
           <Row>
@@ -792,36 +740,24 @@ function ChartDatasetConfig(props) {
           <Spacer y={4} />
           <Divider />
           <Spacer y={4} />
-          
-          <div>
-            <LinkNext to={`/datasets/${cdc.dataset_id}?project_id=${params.projectId}&chart_id=${chartId}&editFilters=true`} className="flex items-center cursor-pointer chart-cdc-goal">
-              <LuListFilter size={24} className="text-primary" />
-              <Spacer x={1} />
-              <div className="text-sm text-foreground">Edit filters</div>
-            </LinkNext>
-          </div>
-
-          <Spacer y={4} />
-          <Divider />
-          <Spacer y={4} />
 
           <div className="flex flex-col gap-2">
             <div className="font-bold">{"Variables"}</div>
             {variables.map((variable) => (
               <div key={variable.id} className="flex flex-col gap-1">
                 <Input
-                  startContent={
+                  startContent={(
                     <div className="flex flex-row gap-1 items-center">
                       <LuVariable size={18} />
                       <div className="text-sm text-gray-400">{variable.name}</div>
                     </div>
-                  }
+                  )}
                   placeholder={`Default: ${variable.default_value || "No default"}`}
                   value={_getVariableCurrentValue(variable)}
-                  onChange={(e) => {
-                    setVariableValues(prev => ({
+                  onChange={(event) => {
+                    setVariableValues((prev) => ({
                       ...prev,
-                      [variable.name]: e.target.value
+                      [variable.name]: event.target.value,
                     }));
                   }}
                   variant="bordered"
@@ -829,7 +765,7 @@ function ChartDatasetConfig(props) {
                     _hasVariableChanged(variable) ? (
                       <div className="flex flex-row gap-1">
                         <Tooltip content="Save variable value">
-                          <Link 
+                          <Link
                             onClick={() => _onSaveVariableValue(variable.name, variableValues[variable.name] || "")}
                             className="text-success"
                           >
@@ -837,12 +773,12 @@ function ChartDatasetConfig(props) {
                           </Link>
                         </Tooltip>
                         <Tooltip content="Reset to saved value">
-                          <Link 
+                          <Link
                             onClick={() => {
                               const originalValue = _getVariableOriginalValue(variable);
-                              setVariableValues(prev => ({
+                              setVariableValues((prev) => ({
                                 ...prev,
-                                [variable.name]: originalValue
+                                [variable.name]: originalValue,
                               }));
                             }}
                             className="text-warning"
@@ -851,7 +787,7 @@ function ChartDatasetConfig(props) {
                           </Link>
                         </Tooltip>
                       </div>
-                    ) : cdc.configuration?.variables?.find(v => v.name === variable.name) && (
+                    ) : cdc.configuration?.variables?.find((item) => item.name === variable.name) && (
                       <div className="flex flex-row gap-1">
                         <Tooltip content="Remove override and use default value">
                           <Link onClick={() => _onClearVariableOverride(variable.name)}>
@@ -870,23 +806,38 @@ function ChartDatasetConfig(props) {
               </div>
             )}
           </div>
-        </>
-      )}
+        </Tab>
+      </Tabs>
 
       <Spacer y={4} />
       <Divider />
       <Spacer y={4} />
 
-      <Row>
+      <div className="flex flex-row justify-between">
+        {canAccess("teamAdmin", user.id, team?.TeamRoles) && (
+          <div className="flex flex-row gap-2 items-center">
+            {dataRequests?.map((dr) => (
+              <Tooltip content={dr?.Connection?.name} key={dr.id}>
+                <Avatar
+                  src={connectionImages(isDark)[dr?.Connection?.subType]}
+                  isBordered
+                  size="sm"
+                />
+              </Tooltip>
+            ))}
+            {dataRequests?.length > 0 && <div><LuPlug /></div>}
+          </div>
+        )}
+
         <Button
           variant="faded"
           color="danger"
           size="sm"
           onPress={_onRemoveCdc}
         >
-          {`Remove ${cdc.legend}`}
+          {`Remove ${seriesLabel}`}
         </Button>
-      </Row>
+      </div>
 
       <Modal isOpen={editConfirmation} onClose={() => setEditConfirmation(false)}>
         <ModalContent>
@@ -922,7 +873,7 @@ function ChartDatasetConfig(props) {
 ChartDatasetConfig.propTypes = {
   chartId: PropTypes.number.isRequired,
   dataRequests: PropTypes.array,
-  cdcId: PropTypes.number.isRequired,
+  cdcId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   onRemove: PropTypes.func.isRequired,
 };
 
@@ -930,4 +881,4 @@ ChartDatasetConfig.defaultProps = {
   dataRequests: [],
 };
 
-export default ChartDatasetConfig
+export default ChartDatasetConfig;

--- a/client/src/containers/AddChart/components/ChartDatasetDataSetup.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasetDataSetup.jsx
@@ -1,0 +1,342 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+import toast from "react-hot-toast";
+import {
+  Autocomplete, AutocompleteItem, Button, Chip, Divider, Input, Select, SelectItem, Spacer, Tooltip,
+} from "@heroui/react";
+import { LuCheck, LuInfo, LuSettings } from "react-icons/lu";
+
+import Row from "../../../components/Row";
+import Text from "../../../components/Text";
+import DatasetFilters from "../../../components/DatasetFilters";
+import autoFieldSelector from "../../../modules/autoFieldSelector";
+import { getDatasetFieldOptionsFromResponse, getDatasetFieldOptionsFromSchema } from "../../../modules/getDatasetFieldOptions";
+import { operations } from "../../../modules/filterOperations";
+import { runRequest as runDatasetRequest, updateDataset } from "../../../slices/dataset";
+import getDatasetDisplayName from "../../../modules/getDatasetDisplayName";
+
+function ChartDatasetDataSetup({
+  cdc,
+  dataset,
+  chart,
+  teamId,
+  legend,
+  onSaveLegend,
+  onUpdateCdc,
+  onEditDataset,
+}) {
+  const dispatch = useDispatch();
+  const datasetResponse = useSelector((state) => state.dataset.responses
+    .find((response) => response.dataset_id === dataset?.id)?.data);
+
+  const [fieldOptions, setFieldOptions] = useState([]);
+  const [loadingFields, setLoadingFields] = useState(false);
+  const autoSuggestedRef = useRef({});
+
+  useEffect(() => {
+    if (!dataset?.id || !teamId || datasetResponse || loadingFields) return;
+
+    setLoadingFields(true);
+    dispatch(runDatasetRequest({
+      team_id: teamId,
+      dataset_id: dataset.id,
+      getCache: true,
+    }))
+      .unwrap()
+      .catch(() => {
+        toast.error("Could not load dataset fields. Please check your query.");
+      })
+      .finally(() => {
+        setLoadingFields(false);
+      });
+  }, [dataset?.id, datasetResponse, teamId]);
+
+  useEffect(() => {
+    if (!dataset?.id) return;
+    if (autoSuggestedRef.current[cdc?.id] && cdc?.id) return;
+
+    let nextFieldOptions = [];
+    let nextFieldsSchema = null;
+
+    if (datasetResponse) {
+      const { fieldOptions: responseFieldOptions, fieldsSchema } = getDatasetFieldOptionsFromResponse(datasetResponse);
+      nextFieldOptions = responseFieldOptions;
+      nextFieldsSchema = fieldsSchema;
+    } else if (dataset?.fieldsSchema) {
+      nextFieldOptions = getDatasetFieldOptionsFromSchema(dataset.fieldsSchema);
+    }
+
+    if (nextFieldOptions.length === 0) return;
+
+    setFieldOptions(nextFieldOptions);
+
+    if (nextFieldsSchema && JSON.stringify(dataset.fieldsSchema || {}) !== JSON.stringify(nextFieldsSchema)) {
+      dispatch(updateDataset({
+        team_id: teamId,
+        dataset_id: dataset.id,
+        data: { fieldsSchema: nextFieldsSchema },
+      }));
+    }
+
+    if (!cdc?.id) return;
+
+    const autoFields = autoFieldSelector(nextFieldOptions);
+    const autoUpdates = {};
+
+    if (!cdc.xAxis && autoFields.xAxis) autoUpdates.xAxis = autoFields.xAxis;
+    if (!cdc.yAxis && autoFields.yAxis) autoUpdates.yAxis = autoFields.yAxis;
+    if (!cdc.dateField && autoFields.dateField) autoUpdates.dateField = autoFields.dateField;
+    if (!cdc.yAxisOperation && autoFields.yAxisOperation) autoUpdates.yAxisOperation = autoFields.yAxisOperation;
+
+    if (Object.keys(autoUpdates).length > 0) {
+      autoSuggestedRef.current[cdc.id] = true;
+      onUpdateCdc(autoUpdates);
+    } else {
+      autoSuggestedRef.current[cdc.id] = true;
+    }
+  }, [cdc?.id, cdc?.xAxis, cdc?.yAxis, cdc?.dateField, cdc?.yAxisOperation, dataset?.id, dataset?.fieldsSchema, datasetResponse, teamId]);
+
+  useEffect(() => {
+    if (cdc?.id && autoSuggestedRef.current[cdc.id] === undefined) {
+      autoSuggestedRef.current[cdc.id] = false;
+    }
+  }, [cdc?.id]);
+
+  const filterDataset = useMemo(() => {
+    return {
+      ...dataset,
+      ...cdc,
+      id: dataset?.id,
+      team_id: dataset?.team_id,
+      VariableBindings: dataset?.VariableBindings || [],
+      conditions: cdc?.conditions || [],
+    };
+  }, [cdc, dataset]);
+
+  const filterOptions = (axis) => {
+    let filteredOptions = fieldOptions;
+    if (axis === "x" && chart?.type !== "table") {
+      filteredOptions = filteredOptions.filter((field) => {
+        if (field.type === "array" || (field.value && field.value.split("[]").length > 2)) {
+          return false;
+        }
+
+        return true;
+      });
+    }
+
+    if (chart?.type !== "table") return filteredOptions;
+
+    filteredOptions = fieldOptions.filter((field) => field.type === "array");
+
+    if (axis === "x") {
+      filteredOptions = filteredOptions.filter((field) => {
+        if (field.type === "array" || (field.value && field.value.split("[]").length > 2)) {
+          return false;
+        }
+
+        return true;
+      });
+    }
+
+    const rootObj = {
+      key: "root[]",
+      text: "Collection root",
+      value: "root[]",
+      type: "array",
+      label: {
+        style: { width: 55, textAlign: "center" },
+        content: "root",
+        size: "mini",
+      },
+    };
+
+    const [rootField] = fieldOptions.filter((field) => field.value.indexOf([]) > -1);
+    if (rootField) {
+      rootObj.text = rootField.value.substring(0, rootField.value.lastIndexOf("."));
+      rootObj.key = rootField.value.substring(0, rootField.value.lastIndexOf("."));
+      rootObj.value = rootField.value.substring(0, rootField.value.lastIndexOf("."));
+    }
+
+    filteredOptions.unshift(rootObj);
+
+    return filteredOptions;
+  };
+
+  const getDateFieldOptions = () => fieldOptions.filter((field) => field.type === "date");
+
+  return (
+    <div>
+      <Input
+        placeholder="Enter a name for your series"
+        label="Series name"
+        value={legend}
+        onChange={onSaveLegend.onChange}
+        endContent={(
+          <Row align="center" className="gap-2">
+            {legend && legend !== cdc.legend && (
+              <Tooltip content="Save series name">
+                <Button
+                  isIconOnly
+                  color="primary"
+                  size="sm"
+                  onPress={onSaveLegend.onSave}
+                >
+                  <LuCheck />
+                </Button>
+              </Tooltip>
+            )}
+            <Tooltip content={`Dataset: ${getDatasetDisplayName(dataset)}`}>
+              <div><LuInfo size={18} className="text-default-400" /></div>
+            </Tooltip>
+          </Row>
+        )}
+      />
+
+      <Spacer y={2} />
+
+      <Button
+        variant="ghost"
+        fullWidth
+        endContent={<LuSettings size={18} />}
+        onPress={onEditDataset}
+      >
+        Edit dataset
+      </Button>
+
+      <Spacer y={4} />
+      <Divider />
+      <Spacer y={4} />
+
+      <Text b>Data setup</Text>
+      <Spacer y={2} />
+
+      <Autocomplete
+        label="Dimension (X-axis)"
+        labelPlacement="outside"
+        placeholder="Select dimension"
+        selectedKey={cdc.xAxis || ""}
+        onSelectionChange={(key) => onUpdateCdc({ xAxis: key })}
+        isLoading={loadingFields}
+        aria-label="Select a dimension"
+        description="The field to group data by (typically time)"
+      >
+        {filterOptions("x").map((option) => (
+          <AutocompleteItem
+            key={option.value}
+            startContent={(
+              <Chip size="sm" variant="flat" className={"min-w-[70px] text-center"} color={option.label.color}>{option.label.content}</Chip>
+            )}
+            description={option.isObject ? "Key-Value visualization" : null}
+            textValue={option.text}
+          >
+            {option.text}
+          </AutocompleteItem>
+        ))}
+      </Autocomplete>
+
+      <Spacer y={4} />
+
+      <Autocomplete
+        label="Metric (Y-axis)"
+        labelPlacement="outside"
+        placeholder="Select metric"
+        selectedKey={cdc.yAxis || ""}
+        onSelectionChange={(key) => onUpdateCdc({ yAxis: key })}
+        isLoading={loadingFields}
+        aria-label="Select a metric"
+        description="The field to measure or count"
+      >
+        {fieldOptions.map((option) => (
+          <AutocompleteItem
+            key={option.value}
+            startContent={(
+              <Chip size="sm" variant="flat" className={"min-w-[70px] text-center"} color={option.label.color}>{option.label.content}</Chip>
+            )}
+            description={option.isObject ? "Key-Value visualization" : null}
+            textValue={option.text}
+          >
+            {option.text}
+          </AutocompleteItem>
+        ))}
+      </Autocomplete>
+
+      <Spacer y={2} />
+
+      <Select
+        label="Operation"
+        placeholder="Select operation"
+        labelPlacement="outside"
+        onSelectionChange={(keys) => onUpdateCdc({ yAxisOperation: keys.currentKey })}
+        selectedKeys={[cdc.yAxisOperation || ""]}
+        selectionMode="single"
+        aria-label="Select an operation"
+      >
+        {operations.map((option) => (
+          <SelectItem key={option.value} textValue={option.text}>
+            {option.text}
+          </SelectItem>
+        ))}
+      </Select>
+
+      <Spacer y={4} />
+
+      <Autocomplete
+        label="Date field"
+        labelPlacement="outside"
+        placeholder="Select a field"
+        selectedKey={cdc.dateField || ""}
+        onSelectionChange={(key) => onUpdateCdc({ dateField: key })}
+        isLoading={loadingFields}
+        aria-label="Select a date field used for filtering"
+        description="Used for time-based filtering"
+      >
+        {getDateFieldOptions().map((option) => (
+          <AutocompleteItem
+            key={option.value}
+            startContent={(
+              <Chip size="sm" variant="flat" className={"min-w-[70px] text-center"} color={option.label.color}>{option.label.content}</Chip>
+            )}
+            textValue={option.text}
+          >
+            {option.text}
+          </AutocompleteItem>
+        ))}
+      </Autocomplete>
+
+      <Spacer y={4} />
+      <Divider />
+      <Spacer y={4} />
+
+      <div className="font-bold">Filters</div>
+      <Spacer y={2} />
+
+      <DatasetFilters
+        onUpdate={onUpdateCdc}
+        fieldOptions={fieldOptions}
+        dataset={filterDataset}
+      />
+    </div>
+  );
+}
+
+ChartDatasetDataSetup.propTypes = {
+  cdc: PropTypes.object.isRequired,
+  dataset: PropTypes.object.isRequired,
+  chart: PropTypes.object.isRequired,
+  teamId: PropTypes.number,
+  legend: PropTypes.string.isRequired,
+  onSaveLegend: PropTypes.shape({
+    onChange: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+  }).isRequired,
+  onUpdateCdc: PropTypes.func.isRequired,
+  onEditDataset: PropTypes.func.isRequired,
+};
+
+ChartDatasetDataSetup.defaultProps = {
+  teamId: null,
+};
+
+export default ChartDatasetDataSetup;

--- a/client/src/containers/AddChart/components/ChartDatasets.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasets.jsx
@@ -19,6 +19,7 @@ import { chartColors } from "../../../config/colors";
 import { selectTeam } from "../../../slices/team";
 import canAccess from "../../../config/canAccess";
 import { selectProjects } from "../../../slices/project";
+import getDatasetDisplayName from "../../../modules/getDatasetDisplayName";
 
 function ChartDatasets(props) {
   const { chartId, user } = props;
@@ -52,7 +53,7 @@ function ChartDatasets(props) {
       initRef.current = true;
       const projectDatasets = datasets.filter((d) => (
         !d.draft
-        && d?.legend?.toLowerCase().includes(datasetSearch?.toLowerCase())
+        && getDatasetDisplayName(d)?.toLowerCase().includes(datasetSearch?.toLowerCase())
         && d.project_ids?.includes(chart.project_id)
       ));
       if (projectDatasets.length === 0) {
@@ -72,11 +73,11 @@ function ChartDatasets(props) {
     if (tag === "project") {
       return datasets.filter((d) => (
         !d.draft
-        && d?.legend?.toLowerCase().includes(datasetSearch.toLowerCase())
+        && getDatasetDisplayName(d)?.toLowerCase().includes(datasetSearch.toLowerCase())
         && d?.project_ids?.includes(chart.project_id)
       ));
     }
-    return datasets.filter((d) => !d.draft && d.legend && d.legend?.toLowerCase().includes(datasetSearch.toLowerCase()));
+    return datasets.filter((d) => !d.draft && getDatasetDisplayName(d)?.toLowerCase().includes(datasetSearch.toLowerCase()));
   };
 
   const _getDatasetTags = (dataset) => {
@@ -93,15 +94,18 @@ function ChartDatasets(props) {
   };
 
   const _onCreateCdc = (datasetId) => {
+    const selectedDataset = datasets.find((dataset) => dataset.id === datasetId);
     // find out the perfect color for the new cdc
     const existingColors = chart.ChartDatasetConfigs.map((cdc) => cdc.datasetColor.toLowerCase());
-    const newColor = Object.values(chartColors).find((color) => !existingColors.includes(color.hex.toLowerCase()) && !existingColors.includes(color.rgb));
+    const newColor = Object.values(chartColors).find((color) => !existingColors.includes(color.hex.toLowerCase()) && !existingColors.includes(color.rgb))
+      || chartColors.blue;
 
     dispatch(createCdc({
       project_id: chart.project_id,
       chart_id: chart.id,
       data: {
         dataset_id: datasetId,
+        legend: getDatasetDisplayName(selectedDataset),
         datasetColor: newColor.hex,
         fill: false,
         order: chart.ChartDatasetConfigs[chart.ChartDatasetConfigs.length - 1]?.order + 1 || 0,
@@ -113,7 +117,7 @@ function ChartDatasets(props) {
           project_id: chart.project_id,
           chart_id: chart.id,
           noSource: false,
-          skiParsing: false,
+          skipParsing: false,
           getCache: true,
         }));
       });
@@ -149,7 +153,7 @@ function ChartDatasets(props) {
       project_id: chart.project_id,
       chart_id: chart.id,
       noSource: false,
-      skiParsing: false,
+      skipParsing: false,
       getCache: true,
     }));
   };
@@ -157,27 +161,28 @@ function ChartDatasets(props) {
   return (
     <div>
       <div className="flex flex-row justify-between items-center">
-        <Text size="h4">Datasets</Text>
+        <div className="font-bold">Chart Series</div>
         <div className="flex flex-row gap-1 items-center">
-          {canAccess("teamAdmin", user.id, team?.TeamRoles) && (
+          {canAccess("teamAdmin", user.id, team?.TeamRoles) && addMode && (
             <Button
               size="sm"
               color="primary"
               onPress={() => navigate(`/datasets/new?create=true&project_id=${chart.project_id}&chart_id=${chart.id}`)}
             >
-              Create dataset
+              Create new dataset
             </Button>
           )}
 
           {datasets.length > 0 && chart?.ChartDatasetConfigs.length > 0 && (
             <Button
-              isIconOnly
+              isIconOnly={addMode}
               variant="faded"
               size="sm"
               onPress={() => setAddMode(!addMode)}
               className="chart-cdc-add"
+              startContent={!addMode ? <LuPlus /> : null}
             >
-              {!addMode && <LuPlus />}
+              {!addMode && "Add series"}
               {addMode && <LuMinus />}
             </Button>
           )}
@@ -194,7 +199,6 @@ function ChartDatasets(props) {
             value={datasetSearch}
             onChange={(e) => setDatasetSearch(e.target.value)}
             startContent={<LuSearch />}
-            variant="bordered"
           />
           <Spacer y={2} />
           <div className="flex flex-row gap-1 items-center">
@@ -238,7 +242,7 @@ function ChartDatasets(props) {
                     <div className={"flex flex-row justify-between gap-4 w-full"}>
                       <div className="flex flex-row gap-4 items-center justify-between w-full">
                         <div className="flex flex-col gap-1 items-start">
-                          <Text b>{dataset.legend}</Text>
+                          <Text b>{getDatasetDisplayName(dataset)}</Text>
                           <div className="flex flex-wrap gap-1">
                             {_getDatasetTags(dataset).map((tag) => (
                               <Chip key={tag} size="sm" variant="flat" color="primary">
@@ -267,11 +271,11 @@ function ChartDatasets(props) {
                     <div className="w-full flex flex-row justify-between">
                       <div>
                         <Text b size="sm">Metric: </Text>
-                        <Text size="sm">{dataset.xAxis?.replace("root[].", "").replace("root.", "")}</Text>
+                        <Text size="sm">{dataset.yAxis?.replace("root[].", "").replace("root.", "") || "Not set"}</Text>
                       </div>
                       <div>
                         <Text b size="sm">Dimension: </Text>
-                        <Text size="sm">{dataset.xAxis?.replace("root[].", "").replace("root.", "")}</Text>
+                        <Text size="sm">{dataset.xAxis?.replace("root[].", "").replace("root.", "") || "Not set"}</Text>
                       </div>
                     </div>
                   </CardBody>
@@ -315,7 +319,7 @@ function ChartDatasets(props) {
             onPress={() => navigate(`/datasets/new?create=true&project_id=${chart.project_id}&chart_id=${chart.id}`)}
             fullWidth
           >
-            Create dataset
+            Create series
           </Button>
         </div>
       )}
@@ -332,7 +336,7 @@ function ChartDatasets(props) {
           renderItem={(cdc, { isDragging }) => (
             <Chip
               key={cdc.id}
-              title={`${cdc.legend}`}
+              title={`${cdc.legend || getDatasetDisplayName(datasets.find((dataset) => dataset.id === cdc.dataset_id))}`}
               radius="sm"
               color={activeCdc?.id === cdc.id ? "primary" : "default"}
               variant={activeCdc?.id === cdc.id ? "solid" : "flat"}
@@ -341,7 +345,7 @@ function ChartDatasets(props) {
               size="lg"
               endContent={<LuGripVertical size={16} className="cursor-grab" />}
             >
-              {cdc.legend}
+              {cdc.legend || getDatasetDisplayName(datasets.find((dataset) => dataset.id === cdc.dataset_id))}
             </Chip>
           )}
         />

--- a/client/src/containers/AddChart/components/ChartDatasets.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasets.jsx
@@ -7,9 +7,8 @@ import moment from "moment";
 
 import { createCdc, runQuery, selectChart, updateCdc } from "../../../slices/chart";
 import {
-  Avatar, Button, Card, CardBody, CardFooter, CardHeader, Chip, Divider, Input, ScrollShadow, Spacer, Tooltip
+  Avatar, Button, Card, CardFooter, CardHeader, Chip, Divider, Input, ScrollShadow, Spacer, Tooltip
 } from "@heroui/react";
-import Text from "../../../components/Text";
 import connectionImages from "../../../config/connectionImages";
 import { getDatasets, selectDatasetsNoDrafts } from "../../../slices/dataset";
 import { useTheme } from "../../../modules/ThemeContext";
@@ -189,8 +188,6 @@ function ChartDatasets(props) {
         </div>
       </div>
       <Spacer y={4} />
-      <Divider />
-      <Spacer y={4} />
 
       {(chart?.ChartDatasetConfigs?.length === 0 || addMode) && (
         <>
@@ -221,7 +218,7 @@ function ChartDatasets(props) {
               All
             </Chip>
             <Spacer x={1} />
-            <Text size="sm">{`${_filteredDatasets().length} datasets found`}</Text>
+            <div className="text-sm text-foreground-500">{`${_filteredDatasets().length} datasets found`}</div>
           </div>
           <Spacer y={4} />
 
@@ -242,7 +239,7 @@ function ChartDatasets(props) {
                     <div className={"flex flex-row justify-between gap-4 w-full"}>
                       <div className="flex flex-row gap-4 items-center justify-between w-full">
                         <div className="flex flex-col gap-1 items-start">
-                          <Text b>{getDatasetDisplayName(dataset)}</Text>
+                          <div className="font-bold">{getDatasetDisplayName(dataset)}</div>
                           <div className="flex flex-wrap gap-1">
                             {_getDatasetTags(dataset).map((tag) => (
                               <Chip key={tag} size="sm" variant="flat" color="primary">
@@ -267,21 +264,8 @@ function ChartDatasets(props) {
                     </div>
                   </CardHeader>
                   <Divider />
-                  <CardBody className="p-2">
-                    <div className="w-full flex flex-row justify-between">
-                      <div>
-                        <Text b size="sm">Metric: </Text>
-                        <Text size="sm">{dataset.yAxis?.replace("root[].", "").replace("root.", "") || "Not set"}</Text>
-                      </div>
-                      <div>
-                        <Text b size="sm">Dimension: </Text>
-                        <Text size="sm">{dataset.xAxis?.replace("root[].", "").replace("root.", "") || "Not set"}</Text>
-                      </div>
-                    </div>
-                  </CardBody>
-                  <Divider />
                   <CardFooter className="justify-between">
-                    <Text className={"text-[12px]"}>{`Created ${moment(dataset.createdAt).calendar()}`}</Text>
+                    <div className="text-xs text-foreground-500">{`Created ${moment(dataset.createdAt).calendar()}`}</div>
                     {canAccess("teamAdmin", user.id, team?.TeamRoles) && (
                       <div className="z-50">
                         <Button
@@ -290,7 +274,7 @@ function ChartDatasets(props) {
                           variant="ghost"
                           endContent={<LuExternalLink size={16} />}
                           as={Link}
-                          to={`/${team.id}/dataset/${dataset.id}`}
+                          to={`/datasets/${dataset.id}`}
                           target="_blank"
                         >
                           Edit
@@ -312,7 +296,7 @@ function ChartDatasets(props) {
           <Spacer y={4} />
           <Divider />
           <Spacer y={4} />
-          <Text>No datasets found. Create a dataset to get started.</Text>
+          <div className="text-sm text-foreground-500">No datasets found. Create a dataset to get started.</div>
           <Spacer y={4} />
           <Button
             color="primary"
@@ -339,11 +323,15 @@ function ChartDatasets(props) {
               title={`${cdc.legend || getDatasetDisplayName(datasets.find((dataset) => dataset.id === cdc.dataset_id))}`}
               radius="sm"
               color={activeCdc?.id === cdc.id ? "primary" : "default"}
-              variant={activeCdc?.id === cdc.id ? "solid" : "flat"}
+              // variant={activeCdc?.id === cdc.id ? "solid" : "flat"}
+              variant="flat"
               onClick={() => setActiveCdc(cdc)}
               className={`cursor-pointer select-none ${isDragging ? "cursor-grab" : ""}`}
               size="lg"
               endContent={<LuGripVertical size={16} className="cursor-grab" />}
+              startContent={(
+                <div className="w-2 h-2 rounded-full" style={{ backgroundColor: cdc.datasetColor }} />
+              )}
             >
               {cdc.legend || getDatasetDisplayName(datasets.find((dataset) => dataset.id === cdc.dataset_id))}
             </Chip>

--- a/client/src/containers/AddChart/components/ChartDescription.jsx
+++ b/client/src/containers/AddChart/components/ChartDescription.jsx
@@ -14,6 +14,7 @@ import availableConnections from "../../../modules/availableConnections";
 import { selectProjects } from "../../../slices/project";
 import { selectTeam } from "../../../slices/team";
 import { selectUser } from "../../../slices/user";
+import getDatasetDisplayName from "../../../modules/getDatasetDisplayName";
 
 const connectionTypeLabels = availableConnections.reduce((acc, connection) => ({
   ...acc,
@@ -93,7 +94,7 @@ function ChartDescription(props) {
 
       const search = searchValue.trim().toLowerCase();
       const haystack = [
-        dataset.legend,
+        getDatasetDisplayName(dataset),
         ..._getDatasetTags(dataset),
         ..._getDatasetConnectionTypes(dataset),
       ]
@@ -165,7 +166,6 @@ function ChartDescription(props) {
             value={searchValue}
             onChange={(e) => setSearchValue(e.target.value)}
             endContent={<LuSearch size={16} />}
-            variant="bordered"
             size="sm"
           />
         </div>
@@ -214,8 +214,8 @@ function ChartDescription(props) {
                 <TableRow key={dataset.id}>
                   <TableCell key="name">
                     <div className={cn(`min-w-0 ${isBusy && !isCreatingChart ? "opacity-60" : ""} cursor-pointer hover:underline`)}>
-                      <div className="truncate text-sm font-medium text-foreground text-wrap min-w-[200px]">
-                        {dataset.legend}
+                        <div className="truncate text-sm font-medium text-foreground text-wrap min-w-[200px]">
+                        {getDatasetDisplayName(dataset)}
                       </div>
                     </div>
                   </TableCell>
@@ -271,7 +271,7 @@ function ChartDescription(props) {
                         onPress={() => _onSelectDataset(dataset)}
                         isLoading={isCreatingChart}
                         isDisabled={isBusy && !isCreatingChart}
-                        aria-label={`Create chart from ${dataset.legend}`}
+                        aria-label={`Create chart from ${getDatasetDisplayName(dataset)}`}
                       >
                         {!isCreatingChart && <LuPlus size={16} />}
                       </Button>

--- a/client/src/containers/AddChart/components/ChartPreview.jsx
+++ b/client/src/containers/AddChart/components/ChartPreview.jsx
@@ -30,6 +30,7 @@ import ChartFilters from "../../Chart/components/ChartFilters";
 import { format } from "date-fns";
 import { enGB } from "date-fns/locale";
 import GaugeChart from "../../Chart/components/GaugeChart";
+import { getExposedChartFilters } from "../../../modules/getChartDatasetConditions";
 
 function ChartPreview(props) {
   const {
@@ -55,14 +56,7 @@ function ChartPreview(props) {
   }, [chart.ranges]);
 
   const _checkIfFilters = () => {
-    let filterCount = 0;
-    chart.ChartDatasetConfigs.forEach((d) => {
-      if (Array.isArray(d.Dataset?.conditions)) {
-        filterCount += d.Dataset.conditions.filter((c) => c.exposed).length;
-      }
-    });
-
-    return filterCount > 0;
+    return getExposedChartFilters(chart).length > 0;
   };
 
   const _onAddFilter = (condition) => {

--- a/client/src/containers/AddChart/components/ChartSettings.jsx
+++ b/client/src/containers/AddChart/components/ChartSettings.jsx
@@ -307,7 +307,6 @@ function ChartSettings({ chart, onChange }) {
             size="sm"
             selectedKeys={[chart.timeInterval]}
             onSelectionChange={(keys) => onChange({ timeInterval: keys.currentKey })}
-            variant="bordered"
             renderValue={() => (
               <Text>{timeIntervalOptions.find((option) => option.value === chart.timeInterval).text}</Text>
             )}
@@ -434,7 +433,6 @@ function ChartSettings({ chart, onChange }) {
                 type="number"
                 value={max}
                 onChange={(e) => setMax(e.target.value)}
-                variant="bordered"
                 fullWidth
               />
               <div className="flex flex-row gap-1">
@@ -471,7 +469,6 @@ function ChartSettings({ chart, onChange }) {
                 type="number"
                 value={min}
                 onChange={(e) => setMin(e.target.value)}
-                variant="bordered"
                 fullWidth
               />
               <div className="flex flex-row gap-1">
@@ -510,7 +507,6 @@ function ChartSettings({ chart, onChange }) {
               label="Default rows per page"
               selectionMode="single"
               placeholder="Default rows per page"
-              variant="bordered"
               selectedKeys={[`${chart.defaultRowsPerPage}`]}
               onSelectionChange={(keys) => onChange({ defaultRowsPerPage: parseInt(keys.currentKey, 10) })}
             >
@@ -537,7 +533,6 @@ function ChartSettings({ chart, onChange }) {
             size="sm"
             selectedKeys={[ticksSelection]}
             onSelectionChange={(keys) => _onChangeTicks(keys.currentKey)}
-            variant="bordered"
             renderValue={() => (
               <Text>{xLabelOptions.find((option) => option.value === ticksSelection).text}</Text>
             )}
@@ -601,7 +596,6 @@ function ChartSettings({ chart, onChange }) {
                 initialValue={chart.dateVarsFormat}
                 value={datesFormat}
                 onChange={(e) => setDatesFormat(e.target.value)}
-                variant="bordered"
                 fullWidth
                 size="sm"
               />

--- a/client/src/containers/AddChart/components/Dataset.jsx
+++ b/client/src/containers/AddChart/components/Dataset.jsx
@@ -14,6 +14,7 @@ import DatarequestModal from "./DatarequestModal";
 import DatasetAppearance from "./DatasetAppearance";
 import DatasetData from "./DatasetData";
 import Text from "../../../components/Text";
+import getDatasetDisplayName from "../../../modules/getDatasetDisplayName";
 
 const emptyColor = "rgba(0,0,0,0)";
 
@@ -48,12 +49,13 @@ function Dataset(props) {
   const [menuItem, setMenuItem] = useState("data");
   const [requestResult, setRequestResult] = useState(null);
   const [editDatasetName, setEditDatasetName] = useState(false);
-  const [datasetName, setDatasetName] = useState(dataset.legend);
+  const [datasetName, setDatasetName] = useState(getDatasetDisplayName(dataset));
   const [savingDatasetName, setSavingDatasetName] = useState(false);
 
   // update the dataset with the active one
   useEffect(() => {
     setNewDataset(dataset);
+    setDatasetName(getDatasetDisplayName(dataset));
   }, [dataset]);
 
   // update the dataset prop based on new changes
@@ -62,7 +64,7 @@ function Dataset(props) {
       return;
     }
 
-    if (dataset.legend !== newDataset.legend) {
+    if (dataset.name !== newDataset.name) {
       if (shouldSave === null) {
         setShouldSave(moment().add(2, "seconds"));
       } else if (moment().isAfter(shouldSave)) {
@@ -167,10 +169,10 @@ function Dataset(props) {
       });
   };
 
-  const _onChangeLegend = () => {
+  const _onChangeDatasetName = () => {
     if (datasetName) {
       setSavingDatasetName(true);
-      onUpdate({ ...newDataset, legend: datasetName })
+      onUpdate({ ...newDataset, name: datasetName })
         .then(() => {
           setSavingDatasetName(false);
           setEditDatasetName(false);
@@ -199,7 +201,7 @@ function Dataset(props) {
           <Spacer y={2} />
         </div>
         <div className="col-span-12 flex items-center">
-          <Text b size={"lg"}>{newDataset.legend}</Text>
+          <Text b size={"lg"}>{getDatasetDisplayName(newDataset)}</Text>
           <Spacer x={1} />
           <Button
             variant="light"
@@ -226,7 +228,7 @@ function Dataset(props) {
         {editDatasetName && (
           <div className="col-span-12 md:col-span-6">
             <Button
-              onClick={_onChangeLegend}
+              onClick={_onChangeDatasetName}
               isDisabled={!datasetName}
               isLoading={savingDatasetName}
               color="success"

--- a/client/src/containers/AddChart/components/SqlBuilder.jsx
+++ b/client/src/containers/AddChart/components/SqlBuilder.jsx
@@ -327,8 +327,6 @@ function SqlBuilder(props) {
             />
           </Tabs>
           <Spacer y={2} />
-          <Divider />
-          <Spacer y={4} />
           <>
             {activeTab === "visual" && (
               <div>

--- a/client/src/containers/Ai/AiModal.jsx
+++ b/client/src/containers/Ai/AiModal.jsx
@@ -18,6 +18,7 @@ import { selectConnections } from "../../slices/connection";
 import { selectDatasetsNoDrafts } from "../../slices/dataset";
 import isMac from "../../modules/isMac";
 import socketClient from "../../modules/socketClient";
+import getDatasetDisplayName from "../../modules/getDatasetDisplayName";
 
 function formatDate(date) {
   return new Date(date).toLocaleDateString("en-US", {
@@ -104,7 +105,7 @@ function AiModal({ isOpen, onClose }) {
       case "connection":
         return `Connection: ${entity.name} (${entity.type})`;
       case "dataset":
-        return `Dataset: ${entity.legend || entity.name}`;
+        return `Dataset: ${getDatasetDisplayName(entity)}`;
       default:
         return entity.name;
     }
@@ -258,7 +259,7 @@ function AiModal({ isOpen, onClose }) {
       }
       if (datasetId && selectedContext?.multiSelect?.find(e => e.id === datasetId) === undefined) {
         const dataset = datasets.find(d => d.id === datasetId);
-        const datasetLabel = `Dataset: ${dataset?.legend || dataset?.name}`;
+        const datasetLabel = `Dataset: ${getDatasetDisplayName(dataset)}`;
         setSelectedContext(prev => ({ ...prev, multiSelect: [...prev.multiSelect, { id: datasetId, entity_type: "dataset", label: datasetLabel }] }));
       }
     }

--- a/client/src/containers/Chart/Chart.jsx
+++ b/client/src/containers/Chart/Chart.jsx
@@ -48,6 +48,7 @@ import { selectTeam } from "../../slices/team";
 import { selectUser } from "../../slices/user";
 import { exportChartToExcel, canExportChart } from "../../modules/exportChart";
 import ChartSharing from "./components/ChartSharing";
+import { getExposedChartFilters } from "../../modules/getChartDatasetConditions";
 
 const getFiltersFromStorage = (projectId) => {
   try {
@@ -214,14 +215,6 @@ function Chart(props) {
 
   const _runFiltering = async (filters, projectId = params.projectId) => {
     if (!chart.ChartDatasetConfigs) return;
-
-    // Get all conditions from the chart's datasets
-    let identifiedConditions = [];
-    chart.ChartDatasetConfigs.forEach((cdc) => {
-      if (Array.isArray(cdc.Dataset?.conditions)) {
-        identifiedConditions = [...identifiedConditions, ...cdc.Dataset.conditions];
-      }
-    });
 
     // If no filters are provided, get them from localStorage
     const allFilters = filters || getFiltersFromStorage(projectId) || [];
@@ -420,16 +413,7 @@ function Chart(props) {
   };
 
   const _checkIfFilters = () => {
-    let filterCount = 0;
-    if (!chart.ChartDatasetConfigs) return false;
-
-    chart.ChartDatasetConfigs.forEach((d) => {
-      if (Array.isArray(d.Dataset?.conditions)) {
-        filterCount += d.Dataset.conditions.filter((c) => c.exposed).length;
-      }
-    });
-
-    return filterCount > 0;
+    return getExposedChartFilters(chart).length > 0;
   };
 
   const _canAccess = (role) => {

--- a/client/src/containers/Chart/components/ChartFilters.jsx
+++ b/client/src/containers/Chart/components/ChartFilters.jsx
@@ -13,6 +13,7 @@ import "react-date-range/dist/theme/default.css"; // theme css file
 import determineType from "../../../modules/determineType";
 import * as operations from "../../../modules/filterOperations";
 import Row from "../../../components/Row";
+import { getExposedChartFilters } from "../../../modules/getChartDatasetConditions";
 
 function ChartFilters(props) {
   const {
@@ -30,7 +31,10 @@ function ChartFilters(props) {
   }, [conditions]);
 
   const _getDropdownOptions = (dataset, condition) => {
-    const conditionOpt = dataset.conditions.find((c) => c.field === condition.field);
+    const conditionOpt = condition.sourceConditions?.find((c) => c.id === condition.id)
+      || condition.sourceConditions?.find((c) => c.field === condition.field)
+      || dataset?.conditions?.find((c) => c.id === condition.id)
+      || dataset?.conditions?.find((c) => c.field === condition.field);
 
     if (!conditionOpt || !conditionOpt.values) return [];
 
@@ -57,14 +61,7 @@ function ChartFilters(props) {
   };
 
   const _checkIfFilters = () => {
-    let filterCount = 0;
-    chart.ChartDatasetConfigs.forEach((cdc) => {
-      if (Array.isArray(cdc.Dataset?.conditions)) {
-        filterCount += cdc.Dataset.conditions.filter((c) => c.exposed).length;
-      }
-    });
-
-    return filterCount;
+    return getExposedChartFilters(chart).length;
   };
 
   const _getFilteredOptions = (filterOptions, cId) => {
@@ -89,16 +86,7 @@ function ChartFilters(props) {
   };
 
   const _getAllFilters = () => {
-    const filters = [];
-    chart.ChartDatasetConfigs.forEach((cdc) => {
-      if (Array.isArray(cdc.Dataset?.conditions)) {
-        cdc.Dataset.conditions.forEach((c) => {
-          if (c.exposed) {
-            filters.push({ ...c, Dataset: cdc.Dataset });
-          }
-        });
-      }
-    });
+    const filters = getExposedChartFilters(chart);
 
     if (amount) return filters.slice(0, amount);
 

--- a/client/src/containers/Dataset/Dataset.jsx
+++ b/client/src/containers/Dataset/Dataset.jsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import toast from "react-hot-toast";
 import {
+  Autocomplete, AutocompleteItem,
   Button, Chip, Input, Link, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Spacer,
 } from "@heroui/react";
-import { LuCheck, LuPencil } from "react-icons/lu";
+import { LuChartColumn, LuCheck, LuPencil } from "react-icons/lu";
 import { useLocation, useNavigate, useParams } from "react-router";
 
-import { createCdc, runQuery, updateChart } from "../../slices/chart";
+import { createChart, createCdc, getProjectCharts, runQuery, updateChart } from "../../slices/chart";
 import { getDataset, saveNewDataset, updateDataset } from "../../slices/dataset";
 import { getTeamConnections } from "../../slices/connection";
 import DatasetQuery from "./DatasetQuery";
@@ -17,6 +18,26 @@ import { selectUser } from "../../slices/user";
 import { getTeams, selectTeam } from "../../slices/team";
 import { getProjects, selectProjects } from "../../slices/project";
 import getDatasetDisplayName from "../../modules/getDatasetDisplayName";
+import getDashboardLayout from "../../modules/getDashboardLayout";
+import { placeNewWidget } from "../../modules/autoLayout";
+
+const defaultNewChart = {
+  type: "line",
+  subType: "lcTimeseries",
+};
+
+function getNewChartLayoutForProject(charts) {
+  const layouts = getDashboardLayout(charts);
+  const chartLayout = {};
+
+  Object.keys(layouts).forEach((bp) => {
+    const w = bp === "lg" ? 4 : bp === "md" ? 5 : bp === "sm" ? 3 : bp === "xs" ? 2 : 2;
+    const pos = placeNewWidget(layouts[bp] || [], { w, h: 2 }, bp);
+    chartLayout[bp] = [pos.x, pos.y, pos.w, pos.h];
+  });
+
+  return chartLayout;
+}
 
 function Dataset() {
   const [error, setError] = useState(null);
@@ -25,7 +46,12 @@ function Dataset() {
   const [saveDatasetLoading, setSaveDatasetLoading] = useState(false);
   const [fromChart, setFromChart] = useState(null);
   const [draftSaveModalOpen, setDraftSaveModalOpen] = useState(false);
+  const [draftSaveIntent, setDraftSaveIntent] = useState("save");
   const [selectedProjectIds, setSelectedProjectIds] = useState([]);
+  const [createChartModalOpen, setCreateChartModalOpen] = useState(false);
+  const [createChartSelectedProjectKey, setCreateChartSelectedProjectKey] = useState(null);
+  const [createChartSubmitAttempted, setCreateChartSubmitAttempted] = useState(false);
+  const [createChartFromDatasetLoading, setCreateChartFromDatasetLoading] = useState(false);
 
   const params = useParams();
   const dispatch = useDispatch();
@@ -127,6 +153,21 @@ function Dataset() {
     }
   }, [query]);
 
+  useEffect(() => {
+    if (!createChartModalOpen) return;
+
+    const selectable = projects.filter((project) => !project.ghost);
+    if (selectedProjectIds.length === 1) {
+      const id = selectedProjectIds[0];
+      if (selectable.some((p) => p.id === id)) {
+        setCreateChartSelectedProjectKey(String(id));
+        return;
+      }
+    }
+    setCreateChartSelectedProjectKey(null);
+    // Prefill from dataset tags only when the modal opens, not when tags/projects change while it stays open.
+  }, [createChartModalOpen]);
+
   const _onUpdateDataset = (data) => {
     return dispatch(updateDataset({
       team_id: team.id,
@@ -143,7 +184,7 @@ function Dataset() {
       });
   };
 
-  const _persistDataset = async (projectIds = dataset?.project_ids || []) => {
+  const _persistDataset = async (projectIds = dataset?.project_ids || [], afterSave = "save") => {
     if (!dataset?.id || !team?.id) return false;
 
     const trimmedName = datasetName.trim() || getDatasetDisplayName(dataset) || "Untitled dataset";
@@ -203,6 +244,12 @@ function Dataset() {
         return true;
       }
 
+      if (afterSave === "createChart" && !fromChart) {
+        setCreateChartModalOpen(true);
+        setEditDatasetName(false);
+        return true;
+      }
+
       toast.success("Dataset saved");
       setEditDatasetName(false);
       return true;
@@ -215,13 +262,79 @@ function Dataset() {
     }
   };
 
-  const _onSaveDataset = async () => {
+  const _onSaveDataset = async (intent = "save") => {
     if (dataset?.draft) {
+      const continueToCreateChart = intent === "createChart" || (!fromChart && intent === "save");
+      setDraftSaveIntent(continueToCreateChart ? "createChart" : "save");
       setDraftSaveModalOpen(true);
       return;
     }
 
-    await _persistDataset(selectedProjectIds);
+    await _persistDataset(
+      selectedProjectIds,
+      intent === "createChart" ? "createChart" : "save",
+    );
+  };
+
+  const _onCreateChartFromDataset = async () => {
+    if (!createChartSelectedProjectKey) {
+      setCreateChartSubmitAttempted(true);
+      return;
+    }
+
+    const projectId = parseInt(String(createChartSelectedProjectKey), 10);
+    if (!dataset?.id || Number.isNaN(projectId)) return;
+
+    setCreateChartFromDatasetLoading(true);
+
+    try {
+      const charts = await dispatch(getProjectCharts({ project_id: projectId })).unwrap();
+      const chartLayout = getNewChartLayoutForProject(charts || []);
+      const trimmedName = datasetName.trim() || getDatasetDisplayName(dataset) || "Untitled dataset";
+
+      const chart = await dispatch(createChart({
+        project_id: projectId,
+        data: {
+          ...defaultNewChart,
+          name: trimmedName,
+          layout: chartLayout,
+        },
+      })).unwrap();
+
+      await dispatch(createCdc({
+        project_id: projectId,
+        chart_id: chart.id,
+        data: {
+          dataset_id: dataset.id,
+          legend: trimmedName,
+          datasetColor: chartColors.blue.hex,
+          fill: false,
+          order: 0,
+        },
+      })).unwrap();
+
+      try {
+        await dispatch(runQuery({
+          project_id: projectId,
+          chart_id: chart.id,
+          noSource: false,
+          skipParsing: false,
+          getCache: true,
+        })).unwrap();
+      } catch (queryError) {
+        // The chart editor can recover from a failed first run.
+      }
+
+      setCreateChartModalOpen(false);
+      setCreateChartSelectedProjectKey(null);
+      setCreateChartSubmitAttempted(false);
+      navigate(`/dashboard/${projectId}/chart/${chart.id}/edit`);
+    } catch (createError) {
+      setError(createError);
+      toast.error("Could not create the chart. Please try again.");
+    } finally {
+      setCreateChartFromDatasetLoading(false);
+    }
   };
 
   const _toggleProjectTag = (projectId) => {
@@ -239,8 +352,8 @@ function Dataset() {
           {!editDatasetName && (
             <>
               <Link onClick={() => setEditDatasetName(true)} className="text-default-500 cursor-pointer flex flex-row items-center gap-2">
-                <div className="font-tw font-bold text-foreground">{getDatasetDisplayName(dataset)}</div>
-                <LuPencil size={16} className="text-secondary" />
+                <div className="font-tw font-bold text-foreground text-lg">{getDatasetDisplayName(dataset)}</div>
+                <LuPencil size={16} className="text-foreground-500" />
               </Link>
             </>
           )}
@@ -253,16 +366,37 @@ function Dataset() {
                 placeholder="Dataset name"
                 variant="bordered"
                 labelPlacement="outside"
+                endContent={
+                  <Button
+                    variant="flat"
+                    isIconOnly
+                    onPress={() => _onSaveDataset("save")}
+                    size="sm"
+                  >
+                    <LuCheck size={16} />
+                  </Button>
+                }
               />
             </>
           )}
         </div>
 
         <div className="flex flex-row gap-2 flex-wrap">
+          {!fromChart && (
+            <Button
+              color="default"
+              variant="ghost"
+              onPress={() => _onSaveDataset("createChart")}
+              isLoading={saveDatasetLoading}
+              isDisabled={!dataset?.id || dataset?.DataRequests?.length === 0}
+              startContent={<LuChartColumn size={16} />}
+            >
+              Save & create chart
+            </Button>
+          )}
           <Button
             color="primary"
-            onPress={_onSaveDataset}
-            endContent={!saveDatasetLoading ? <LuCheck /> : null}
+            onPress={() => _onSaveDataset("save")}
             isLoading={saveDatasetLoading}
             isDisabled={!dataset?.id || dataset?.DataRequests?.length === 0}
           >
@@ -273,7 +407,14 @@ function Dataset() {
 
       <DatasetQuery onUpdateDataset={_onUpdateDataset} />
 
-      <Modal isOpen={draftSaveModalOpen} onClose={() => setDraftSaveModalOpen(false)} size="2xl">
+      <Modal
+        isOpen={draftSaveModalOpen}
+        onClose={() => {
+          setDraftSaveModalOpen(false);
+          setDraftSaveIntent("save");
+        }}
+        size="2xl"
+      >
         <ModalContent>
           <ModalHeader>Save dataset</ModalHeader>
           <ModalBody>
@@ -314,7 +455,10 @@ function Dataset() {
           <ModalFooter>
             <Button
               variant="bordered"
-              onPress={() => setDraftSaveModalOpen(false)}
+              onPress={() => {
+                setDraftSaveModalOpen(false);
+                setDraftSaveIntent("save");
+              }}
             >
               Cancel
             </Button>
@@ -322,9 +466,13 @@ function Dataset() {
               color="primary"
               isLoading={saveDatasetLoading}
               onPress={async () => {
-                const success = await _persistDataset(selectedProjectIds);
+                const success = await _persistDataset(
+                  selectedProjectIds,
+                  draftSaveIntent === "createChart" ? "createChart" : "save",
+                );
                 if (success) {
                   setDraftSaveModalOpen(false);
+                  setDraftSaveIntent("save");
                 }
               }}
             >
@@ -333,6 +481,74 @@ function Dataset() {
           </ModalFooter>
         </ModalContent>
       </Modal>
+
+      <Modal
+        isOpen={createChartModalOpen}
+        onClose={() => {
+          setCreateChartModalOpen(false);
+          setCreateChartSelectedProjectKey(null);
+          setCreateChartSubmitAttempted(false);
+        }}
+        size="2xl"
+      >
+        <ModalContent>
+          <ModalHeader>Create a chart from this dataset</ModalHeader>
+          <ModalBody>
+            <div className="text-sm text-foreground-500">
+              Pick the dashboard (project) where this chart should be added. A new chart will be created and linked to this dataset.
+            </div>
+            <Spacer y={2} />
+            <Autocomplete
+              label="Dashboard"
+              placeholder="Search or select a dashboard"
+              labelPlacement="outside"
+              isRequired
+              selectedKey={createChartSelectedProjectKey}
+              onSelectionChange={(key) => {
+                setCreateChartSelectedProjectKey(key);
+                setCreateChartSubmitAttempted(false);
+              }}
+              isInvalid={createChartSubmitAttempted && !createChartSelectedProjectKey}
+              errorMessage={
+                createChartSubmitAttempted && !createChartSelectedProjectKey
+                  ? "Select a dashboard to continue."
+                  : undefined
+              }
+              aria-label="Dashboard for new chart"
+            >
+              {projects.filter((project) => !project.ghost).map((project) => (
+                <AutocompleteItem key={String(project.id)} textValue={project.name}>
+                  {project.name}
+                </AutocompleteItem>
+              ))}
+            </Autocomplete>
+            {projects.filter((project) => !project.ghost).length === 0 && (
+              <div className="text-sm text-foreground-400 mt-2">No projects available yet.</div>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="bordered"
+              onPress={() => {
+                setCreateChartModalOpen(false);
+                setCreateChartSelectedProjectKey(null);
+                setCreateChartSubmitAttempted(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="primary"
+              isLoading={createChartFromDatasetLoading}
+              isDisabled={projects.filter((project) => !project.ghost).length === 0}
+              onPress={_onCreateChartFromDataset}
+            >
+              Create chart
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
     </div>
   );
 }

--- a/client/src/containers/Dataset/Dataset.jsx
+++ b/client/src/containers/Dataset/Dataset.jsx
@@ -2,73 +2,59 @@ import React, { useState, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import toast from "react-hot-toast";
 import {
-  Button, Link, Spacer, Input, Modal, ModalHeader, ModalBody, ModalFooter, ModalContent, Chip,
-  Checkbox,
-  Tabs,
-  Tab,
+  Button, Chip, Input, Link, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Spacer,
 } from "@heroui/react";
-import { LuArrowRight, LuChartArea, LuCheck, LuLayers, LuPencil, LuSearch } from "react-icons/lu";
+import { LuCheck, LuPencil } from "react-icons/lu";
 import { useLocation, useNavigate, useParams } from "react-router";
 
-import { createCdc, createChart, runQuery } from "../../slices/chart";
-import { getDataset, runRequest, saveNewDataset, updateDataset } from "../../slices/dataset";
+import { createCdc, runQuery, updateChart } from "../../slices/chart";
+import { getDataset, saveNewDataset, updateDataset } from "../../slices/dataset";
 import { getTeamConnections } from "../../slices/connection";
 import DatasetQuery from "./DatasetQuery";
-import DatasetBuilder from "./DatasetBuilder";
-import { getProjects, selectProjects } from "../../slices/project";
 import { chartColors } from "../../config/colors";
-import getDashboardLayout from "../../modules/getDashboardLayout";
-import { placeNewWidget } from "../../modules/autoLayout";
 import useQuery from "../../modules/useQuery";
 import { selectUser } from "../../slices/user";
 import { getTeams, selectTeam } from "../../slices/team";
-import canAccess from "../../config/canAccess";
+import { getProjects, selectProjects } from "../../slices/project";
+import getDatasetDisplayName from "../../modules/getDatasetDisplayName";
 
 function Dataset() {
   const [error, setError] = useState(null);
-  const [legend, setLegend] = useState("");
-  const [editLegend, setEditLegend] = useState(false);
-  const [datasetMenu, setDatasetMenu] = useState("query");
-  const [chart, setChart] = useState(null);
-  const [completeModal, setCompleteModal] = useState(false);
-  const [completeProjects, setCompleteProjects] = useState([]);
-  const [projectSearch, setProjectSearch] = useState("");
-  const [completeDatasetLoading, setCompleteDatasetLoading] = useState(false);
-  const [fromChart, setFromChart] = useState("");
-  const [shouldTagProjects, setShouldTagProjects] = useState(true);
+  const [datasetName, setDatasetName] = useState("");
+  const [editDatasetName, setEditDatasetName] = useState(false);
+  const [saveDatasetLoading, setSaveDatasetLoading] = useState(false);
+  const [fromChart, setFromChart] = useState(null);
+  const [draftSaveModalOpen, setDraftSaveModalOpen] = useState(false);
+  const [selectedProjectIds, setSelectedProjectIds] = useState([]);
 
   const params = useParams();
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { search } = useLocation();
-  const initRef = useRef(null);
-  const datasetInitRef = useRef(null);
-  const chartInitRef = useRef(null);
   const createInitRef = useRef(null);
   const query = useQuery();
 
   const dataset = useSelector((state) => state.dataset.data.find((d) => `${d.id}` === `${params.datasetId}`));
-  const ghostProject = useSelector((state) => state.project.data?.find((p) => p.ghost));
-  const ghostChart = useSelector((state) => state.chart.data?.find((c) => c.id === chart?.id));
   const projects = useSelector(selectProjects);
   const user = useSelector(selectUser);
   const team = useSelector(selectTeam);
 
   useEffect(() => {
     async function fetchData() {
-      dispatch(getDataset({
-        team_id: team.id,
-        dataset_id: params.datasetId,
-      }));
-      dispatch(getTeamConnections({ team_id: team.id }));
+      if (params.datasetId !== "new") {
+        dispatch(getDataset({
+          team_id: team.id,
+          dataset_id: params.datasetId,
+        }));
+      }
       dispatch(getProjects({ team_id: team.id }));
+      dispatch(getTeamConnections({ team_id: team.id }));
     }
 
-    if (team?.id && !initRef.current) {
-      initRef.current = true;
+    if (team?.id) {
       fetchData();
     }
-  }, [team]);
+  }, [dispatch, params.datasetId, team?.id]);
 
   useEffect(() => {
     if (user?.id && !team) {
@@ -77,30 +63,28 @@ function Dataset() {
   }, [user]);
 
   useEffect(() => {
-    if (user?.id && team?.id) {
-      if (!canAccess("projectAdmin", user.id, team.TeamRoles)) {
-        setDatasetMenu("configure");
+    if (dataset?.id) {
+      setDatasetName(getDatasetDisplayName(dataset));
+      const chartProjectId = query.get("project_id");
+      const datasetProjectIds = dataset.project_ids || [];
+
+      if (datasetProjectIds.length > 0) {
+        setSelectedProjectIds(datasetProjectIds);
+      } else if (chartProjectId && (fromChart === "create" || fromChart === "edit")) {
+        setSelectedProjectIds([parseInt(chartProjectId, 10)]);
+      } else {
+        setSelectedProjectIds([]);
       }
     }
-  }, [user, team]);
+  }, [dataset?.id, dataset?.project_ids, fromChart, query]);
 
   useEffect(() => {
-    if (!dataset) {
-      return;
-    }
-
-    if (!datasetInitRef.current) {
-      datasetInitRef.current = true;
-      setLegend(dataset.legend);
-    }
-  }, [dataset]);
-
-  useEffect(() => {
-    if (params.datasetId === "new" && !createInitRef.current) {
+    if (params.datasetId === "new" && team?.id && !createInitRef.current) {
       createInitRef.current = true;
       dispatch(saveNewDataset({
         team_id: team.id,
         data: {
+          name: "New dataset",
           legend: "New dataset",
           team_id: team.id,
           draft: true,
@@ -119,48 +103,7 @@ function Dataset() {
           }
         });
     }
-  }, [params]);
-
-  useEffect(() => {
-    if (ghostProject?.id && !chart && dataset?.id && !chartInitRef.current) {
-      chartInitRef.current = true;
-      dispatch(createChart({
-        project_id: ghostProject.id,
-        data: {
-          name: dataset.legend,
-          type: "line",
-          subType: "timeseries",
-        },
-      }))
-        .then((data) => {
-          setChart(data.payload);
-          const cdcData = {
-            ...dataset,
-            dataset_id: dataset.id,
-            datasetColor: chartColors.blue.hex,
-            fill: false,
-            order: 0,
-          };
-          delete cdcData.id;
-
-          dispatch(createCdc({
-            project_id: data.payload.project_id,
-            chart_id: data.payload.id,
-            data: cdcData,
-          }))
-        });
-    }
-  }, [ghostProject, dataset]);
-
-  useEffect(() => {
-    if (datasetMenu === "configure" && dataset?.id && team?.id) {
-      dispatch(runRequest({
-        team_id: team.id,
-        dataset_id: dataset.id,
-        getCache: true,
-      }));
-    }
-  }, [datasetMenu, team]);
+  }, [params, team?.id]);
 
   useEffect(() => {
     let message = error;
@@ -175,14 +118,12 @@ function Dataset() {
 
   useEffect(() => {
     if (query) {
-      if (query.has("create") && query.has("chart_id") && query.has("project_id")) {
+      if (query.has("chart_id") && query.has("project_id") && query.has("create")) {
         setFromChart("create");
-      }
-      if (!query.has("create") && query.has("chart_id") && query.has("project_id")) {
+      } else if (query.has("chart_id") && query.has("project_id")) {
         setFromChart("edit");
-      }
-      if (query.has("editFilters")) {
-        setDatasetMenu("configure");
+      } else {
+        setFromChart(null);
       }
     }
   }, [query]);
@@ -203,328 +144,194 @@ function Dataset() {
       });
   };
 
-  const _onSelectCompleteProject = (projectId) => {
-    setCompleteProjects((prev) => {
-      if (prev.includes(projectId)) {
-        return prev.filter((p) => p !== projectId);
-      }
-      return [...prev, projectId];
-    });
-  };
+  const _persistDataset = async (projectIds = dataset?.project_ids || []) => {
+    if (!dataset?.id || !team?.id) return false;
 
-  const _onSaveDataset = () => {
-    if (fromChart === "edit") {
-      navigate(`/dashboard/${query.get("project_id")}/chart/${query.get("chart_id")}/edit`);
-      return;
-    }
+    const trimmedName = datasetName.trim() || getDatasetDisplayName(dataset) || "Untitled dataset";
+    setSaveDatasetLoading(true);
 
-    setCompleteModal(true);
-  }
-
-  const _onCompleteDataset = () => {
-    setCompleteDatasetLoading(true);
-    const datasetData = {
-      team_id: team.id,
-      dataset_id: dataset.id,
-      data: {
-        draft: false,
-        legend,
-      },
-    };
-
-    if (shouldTagProjects && completeProjects.length > 0) {
-      datasetData.data.project_ids = completeProjects;
-    }
-
-    dispatch(updateDataset(datasetData));
-
-    let ghostCdc = ghostChart?.ChartDatasetConfigs?.[0] || {};
-    let cdcData = { ...dataset, ...ghostCdc, legend };
-    delete cdcData.id;
-
-    if (fromChart === "create") {
-      dispatch(createCdc({
-        project_id: query.get("project_id"),
-        chart_id: query.get("chart_id"),
+    try {
+      await dispatch(updateDataset({
+        team_id: team.id,
+        dataset_id: dataset.id,
         data: {
-          ...cdcData,
-          dataset_id: dataset.id,
-          datasetColor: chartColors.blue.hex,
+          draft: false,
+          name: trimmedName,
+          legend: trimmedName,
+          project_ids: projectIds,
         },
-      }))
-        .then((cdcData) => {
-          navigate(`/dashboard/${query.get("project_id")}/chart/${query.get("chart_id")}/edit`);          
-          dispatch(runQuery({
-            project_id: query.get("project_id"),
-            chart_id: cdcData.payload.chart_id,
+      })).unwrap();
+
+      if (fromChart === "create") {
+        const chartId = query.get("chart_id");
+        const projectId = query.get("project_id");
+
+        await dispatch(updateChart({
+          project_id: projectId,
+          chart_id: chartId,
+          data: { name: trimmedName },
+        })).unwrap();
+
+        await dispatch(createCdc({
+          project_id: projectId,
+          chart_id: chartId,
+          data: {
+            dataset_id: dataset.id,
+            legend: trimmedName,
+            datasetColor: chartColors.blue.hex,
+            fill: false,
+            order: 0,
+          },
+        })).unwrap();
+
+        try {
+          await dispatch(runQuery({
+            project_id: projectId,
+            chart_id: chartId,
             noSource: false,
             skipParsing: false,
             getCache: true,
-          }));
-        });
+          })).unwrap();
+        } catch (queryError) {
+          // The chart editor can recover from a failed first run.
+        }
+
+        navigate(`/dashboard/${projectId}/chart/${chartId}/edit`);
+        return true;
+      }
+
+      if (fromChart === "edit") {
+        navigate(`/dashboard/${query.get("project_id")}/chart/${query.get("chart_id")}/edit`);
+        return true;
+      }
+
+      toast.success("Dataset saved");
+      setEditDatasetName(false);
+      return true;
+    } catch (saveError) {
+      setError(saveError);
+      toast.error("Could not save the dataset. Please try again.");
+      return false;
+    } finally {
+      setSaveDatasetLoading(false);
+    }
+  };
+
+  const _onSaveDataset = async () => {
+    if (dataset?.draft) {
+      setDraftSaveModalOpen(true);
       return;
     }
 
-    if (completeProjects.length === 0) {
-      navigate("/");
-      return;
-    }
+    await _persistDataset(selectedProjectIds);
+  };
 
-    let loadingCounter = 0;
-
-    completeProjects.forEach((projectId) => {
-      const currentProject = projects.find((p) => p.id === projectId);
-      // add chart at the end of the dashboard
-      const layouts = getDashboardLayout(currentProject.Charts);
-      const chartLayout = {};
-      Object.keys(layouts).map((bp) => {
-        const w = bp === "lg" ? 4 : bp === "md" ? 5 : bp === "sm" ? 3 : bp === "xs" ? 2 : 2;
-        const pos = placeNewWidget(layouts[bp] || [], { w, h: 2 }, bp);
-        chartLayout[bp] = [pos.x, pos.y, pos.w, pos.h];
-        return bp;
-      });
-
-      const newChart = {
-        ...ghostChart,
-        name: legend,
-        draft: false,
-        id: null,
-        layout: chartLayout,
-      };
-
-      dispatch(createChart({
-        project_id: projectId,
-        data: newChart,
-      }))
-        .then((actionData) => {
-          dispatch(createCdc({
-            project_id: projectId,
-            chart_id: actionData.payload.id,
-            data: {
-              ...cdcData,
-              dataset_id: dataset.id,
-              datasetColor: chartColors.blue.hex,
-            },
-          }))
-            .then((cdcData) => {
-              dispatch(runQuery({
-                project_id: projectId,
-                chart_id: cdcData.payload.chart_id,
-                noSource: false,
-                skipParsing: false,
-                getCache: true,
-              }));
-            });
-
-          loadingCounter += 1;
-          if (loadingCounter === completeProjects.length) {
-            setCompleteDatasetLoading(false);
-            if (completeProjects.length === 1) {
-              navigate(`/dashboard/${completeProjects[0]}`);
-            } else {
-              navigate("/");
-            }
-          }
-        })
-        .catch(() => {
-          loadingCounter += 1;
-          if (loadingCounter === completeProjects.length) {
-            setCompleteDatasetLoading(false);
-            if (completeProjects.length === 1) {
-              toast.error("Could not create chart. Please try again");
-              setCompleteModal(false);
-            } else {
-              navigate("/");
-            }
-          }
-        });
-    });
+  const _toggleProjectTag = (projectId) => {
+    setSelectedProjectIds((prev) => (
+      prev.includes(projectId)
+        ? prev.filter((id) => id !== projectId)
+        : [...prev, projectId]
+    ));
   };
 
   return (
     <div>
       <div className="flex flex-row justify-between flex-wrap gap-2 items-center bg-background px-4 rounded-lg border-1 border-divider py-2">
         <div className="flex flex-row gap-2 items-center">
-          {!editLegend && (
+          {!editDatasetName && (
             <>
-              <Link onClick={() => setEditLegend(true)} className="text-default-500 cursor-pointer flex flex-row items-center gap-2">
-                <div className="font-tw font-bold text-foreground">{dataset?.legend}</div>
+              <Link onClick={() => setEditDatasetName(true)} className="text-default-500 cursor-pointer flex flex-row items-center gap-2">
+                <div className="font-tw font-bold text-foreground">{getDatasetDisplayName(dataset)}</div>
                 <LuPencil size={16} className="text-secondary" />
               </Link>
             </>
           )}
 
-          {editLegend && (
+          {editDatasetName && (
             <>
               <Input
-                value={legend}
-                onChange={(e) => setLegend(e.target.value)}
+                value={datasetName}
+                onChange={(e) => setDatasetName(e.target.value)}
                 placeholder="Dataset name"
                 variant="bordered"
                 labelPlacement="outside"
               />
-              <Button
-                variant="ghost"
-                isIconOnly
-                color="primary"
-                onPress={() => {
-                  _onUpdateDataset({ legend });
-                  setEditLegend(false);
-                }}
-                size="sm"
-              >
-                <LuCheck />
-              </Button>
             </>
           )}
         </div>
 
         <div className="flex flex-row gap-2 flex-wrap">
-          <Tabs
-            selectedKey={datasetMenu}
-            onSelectionChange={(key) => setDatasetMenu(key)}
+          <Button
+            color="primary"
+            onPress={_onSaveDataset}
+            endContent={!saveDatasetLoading ? <LuCheck /> : null}
+            isLoading={saveDatasetLoading}
+            isDisabled={!dataset?.id || dataset?.DataRequests?.length === 0}
           >
-            {canAccess("projectAdmin", user.id, team.TeamRoles) && (
-              <Tab key="query" title={(
-                <div className="flex flex-row items-center gap-2">
-                  <LuLayers size={18} />
-                  <span>1. Query</span>
-                </div>
-              )} />
-            )}
-            {canAccess("projectEditor", user.id, team.TeamRoles) && (
-              <Tab key="configure" title={(
-                <div className="flex flex-row items-center gap-2">
-                  <LuChartArea size={18} />
-                  <span>2. Configure</span>
-                </div>
-              )} />
-            )}
-          </Tabs>
-          {datasetMenu === "query" && (
-            <Button
-              color="primary"
-              // size="sm"
-              onPress={() => setDatasetMenu("configure")}
-              endContent={<LuArrowRight />}
-              isDisabled={dataset?.DataRequests.length === 0}
-            >
-              Configure dataset
-            </Button>
-          )}
-          {datasetMenu === "configure" && (
-            <Button
-              color="primary"
-              onPress={() => _onSaveDataset()}
-              endContent={<LuCheck />}
-              isDisabled={dataset?.DataRequests.length === 0}
-            >
-              {fromChart === "edit" && "Save & return to chart"}
-              {fromChart !== "edit" && "Complete dataset"}
-            </Button>
-          )}
+            {fromChart ? "Save & return to chart" : "Save dataset"}
+          </Button>
         </div>
       </div>
 
-      {datasetMenu === "query" && (
-        <DatasetQuery onUpdateDataset={_onUpdateDataset} />
-      )}
+      <DatasetQuery onUpdateDataset={_onUpdateDataset} />
 
-      {datasetMenu === "configure" && ghostChart && (
-        <DatasetBuilder
-          chart={ghostChart}
-          projectId={ghostProject?.id}
-        />
-      )}
-
-      <Modal
-        isOpen={completeModal}
-        onClose={() => setCompleteModal(false)}
-        size="2xl"
-      >
+      <Modal isOpen={draftSaveModalOpen} onClose={() => setDraftSaveModalOpen(false)} size="2xl">
         <ModalContent>
-          <ModalHeader>Complete your dataset</ModalHeader>
+          <ModalHeader>Save dataset</ModalHeader>
           <ModalBody>
-            <div>Enter a name for your dataset</div>
             <Input
+              value={datasetName}
+              onChange={(event) => setDatasetName(event.target.value)}
+              placeholder="Dataset name"
+              label="Dataset name"
               labelPlacement="outside"
-              value={legend}
-              onChange={(e) => setLegend(e.target.value)}
-              variant="bordered"
-              className="max-w-[300px]"
             />
-            <Spacer y={1} />
 
-            {fromChart !== "create" && (
-              <>
-                <div>Want to add this chart to a dashboard?</div>
-                {projects.length > 5 && (
-                  <Input
-                    labelPlacement="outside"
-                    placeholder="Search projects"
-                    startContent={<LuSearch />}
-                    variant="bordered"
-                    className="max-w-[300px]"
-                    onChange={(e) => setProjectSearch(e.target.value)}
-                    onClear={() => setProjectSearch("")}
-                    value={projectSearch}
-                    isClearable
-                  />
+            <Spacer y={2} />
+
+            <div className="flex flex-col gap-2">
+              <div className="text-sm font-medium text-foreground">Tags</div>
+              <div className="text-sm text-foreground-500">
+                Assign dashboard tags now, or leave this empty and add them later.
+              </div>
+              <div className="flex flex-row flex-wrap gap-2">
+                {projects.filter((project) => !project.ghost).map((project) => (
+                  <Chip
+                    key={project.id}
+                    radius="sm"
+                    color={selectedProjectIds.includes(project.id) ? "primary" : "default"}
+                    variant={selectedProjectIds.includes(project.id) ? "solid" : "bordered"}
+                    onClick={() => _toggleProjectTag(project.id)}
+                    className="cursor-pointer"
+                  >
+                    {project.name}
+                  </Chip>
+                ))}
+                {projects.filter((project) => !project.ghost).length === 0 && (
+                  <div className="text-sm text-foreground-400">No tags available yet.</div>
                 )}
-                <div className="flex flex-row flex-wrap gap-1">
-                  {projects.filter((p) => p.name.toLowerCase().indexOf(projectSearch.toLowerCase()) > -1 && !p.ghost).map((p) => (
-                    <Chip
-                      key={p.id}
-                      radius="sm"
-                      color={completeProjects.includes(p.id) ? "primary" : "default"}
-                      variant={completeProjects.includes(p.id) ? "solid" : "bordered"}
-                      onClick={() => _onSelectCompleteProject(p.id)}
-                      className="cursor-pointer hover:shadow-md hover:saturate-150 transition-shadow"
-                    >
-                      {p.name}
-                    </Chip>
-                  ))}
-                </div>
-              </>
-            )}
+              </div>
+            </div>
           </ModalBody>
           <ModalFooter>
-            {completeProjects.length > 0 && (
-              <Checkbox
-                isSelected={shouldTagProjects}
-                onValueChange={(selected) => setShouldTagProjects(selected)}
-                size="sm"
-              >
-                Tag dataset to projects
-              </Checkbox>
-            )}
             <Button
               variant="bordered"
-              onPress={() => setCompleteModal(false)}
-              size="sm"
+              onPress={() => setDraftSaveModalOpen(false)}
             >
-              Close
+              Cancel
             </Button>
-            {fromChart !== "create" && (
-              <Button
-                color="primary"
-                onPress={_onCompleteDataset}
-                isLoading={completeDatasetLoading}
-                size="sm"
-              >
-                {completeProjects.length > 0 ? "Save dataset & create chart" : "Save dataset"}
-              </Button>
-            )}
-            {fromChart === "create" && (
-              <Button
-                color="primary"
-                onPress={_onCompleteDataset}
-                isLoading={completeDatasetLoading}
-                size="sm"
-              >
-                Save & return to chart
-              </Button>
-            )}
+            <Button
+              color="primary"
+              isLoading={saveDatasetLoading}
+              onPress={async () => {
+                const success = await _persistDataset(selectedProjectIds);
+                if (success) {
+                  setDraftSaveModalOpen(false);
+                }
+              }}
+            >
+              {fromChart ? "Save & return to chart" : "Save dataset"}
+            </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/client/src/containers/Dataset/Dataset.jsx
+++ b/client/src/containers/Dataset/Dataset.jsx
@@ -85,7 +85,6 @@ function Dataset() {
         team_id: team.id,
         data: {
           name: "New dataset",
-          legend: "New dataset",
           team_id: team.id,
           draft: true,
         },
@@ -157,7 +156,6 @@ function Dataset() {
         data: {
           draft: false,
           name: trimmedName,
-          legend: trimmedName,
           project_ids: projectIds,
         },
       })).unwrap();
@@ -291,8 +289,8 @@ function Dataset() {
 
             <div className="flex flex-col gap-2">
               <div className="text-sm font-medium text-foreground">Tags</div>
-              <div className="text-sm text-foreground-500">
-                Assign dashboard tags now, or leave this empty and add them later.
+              <div className="text-xs text-foreground-500">
+                Assign dashboard tags now, or leave this empty and add them later. Dashboard tags make it easier to find this dataset in the future.
               </div>
               <div className="flex flex-row flex-wrap gap-2">
                 {projects.filter((project) => !project.ghost).map((project) => (

--- a/client/src/containers/Dataset/DatasetQuery.jsx
+++ b/client/src/containers/Dataset/DatasetQuery.jsx
@@ -7,7 +7,7 @@ import {
   Tab,
   Image,
 } from "@heroui/react";
-import { LuBrainCircuit, LuGitMerge, LuPlug, LuPlus, LuSearch, LuX } from "react-icons/lu";
+import { LuArrowLeft, LuBrainCircuit, LuGitMerge, LuLayers, LuPlus, LuSearch, LuX } from "react-icons/lu";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 import { cloneDeep, findIndex } from "lodash";
@@ -39,10 +39,11 @@ import { selectTeam } from "../../slices/team";
 function DatasetQuery(props) {
   const { onUpdateDataset } = props;
 
-  const [selectedRequest, setSelectedRequest] = useState({ isSettings: true });
+  const [selectedRequest, setSelectedRequest] = useState({});
   const [createMode, setCreateMode] = useState(false);
   const [dataRequests, setDataRequests] = useState([]);
   const [connectionSearch, setConnectionSearch] = useState("");
+  const [selectedTab, setSelectedTab] = useState("queryBuilder");
 
   const { isDark } = useTheme();
   const theme = isDark ? "dark" : "light";
@@ -68,10 +69,10 @@ function DatasetQuery(props) {
         .then((drs) => {
           if (drs.payload?.length > 1) {
             setDataRequests(drs.payload);
-            setSelectedRequest({ isSettings: true });
+            setSelectedRequest(drs.payload[0] || {});
           } else if (drs.payload?.length === 1) {
             setDataRequests(drs.payload);
-            setSelectedRequest(drs.payload[0]);
+            setSelectedRequest(drs.payload[0] || {});
             setCreateMode(false);
           }
 
@@ -220,14 +221,6 @@ function DatasetQuery(props) {
     }
   };
 
-  const _onSelectSettings = () => {
-    if (dataRequests.length === 0) {
-      toast.info("You need to create a data request first.");
-      return;
-    }
-    setSelectedRequest({ isSettings: true });
-  };
-
   const _filteredConnections = () => {
     if (connectionSearch.length > 0) {
       return connections.filter((c) => c?.name?.toLowerCase().includes(connectionSearch.toLowerCase()));
@@ -250,10 +243,6 @@ function DatasetQuery(props) {
   };
 
   const _getSelectedTab = () => {
-    if (selectedRequest?.isSettings) {
-      return dataRequests[0]?.id ?? "add";
-    }
-
     if (createMode) {
       return "add";
     }
@@ -265,62 +254,93 @@ function DatasetQuery(props) {
     return "add";
   };
 
+  const _getJoinSettingsJoinCount = () => dataset?.joinSettings?.joins?.length || 0;
+
+  const _hasJoinConfiguration = () => {
+    const joins = dataset?.joinSettings?.joins;
+    if (!joins?.length) return false;
+    return joins.some(
+      (j) => j.join_id != null && String(j.dr_field || "").trim() !== "" && String(j.join_field || "").trim() !== ""
+    );
+  };
+
+  const _isMainDataRequest = (dr) => {
+    if (dataset?.main_dr_id == null || !dr?.id) return false;
+    return `${dataset.main_dr_id}` === `${dr.id}`;
+  };
+
+  const _isDataRequestInJoin = (dr) => {
+    const joins = dataset?.joinSettings?.joins;
+    if (!joins?.length || dr?.id == null) return false;
+    return joins.some(
+      (j) =>
+        (j.dr_id != null && `${j.dr_id}` === `${dr.id}`) ||
+        (j.join_id != null && `${j.join_id}` === `${dr.id}`)
+    );
+  };
+
+  const _renderDataRequestTabChip = (dr) => {
+    if (_isMainDataRequest(dr)) {
+      return (
+        <Chip size="sm" variant="flat" color="primary" radius="sm">
+          main
+        </Chip>
+      );
+    }
+    if (_isDataRequestInJoin(dr)) {
+      return (
+        <Chip size="sm" variant="flat" color="success" radius="sm">
+          joined
+        </Chip>
+      );
+    }
+    return (
+      <Chip size="sm" variant="flat" color="warning" radius="sm">
+        needs config
+      </Chip>
+    );
+  };
+
   return (
     <>
       <div className="h-full py-2 overflow-y-auto flex flex-col gap-2">
-        <div className="flex flex-row items-center justify-start gap-2">
-          {dataRequests && dataRequests.length > 0 && (
-            <>
-              <Button
-                variant={selectedRequest?.isSettings ? "flat" : "bordered"}
-                color={selectedRequest?.isSettings ? "primary" : "default"}
-                className="h-9 min-w-unit-16"
-                onPress={() => _onSelectSettings()}
-                startContent={<LuGitMerge size={16} />}
-              >
-                Join settings
-              </Button>
-              <LuPlug />
-              <Tabs
-                key={`sources-${_getSelectedTab()}`}
-                defaultSelectedKey={_getSelectedTab()}
-                variant="bordered"
-              >
-                {dataRequests.map((dr) => (
-                  <Tab
-                    key={dr.id}
-                    title={(
-                      <div className="flex flex-row items-center gap-2">
-                        <Image
-                          src={connectionImages(theme === "dark")[dr?.Connection?.subType || dr?.Connection?.type]}
-                          alt={`${dr?.Connection?.subType || dr?.Connection?.type} logo`}
-                          width={16}
-                          height={16}
-                          className="rounded-sm"
-                        />
-                        <span>{dr?.Connection?.name}</span>
-                      </div>
-                    )}
-                    onPress={() => _onSelectDataRequest(dr)}
-                  />
-                ))}
-                <Tab
-                  key="add"
-                  title={(
-                    <div className="flex flex-row items-center gap-2">
-                      <LuPlus size={16} />
-                      <span>Add a new data source</span>
-                    </div>
+        <div className="flex flex-row items-center">
+          <Tabs
+            variant="solid"
+            selectedKey={selectedTab}
+            onSelectionChange={(key) => {
+              setSelectedTab(key);
+              setCreateMode(false);
+            }}
+          >
+            <Tab
+              key="queryBuilder"
+              title={(
+                <div className="flex flex-row items-center gap-2">
+                  <LuLayers size={16} />
+                  <span>Query builder</span>
+                </div>
+              )}
+            />
+            <Tab
+              key="joinSettings"
+              title={(
+                <div className="flex flex-row items-center gap-2">
+                  <LuGitMerge size={16} />
+                  <span>Join settings</span>
+                  {_hasJoinConfiguration() && (
+                    <Chip size="sm" variant="flat" radius="sm">
+                      {`${_getJoinSettingsJoinCount()} join${_getJoinSettingsJoinCount() === 1 ? "" : "s"}`}
+                    </Chip>
                   )}
-                  onPress={() => setCreateMode(true)}
-                />
-              </Tabs>
-            </>
-          )}
+                </div>
+              )}
+            />
+          </Tabs>
         </div>
       </div>
       <div className="grid grid-cols-12">
-        {!createMode && selectedRequest?.isSettings && (
+        {!createMode && selectedTab === "joinSettings" && (
           <div className="col-span-12">
             <DatarequestSettings
               dataset={dataset}
@@ -329,8 +349,48 @@ function DatasetQuery(props) {
             />
           </div>
         )}
-        {!createMode && selectedRequest && !selectedRequest.isSettings && (
+        {!createMode && selectedTab === "queryBuilder" && (
           <div className="col-span-12 bg-background rounded-lg border-1 border-divider p-4">
+            {dataRequests && dataRequests.length > 0 && (
+              <div className="bg-content2 rounded-lg p-2">
+                <Tabs
+                  key={`sources-${_getSelectedTab()}`}
+                  defaultSelectedKey={_getSelectedTab()}
+                  variant="light"
+                >
+                  {dataRequests.map((dr) => (
+                    <Tab
+                      key={dr.id}
+                      title={(
+                        <div className="flex flex-row items-center gap-2">
+                          <Image
+                            src={connectionImages(theme === "dark")[dr?.Connection?.subType || dr?.Connection?.type]}
+                            alt={`${dr?.Connection?.subType || dr?.Connection?.type} logo`}
+                            width={20}
+                            height={20}
+                            className="rounded-sm border-1 border-divider"
+                          />
+                          <span>{dr?.Connection?.name}</span>
+                          {_renderDataRequestTabChip(dr)}
+                        </div>
+                      )}
+                      onPress={() => _onSelectDataRequest(dr)}
+                    />
+                  ))}
+                  <Tab
+                    key="add"
+                    title={(
+                      <div className="flex flex-row items-center gap-2">
+                        <LuPlus size={16} />
+                        <span>Add data request</span>
+                      </div>
+                    )}
+                    onPress={() => setCreateMode(true)}
+                  />
+                </Tabs>
+              </div>
+            )}
+            <Spacer y={4} />
             {dataRequests.map((dr) => (
               <Fragment key={dr.id}>
                 {selectedRequest.Connection?.type === "api" && selectedRequest.id === dr.id && (
@@ -425,9 +485,14 @@ function DatasetQuery(props) {
           </div>
         )}
         {createMode && (
-          <div className="col-span-12 md:col-span-12 w-full max-w-(--breakpoint-2xl) mx-auto pb-20">
+          <div className="col-span-12 md:col-span-12 w-full max-w-(--breakpoint-2xl) mx-auto pb-20 bg-background rounded-lg border-1 border-divider p-4">
             <Spacer y={1} />
-            <div className="text-lg font-tw font-semibold">Select a connection</div>
+            <div className="flex flex-row items-center gap-2">
+              <Button variant="flat" isIconOnly onPress={() => setCreateMode(false)} size="sm">
+                <LuArrowLeft size={16} />
+              </Button>
+              <div className="text-lg font-tw font-semibold">Select a connection</div>
+            </div>
             <Spacer y={2} />
             {connections.length > 0 && (
               <div>

--- a/client/src/containers/Dataset/DatasetQuery.jsx
+++ b/client/src/containers/Dataset/DatasetQuery.jsx
@@ -363,13 +363,13 @@ function DatasetQuery(props) {
                       key={dr.id}
                       title={(
                         <div className="flex flex-row items-center gap-2">
-                          <Image
-                            src={connectionImages(theme === "dark")[dr?.Connection?.subType || dr?.Connection?.type]}
-                            alt={`${dr?.Connection?.subType || dr?.Connection?.type} logo`}
-                            width={20}
-                            height={20}
-                            className="rounded-sm border-1 border-divider"
-                          />
+                          <div className="w-6 h-6">
+                            <Image
+                              src={connectionImages(theme === "dark")[dr?.Connection?.subType || dr?.Connection?.type]}
+                              alt={`${dr?.Connection?.subType || dr?.Connection?.type} logo`}
+                              className="rounded-sm border-1 border-divider"
+                            />
+                          </div>
                           <span>{dr?.Connection?.name}</span>
                           {_renderDataRequestTabChip(dr)}
                         </div>

--- a/client/src/containers/Dataset/DatasetQuery.jsx
+++ b/client/src/containers/Dataset/DatasetQuery.jsx
@@ -486,8 +486,8 @@ function DatasetQuery(props) {
                       isHoverable
                       onPress={() => _onCreateNewRequest(c)}
                       fullWidth
-                      shadow="sm"
-                      className="h-full"
+                      shadow="none"
+                      className="h-full border-1 border-solid border-content3"
                     >
                       <CardBody className="p-4 pl-unit-8">
                         <div className="flex flex-row items-center justify-between">

--- a/client/src/containers/EmbeddedChart.jsx
+++ b/client/src/containers/EmbeddedChart.jsx
@@ -31,6 +31,7 @@ import useChartSize from "../modules/useChartSize";
 import { useTheme } from "../modules/ThemeContext";
 import MatrixChart from "./Chart/components/MatrixChart";
 import GaugeChart from "./Chart/components/GaugeChart";
+import { getExposedChartFilters } from "../modules/getChartDatasetConditions";
 
 const pageHeight = window.innerHeight;
 
@@ -211,14 +212,7 @@ function EmbeddedChart() {
   };
 
   const _checkIfFilters = () => {
-    let filterCount = 0;
-    chart.ChartDatasetConfigs.forEach((cdc) => {
-      if (Array.isArray(cdc.Dataset?.conditions)) {
-        filterCount += cdc.Dataset.conditions.filter((c) => c.exposed).length;
-      }
-    });
-
-    return filterCount > 0;
+    return getExposedChartFilters(chart).length > 0;
   };
 
   if ((loading || !chart || !showChart) && !error) {

--- a/client/src/containers/ProjectDashboard/ProjectDashboard.jsx
+++ b/client/src/containers/ProjectDashboard/ProjectDashboard.jsx
@@ -48,6 +48,7 @@ import { selectProjectMembers, selectTeam } from "../../slices/team";
 import { cols, margin, widthSize } from "../../modules/layoutBreakpoints";
 import { completeTutorial, selectUser } from "../../slices/user";
 import UpdateSchedule from "./components/UpdateSchedule";
+import { getChartIdentifiedConditions } from "../../modules/getChartDatasetConditions";
 import { exportMultipleChartsToExcel, canExportChart } from "../../modules/exportChart";
 import { selectProject } from "../../slices/project";
 import SharingSettings from "../PublicDashboard/components/SharingSettings";
@@ -526,12 +527,7 @@ function ProjectDashboard() {
     
     chartsToProcess.forEach((chart) => {
       // Get all conditions from the chart's datasets to calculate the processed filters
-      let identifiedConditions = [];
-      chart.ChartDatasetConfigs.forEach((cdc) => {
-        if (Array.isArray(cdc.Dataset?.conditions)) {
-          identifiedConditions = [...identifiedConditions, ...cdc.Dataset.conditions];
-        }
-      });
+      const identifiedConditions = getChartIdentifiedConditions(chart);
 
       // Separate filters by type
       const variableFilters = currentFilters[projectId].filter(f => f.type === "variable" && f.value);

--- a/client/src/containers/ProjectDashboard/components/DateRangeFilter.jsx
+++ b/client/src/containers/ProjectDashboard/components/DateRangeFilter.jsx
@@ -10,7 +10,7 @@ function DateRangeFilter({
   endDate,
   onChange,
   className = "",
-  variant = "bordered",
+  variant = "",
   size = "sm",
   isEdit = false,
 }) {
@@ -122,7 +122,8 @@ function DateRangeFilter({
 
   return (
     <DateRangePicker
-      variant={variant}
+      variant="faded"
+      color="primary"
       visibleMonths={2}
       value={currentValue}
       calendarProps={{
@@ -130,7 +131,6 @@ function DateRangeFilter({
         autoFocus: true,
       }}
       onChange={_handleDateRangeChange}
-      color="primary"
       aria-label="Select a date range"
       size={size}
       className={className}

--- a/client/src/containers/ProjectDashboard/components/DateRangeFilter.jsx
+++ b/client/src/containers/ProjectDashboard/components/DateRangeFilter.jsx
@@ -10,7 +10,6 @@ function DateRangeFilter({
   endDate,
   onChange,
   className = "",
-  variant = "",
   size = "sm",
   isEdit = false,
 }) {

--- a/client/src/containers/PublicDashboard/PublicDashboard.jsx
+++ b/client/src/containers/PublicDashboard/PublicDashboard.jsx
@@ -48,6 +48,7 @@ import { cols, margin, widthSize } from "../../modules/layoutBreakpoints";
 import { selectUser } from "../../slices/user";
 import DashboardFilters from "../ProjectDashboard/components/DashboardFilters";
 import useInterval from "../../modules/useInterval";
+import { getChartIdentifiedConditions } from "../../modules/getChartDatasetConditions";
 
 const ResponsiveGridLayout = WidthProvider(Responsive, { measureBeforeMount: true });
 
@@ -409,12 +410,7 @@ function PublicDashboard() {
         setFilterLoading(true);
         
         // Get all conditions from the chart's datasets
-        let identifiedConditions = [];
-        chart.ChartDatasetConfigs.forEach((cdc) => {
-          if (Array.isArray(cdc.Dataset?.conditions)) {
-            identifiedConditions = [...identifiedConditions, ...cdc.Dataset.conditions];
-          }
-        });
+        const identifiedConditions = getChartIdentifiedConditions(chart);
 
         // Separate filters by type
         const variableFilters = currentFilters[project.id].filter(f => f.type === "variable" && f.value);

--- a/client/src/containers/PublicDashboard/Report.jsx
+++ b/client/src/containers/PublicDashboard/Report.jsx
@@ -50,6 +50,7 @@ import { cols, margin, widthSize } from "../../modules/layoutBreakpoints";
 import { selectUser } from "../../slices/user";
 import DashboardFilters from "../ProjectDashboard/components/DashboardFilters";
 import useInterval from "../../modules/useInterval";
+import { getChartIdentifiedConditions } from "../../modules/getChartDatasetConditions";
 
 const ResponsiveGridLayout = WidthProvider(Responsive, { measureBeforeMount: true });
 
@@ -413,12 +414,7 @@ function Report({ editMode = false }) {
         setFilterLoading(true);
         
         // Get all conditions from the chart's datasets
-        let identifiedConditions = [];
-        chart.ChartDatasetConfigs.forEach((cdc) => {
-          if (Array.isArray(cdc.Dataset?.conditions)) {
-            identifiedConditions = [...identifiedConditions, ...cdc.Dataset.conditions];
-          }
-        });
+        const identifiedConditions = getChartIdentifiedConditions(chart);
 
         // Separate filters by type
         const variableFilters = currentFilters[project.id].filter(f => f.type === "variable" && f.value);

--- a/client/src/containers/SharedChart.jsx
+++ b/client/src/containers/SharedChart.jsx
@@ -36,6 +36,7 @@ import toast from "react-hot-toast";
 import { canExportChart, exportChartToExcel } from "../modules/exportChart";
 import GaugeChart from "./Chart/components/GaugeChart";
 import MatrixChart from "./Chart/components/MatrixChart";
+import { getExposedChartFilters } from "../modules/getChartDatasetConditions";
 
 const pageHeight = window.innerHeight;
 
@@ -217,14 +218,7 @@ function SharedChart() {
   };
 
   const _checkIfFilters = () => {
-    let filterCount = 0;
-    chart.ChartDatasetConfigs.forEach((cdc) => {
-      if (Array.isArray(cdc.Dataset?.conditions)) {
-        filterCount += cdc.Dataset.conditions.filter((c) => c.exposed).length;
-      }
-    });
-
-    return filterCount > 0;
+    return getExposedChartFilters(chart).length > 0;
   };
 
   const _onPublicExport = (chart) => {

--- a/client/src/containers/UserDashboard/ConnectionList.jsx
+++ b/client/src/containers/UserDashboard/ConnectionList.jsx
@@ -13,6 +13,7 @@ import { duplicateConnection, removeConnection, saveConnection, selectConnection
 import { useTheme } from "../../modules/ThemeContext"
 import { selectProjects } from "../../slices/project"
 import { selectDatasets } from "../../slices/dataset"
+import getDatasetDisplayName from "../../modules/getDatasetDisplayName"
 
 function ConnectionList() {
   const [connectionSearch, setConnectionSearch] = useState("");
@@ -318,7 +319,7 @@ function ConnectionList() {
                   variant="flat"
                   color="primary"
                 >
-                  {dataset.legend}
+                  {getDatasetDisplayName(dataset)}
                 </Chip>
               ))}
               {_getRelatedDatasets(connectionToDelete?.id).length > 10 && (

--- a/client/src/containers/UserDashboard/DatasetList.jsx
+++ b/client/src/containers/UserDashboard/DatasetList.jsx
@@ -13,6 +13,7 @@ import { useTheme } from "../../modules/ThemeContext";
 import canAccess from "../../config/canAccess";
 import { selectUser } from "../../slices/user";
 import { selectProjects } from "../../slices/project";
+import getDatasetDisplayName from "../../modules/getDatasetDisplayName";
 
 const DATASETS_PER_PAGE = 25;
 
@@ -73,7 +74,7 @@ function DatasetList() {
     return datasets.filter((dataset) => {
       // Search filter - check if search text is in legend
       const matchesSearch = !searchFilter.search ||
-        dataset.legend.toLowerCase().indexOf(searchFilter.search.toLowerCase()) > -1;
+        getDatasetDisplayName(dataset).toLowerCase().indexOf(searchFilter.search.toLowerCase()) > -1;
 
       // Project filter - check if dataset has the selected project in project_ids
       // Treat undefined/null as "all"
@@ -489,7 +490,7 @@ function DatasetList() {
                 <TableCell key="name">
                   <div className="flex flex-row items-center gap-2">
                     <Link to={`/datasets/${dataset.id}`} className="cursor-pointer">
-                      <span className="text-foreground font-medium">{dataset.legend}</span>
+                      <span className="text-foreground font-medium">{getDatasetDisplayName(dataset)}</span>
                     </Link>
                     {dataset.draft && (
                       <Chip size="sm" variant="flat" color="secondary">
@@ -586,7 +587,7 @@ function DatasetList() {
                           key="duplicate"
                           onPress={() => {
                             setDatasetToDuplicate(dataset);
-                            setDuplicateDatasetName(dataset.legend);
+                            setDuplicateDatasetName(getDatasetDisplayName(dataset));
                           }}
                           startContent={<LuCopy />}
                           textValue="Duplicate dataset"

--- a/client/src/modules/getChartDatasetConditions.js
+++ b/client/src/modules/getChartDatasetConditions.js
@@ -1,0 +1,42 @@
+export function getCdcConditions(cdc) {
+  if (Array.isArray(cdc?.conditions)) {
+    return cdc.conditions;
+  }
+
+  if (Array.isArray(cdc?.Dataset?.conditions)) {
+    return cdc.Dataset.conditions;
+  }
+
+  return [];
+}
+
+export function getChartIdentifiedConditions(chart) {
+  const conditions = [];
+
+  chart?.ChartDatasetConfigs?.forEach((cdc) => {
+    conditions.push(...getCdcConditions(cdc));
+  });
+
+  return conditions;
+}
+
+export function getExposedChartFilters(chart) {
+  const filters = [];
+
+  chart?.ChartDatasetConfigs?.forEach((cdc) => {
+    const conditions = getCdcConditions(cdc);
+
+    conditions.forEach((condition) => {
+      if (!condition.exposed) return;
+
+      filters.push({
+        ...condition,
+        Dataset: cdc.Dataset,
+        cdcId: cdc.id,
+        sourceConditions: conditions,
+      });
+    });
+  });
+
+  return filters;
+}

--- a/client/src/modules/getDatasetDisplayName.js
+++ b/client/src/modules/getDatasetDisplayName.js
@@ -1,0 +1,5 @@
+export default function getDatasetDisplayName(dataset) {
+  if (!dataset) return "";
+
+  return dataset.name || dataset.legend || "";
+}

--- a/client/src/modules/getDatasetFieldOptions.js
+++ b/client/src/modules/getDatasetFieldOptions.js
@@ -1,0 +1,59 @@
+import fieldFinder from "./fieldFinder";
+
+function createFieldOption(field, type, isObject = false) {
+  let text = field && field.replace("root[].", "").replace("root.", "");
+  if (type === "array") text += "(get element count)";
+
+  return {
+    key: field,
+    text,
+    value: field,
+    type,
+    isObject,
+    label: {
+      style: { width: 55, textAlign: "center" },
+      content: type || "unknown",
+      size: "mini",
+      color: type === "date" ? "secondary"
+        : type === "number" ? "primary"
+          : type === "string" ? "success"
+            : type === "boolean" ? "warning"
+              : "default",
+    },
+  };
+}
+
+export function getDatasetFieldOptionsFromResponse(datasetResponse) {
+  const fieldOptions = [];
+  const fieldsSchema = {};
+
+  const fields = fieldFinder(datasetResponse);
+  const objectFields = fieldFinder(datasetResponse, false, true);
+
+  fields.forEach((field) => {
+    if (field.field) {
+      fieldOptions.push(createFieldOption(field.field, field.type));
+    }
+    fieldsSchema[field.field] = field.type;
+  });
+
+  objectFields.forEach((field) => {
+    if (field.field) {
+      fieldOptions.push(createFieldOption(field.field, field.type, true));
+    }
+    fieldsSchema[field.field] = field.type;
+  });
+
+  return {
+    fieldOptions,
+    fieldsSchema,
+  };
+}
+
+export function getDatasetFieldOptionsFromSchema(fieldsSchema = {}) {
+  return Object.keys(fieldsSchema).map((field) => createFieldOption(
+    field,
+    fieldsSchema[field],
+    field.indexOf("[]") === -1
+  ));
+}

--- a/docs/specs/FS-20260321-cdc-viz-binding.md
+++ b/docs/specs/FS-20260321-cdc-viz-binding.md
@@ -83,11 +83,60 @@ This is a minimal pass, not a new visualization engine. The goal is to change ow
 ## UI Changes
 
 - Stop treating the dataset builder as the owner of chart-binding config.
-- Move dimension/metric/date/formula/filter editing to CDC-backed flows.
-- Keep the dataset page focused on query/data concerns.
+- Move dimension/metric/date/formula/filter editing to CDC-backed flows in the chart editor.
+- Keep the dataset page focused on query/data concerns only.
 - Extract reusable field-picker and filter UI from `DatasetBuilder.jsx` so it can be used by CDC configuration.
 - Update dataset-to-chart creation flow to initialize CDC binding values directly instead of copying the dataset object wholesale.
 - Update dataset naming UI to edit `name`, not `legend`, with fallback while older data is still present.
+
+## Dataset Page UX
+
+- Remove the `Configure` dataset step/menu entirely.
+- The dataset page becomes a data-definition screen:
+  - query / API request / join settings
+  - transforms
+  - sample response / field discovery
+- When saving a draft dataset, open a confirmation modal first so the user can:
+  - confirm or edit the dataset name
+  - assign dashboard tags before publishing the dataset
+- Main CTA rules:
+  - `Save dataset` when opened from the dataset list or other standalone dataset entry points
+  - `Save & return to chart` when opened from the chart editor flow
+- Keep the existing route/query-param behavior that already distinguishes chart-origin flows.
+
+## Chart Editor UX
+
+- The right-side dataset panel becomes the primary home for per-series configuration.
+- Rename the first CDC tab from `Binding` to `Data setup`.
+- Keep dataset/series tabs at the top so users can switch between `Signups`, `Active trials`, etc.
+- For the selected series, split the right panel into tabs:
+  - `Data setup`
+    - series name
+    - edit dataset CTA
+    - dimension (`xAxis`)
+    - metric (`yAxis`)
+    - operation (`yAxisOperation`)
+    - date field
+    - filters
+  - `Display`
+    - colors
+    - fill / multi-fill
+    - sort
+    - max records
+    - formula
+    - goal
+  - `Automation`
+    - variables
+    - alerts
+- `Chart Settings` stays outside the dataset panel as chart-global configuration.
+- This split should preserve all current CDC controls; the work is a reorganization, not a reduction of functionality.
+
+## Field Discovery & Suggestions
+
+- `Data setup` should auto-suggest optimal dimension / metric / operation / date field when the CDC does not have them yet.
+- Reuse the current dataset-preview request behavior used by `Dataset.jsx` / `DatasetBuilder.jsx` to fetch enough sample data to build field options.
+- Reuse `autoFieldSelector` logic where possible so default suggestions stay consistent with the current dataset flow.
+- Reuse `DatasetFilters.jsx` for CDC conditions if possible, but make it operate on CDC-backed data instead of dataset-backed data.
 
 ## Client Touchpoints
 
@@ -122,13 +171,13 @@ This is a minimal pass, not a new visualization engine. The goal is to change ow
 
 ## Progress
 
-- [ ] Add `Dataset.name` and backfill from `legend`.
-- [ ] Add new CDC fields and model accessors.
-- [ ] Add migration script to backfill CDC visualization fields from datasets.
+- [x] Add `Dataset.name` and backfill from `legend`.
+- [x] Add new CDC fields and model accessors.
+- [x] Add migration script to backfill CDC visualization fields from datasets.
 - [ ] Update dataset callers to prefer `name` over `legend`.
-- [ ] Merge dataset + CDC binding at runtime in `ChartController`.
-- [ ] Persist condition options to CDC instead of dataset.
-- [ ] Move dataset builder writes from `updateDataset` to `updateCdc` for binding fields.
+- [x] Merge dataset + CDC binding at runtime in `ChartController`.
+- [x] Persist condition options to CDC instead of dataset.
+- [x] Move dataset builder writes from `updateDataset` to `updateCdc` for binding fields.
 - [ ] Update chart/dashboard filter consumers to read CDC conditions.
 - [ ] Update orchestrator tool schemas, rules, and payloads to use `Dataset.name` and CDC-owned binding fields.
 - [ ] Verify reuse: same dataset used by multiple charts with different bindings and filters.
@@ -138,4 +187,5 @@ This is a minimal pass, not a new visualization engine. The goal is to change ow
 - This pass intentionally avoids removing legacy dataset viz fields.
 - This pass intentionally avoids removing `Dataset.legend`; it becomes compatibility-only until callers are migrated.
 - This pass intentionally avoids a new viz engine or payload redesign.
+- The client now treats the dataset page as query-only and moves per-series setup to chart-side `Data setup / Display / Automation` tabs.
 - Once stable, a follow-up spec can remove legacy dataset binding fields entirely.

--- a/docs/specs/FS-20260321-cdc-viz-binding.md
+++ b/docs/specs/FS-20260321-cdc-viz-binding.md
@@ -147,6 +147,70 @@ This is a minimal pass, not a new visualization engine. The goal is to change ow
 - client callers that display dataset titles from `legend`
 - chart/dashboard filter consumers that currently read `cdc.Dataset.conditions`
 
+## Remaining Work
+
+The implementation is mostly complete. The remaining work is intentionally narrow and should not reopen the architecture.
+
+### 1. Orchestrator Compatibility
+
+The AI orchestrator still needs to be aligned with the new ownership model.
+
+Required outcomes:
+- dataset entities should use `name` as the canonical dataset label
+- chart-series / CDC creation should treat `legend` as chart-specific label text
+- dataset creation and update tools should stop treating dataset `legend` as the primary dataset name
+- chart creation tools should default CDC `legend` from `dataset.name || dataset.legend`
+- orchestrator prompts and tool schemas should describe binding fields as CDC-owned, not dataset-owned
+
+Files to review:
+- `server/modules/ai/orchestrator/orchestrator.js`
+- `server/modules/ai/orchestrator/entityCreationRules.js`
+- `server/modules/ai/orchestrator/tools/createDataset.js`
+- `server/modules/ai/orchestrator/tools/updateDataset.js`
+- `server/modules/ai/orchestrator/tools/createChart.js`
+- `server/modules/ai/orchestrator/tools/createTemporaryChart.js`
+
+Acceptance criteria:
+- AI-created datasets return `name` correctly populated
+- AI-updated datasets modify `name` instead of relying on `legend`
+- AI-created charts create CDCs with correct `legend` fallback and do not copy binding fields back onto `Dataset`
+- orchestrator-facing entity descriptions match the current runtime model
+
+### 2. Finish Dataset Name Migration In Remaining Callers
+
+Most active UI paths now prefer `dataset.name || dataset.legend`, but a few legacy or secondary callers still read `legend` directly as if it were the dataset name.
+
+This remaining pass should:
+- migrate display/search-only dataset name callers to `name || legend`
+- leave runtime series-label usages alone where `legend` is still the correct chart label key
+
+Important distinction:
+- keep `legend` where the code is referring to chart-series identity or chart-data lookup keys
+- migrate to `name || legend` where the code is rendering or searching for the reusable dataset itself
+
+Known remaining callers to review:
+- `client/src/containers/AddChart/components/Dataset.jsx`
+- any remaining dataset list / picker / breadcrumb / modal labels not yet updated
+- any server-side dataset labels returned to the UI that still prefer `legend`
+
+Acceptance criteria:
+- reusable dataset labels render consistently across the UI using `name || legend`
+- no chart runtime lookups break because of an over-eager `legend` replacement
+
+### 3. Reuse Verification
+
+This is a verification task, not a new implementation phase.
+
+Scenarios to verify:
+- the same dataset can be used by multiple charts with different `xAxis`, `yAxis`, `yAxisOperation`, `dateField`, and `conditions`
+- hiding a filter in one chart does not hide it in another chart using the same dataset
+- changing a chart-level condition in one CDC does not mutate the shared dataset or another CDC
+- chart creation from an existing dataset still produces a usable default series configuration
+
+Acceptance criteria:
+- CDC-owned bindings are isolated per chart
+- dataset reuse behaves as expected across at least two charts using the same underlying dataset
+
 ## Orchestrator Compatibility
 
 - Update orchestrator contracts so datasets use `name` as the entity name and CDC owns visualization binding fields.
@@ -174,11 +238,11 @@ This is a minimal pass, not a new visualization engine. The goal is to change ow
 - [x] Add `Dataset.name` and backfill from `legend`.
 - [x] Add new CDC fields and model accessors.
 - [x] Add migration script to backfill CDC visualization fields from datasets.
-- [ ] Update dataset callers to prefer `name` over `legend`.
+- [~] Update dataset callers to prefer `name` over `legend`.
 - [x] Merge dataset + CDC binding at runtime in `ChartController`.
 - [x] Persist condition options to CDC instead of dataset.
 - [x] Move dataset builder writes from `updateDataset` to `updateCdc` for binding fields.
-- [ ] Update chart/dashboard filter consumers to read CDC conditions.
+- [x] Update chart/dashboard filter consumers to read CDC conditions.
 - [ ] Update orchestrator tool schemas, rules, and payloads to use `Dataset.name` and CDC-owned binding fields.
 - [ ] Verify reuse: same dataset used by multiple charts with different bindings and filters.
 
@@ -186,6 +250,7 @@ This is a minimal pass, not a new visualization engine. The goal is to change ow
 
 - This pass intentionally avoids removing legacy dataset viz fields.
 - This pass intentionally avoids removing `Dataset.legend`; it becomes compatibility-only until callers are migrated.
+- `Dataset.legend` should now be treated as a compatibility field only. New product logic should not introduce additional dataset-name reads from `legend` unless there is a compatibility reason.
 - This pass intentionally avoids a new viz engine or payload redesign.
 - The client now treats the dataset page as query-only and moves per-series setup to chart-side `Data setup / Display / Automation` tabs.
 - Once stable, a follow-up spec can remove legacy dataset binding fields entirely.

--- a/docs/specs/FS-20260321-cdc-viz-binding.md
+++ b/docs/specs/FS-20260321-cdc-viz-binding.md
@@ -1,0 +1,141 @@
+# CDC Viz Binding Split
+
+Status: draft
+
+## Overview
+
+`Dataset` currently mixes source/data concerns with chart-binding concerns. This makes datasets hard to reuse because changing `xAxis`, `yAxis`, `dateField`, `formula`, or `conditions` changes behavior globally across all charts using that dataset. This spec moves the visualization binding layer to `ChartDatasetConfig` and keeps `Dataset` focused on data retrieval, joins, schema, and variables.
+
+This is a minimal pass, not a new visualization engine. The goal is to change ownership of config without rewriting the chart pipeline.
+
+## Scope
+
+- Move chart-binding fields from `Dataset` to `ChartDatasetConfig`.
+- Include `conditions` in the move so chart-specific filters stop mutating shared datasets.
+- Add `Dataset.name` as the canonical dataset name and backfill it from `legend`.
+- Keep the current chart processing pipeline and payload shape.
+- Add a migration script that copies existing dataset visualization values into each related CDC.
+- Migrate dataset naming code from `legend` to `name`, with legacy fallback during the transition.
+- Update AI orchestrator entity definitions and tools to match the new dataset/CDC shape.
+- Keep legacy dataset fields as fallback for one pass to reduce migration risk.
+
+## Data Model
+
+- Add `name` to `Dataset`.
+- Add these nullable fields to `ChartDatasetConfig`:
+  - `xAxis`
+  - `xAxisOperation`
+  - `yAxis`
+  - `yAxisOperation`
+  - `dateField`
+  - `dateFormat`
+  - `conditions`
+- Keep existing CDC fields as-is:
+  - `legend`, `formula`, `datasetColor`, `fillColor`, `fill`, `multiFill`, `pointRadius`, `excludedFields`, `sort`, `columnsOrder`, `order`, `maxRecords`, `goal`, `configuration`
+- Keep these dataset fields for now as legacy fallback only:
+  - `xAxis`, `xAxisOperation`, `yAxis`, `yAxisOperation`, `dateField`, `dateFormat`, `legend`, `conditions`, `formula`
+
+## Ownership Rules
+
+- `Dataset` owns:
+  - `name`
+  - `DataRequests`, `joinSettings`, `main_dr_id`, `fieldsSchema`, variable bindings, source query logic, reusable data shape
+- `ChartDatasetConfig` owns:
+  - dimension/metric/date binding
+  - chart-specific conditions
+  - formula and legend
+  - per-chart display and ordering settings
+
+## Naming Rules
+
+- `Dataset.name` becomes the canonical dataset display name.
+- `ChartDatasetConfig.legend` remains chart-specific label text.
+- `Dataset.legend` remains temporary legacy fallback only.
+- During transition, reads should prefer:
+  - dataset name: `name || legend`
+  - chart label: `cdc.legend || dataset.name || dataset.legend`
+
+## Runtime Changes
+
+- Do not add a new persisted model.
+- In `ChartController.updateChartData()`, build the runtime `options` object for each dataset from:
+  - base dataset fields
+  - CDC binding overrides
+- The runtime shape returned to chart modules stays:
+  - `{ data, options }`
+- Merge precedence:
+  - CDC field if present
+  - otherwise dataset legacy field
+- Set runtime `options.id` to `cdc.id` and keep `options.dataset_id` as the underlying dataset id.
+- Update condition-option persistence to write back to `ChartDatasetConfig.conditions`, not `Dataset.conditions`.
+
+## Server Touchpoints
+
+- `server/models/models/dataset.js`
+- `server/models/models/chartdatasetconfig.js`
+- `server/controllers/ChartController.js`
+- `server/controllers/DatasetController.js`
+- `server/charts/AxisChart.js`
+- `server/charts/DataExtractor.js`
+- `server/charts/TableView.js`
+- dataset name callers still reading `legend`
+
+## UI Changes
+
+- Stop treating the dataset builder as the owner of chart-binding config.
+- Move dimension/metric/date/formula/filter editing to CDC-backed flows.
+- Keep the dataset page focused on query/data concerns.
+- Extract reusable field-picker and filter UI from `DatasetBuilder.jsx` so it can be used by CDC configuration.
+- Update dataset-to-chart creation flow to initialize CDC binding values directly instead of copying the dataset object wholesale.
+- Update dataset naming UI to edit `name`, not `legend`, with fallback while older data is still present.
+
+## Client Touchpoints
+
+- `client/src/containers/Dataset/Dataset.jsx`
+- `client/src/containers/Dataset/DatasetBuilder.jsx`
+- `client/src/containers/AddChart/components/ChartDatasetConfig.jsx`
+- `client/src/components/DatasetFilters.jsx`
+- client callers that display dataset titles from `legend`
+- chart/dashboard filter consumers that currently read `cdc.Dataset.conditions`
+
+## Orchestrator Compatibility
+
+- Update orchestrator contracts so datasets use `name` as the entity name and CDC owns visualization binding fields.
+- Review and migrate:
+  - `server/modules/ai/orchestrator/orchestrator.js`
+  - `server/modules/ai/orchestrator/entityCreationRules.js`
+  - `server/modules/ai/orchestrator/tools/createDataset.js`
+  - `server/modules/ai/orchestrator/tools/updateDataset.js`
+  - chart creation/update tools that still default CDC legend from `dataset.legend`
+- The final step of the rollout is updating orchestrator prompts, tool schemas, selected attributes, and returned entity payloads so AI-generated entities match the new runtime model.
+
+## Migration
+
+- Write a migration script that:
+  - backfills `Dataset.name` from `legend` where `name` is empty
+  - finds every `ChartDatasetConfig`
+  - copies matching legacy visualization fields from its linked `Dataset` into the CDC if the CDC field is empty
+  - copies `conditions` from dataset to CDC
+- Migration should be idempotent.
+- Do not delete legacy dataset columns in the same pass.
+- After migration, new writes go to CDC first while reads still support dataset fallback.
+
+## Progress
+
+- [ ] Add `Dataset.name` and backfill from `legend`.
+- [ ] Add new CDC fields and model accessors.
+- [ ] Add migration script to backfill CDC visualization fields from datasets.
+- [ ] Update dataset callers to prefer `name` over `legend`.
+- [ ] Merge dataset + CDC binding at runtime in `ChartController`.
+- [ ] Persist condition options to CDC instead of dataset.
+- [ ] Move dataset builder writes from `updateDataset` to `updateCdc` for binding fields.
+- [ ] Update chart/dashboard filter consumers to read CDC conditions.
+- [ ] Update orchestrator tool schemas, rules, and payloads to use `Dataset.name` and CDC-owned binding fields.
+- [ ] Verify reuse: same dataset used by multiple charts with different bindings and filters.
+
+## Notes
+
+- This pass intentionally avoids removing legacy dataset viz fields.
+- This pass intentionally avoids removing `Dataset.legend`; it becomes compatibility-only until callers are migrated.
+- This pass intentionally avoids a new viz engine or payload redesign.
+- Once stable, a follow-up spec can remove legacy dataset binding fields entirely.

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -462,7 +462,9 @@ class ChartController {
           resolvingData.datasets = gCache.data.datasets.map((item) => {
             const tempItem = item;
             for (let i = 0; i < resolvedDatasets.length; i++) {
-              if (getRuntimeDatasetKey(item.options) === getRuntimeDatasetKey(resolvedDatasets[i].options)) {
+              if (getRuntimeDatasetKey(item.options)
+                === getRuntimeDatasetKey(resolvedDatasets[i].options)
+              ) {
                 tempItem.options = resolvedDatasets[i].options;
                 break;
               }

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -8,6 +8,7 @@ const jwt = require("jsonwebtoken");
 const externalDbConnection = require("../modules/externalDbConnection");
 const { calculateChartLayout, ensureCompleteLayout, DEFAULT_CHART_LAYOUT } = require("../modules/chartLayoutEngine");
 const validateMongoQuery = require("../modules/validateMongoQuery");
+const { getDatasetName, resolveChartDatasetOptions } = require("../modules/resolveChartDatasetOptions");
 
 const db = require("../models/models");
 const DatasetController = require("./DatasetController");
@@ -64,6 +65,10 @@ function toAuditError(error, stage = "unknown") {
   const wrappedError = new Error(String(error));
   wrappedError.auditStage = stage;
   return wrappedError;
+}
+
+function getRuntimeDatasetKey(options = {}) {
+  return options.dataset_id || options.id || null;
 }
 
 class ChartController {
@@ -439,18 +444,26 @@ class ChartController {
         return Promise.all(requestPromises);
       })
       .then(async (datasets) => {
+        const resolvedDatasets = datasets.map((dataset, index) => {
+          const cdc = gChart.ChartDatasetConfigs[index];
+          return {
+            ...dataset,
+            options: resolveChartDatasetOptions(cdc, dataset?.options),
+          };
+        });
+
         const resolvingData = {
           chart: gChart,
-          datasets,
+          datasets: resolvedDatasets,
         };
 
         // change the datasets data if the cache is called
         if (!skipCache && noSource === true && gCache && gCache.data && gCache.data.datasets) {
           resolvingData.datasets = gCache.data.datasets.map((item) => {
             const tempItem = item;
-            for (let i = 0; i < datasets.length; i++) {
-              if (item.options.id === datasets[i].options.id) {
-                tempItem.options = datasets[i].options;
+            for (let i = 0; i < resolvedDatasets.length; i++) {
+              if (getRuntimeDatasetKey(item.options) === getRuntimeDatasetKey(resolvedDatasets[i].options)) {
+                tempItem.options = resolvedDatasets[i].options;
                 break;
               }
             }
@@ -534,10 +547,14 @@ class ChartController {
           if (chartData.conditionsOptions) {
             chartData.conditionsOptions.forEach((opt) => {
               if (opt.dataset_id) {
-                const cdc = gChart.ChartDatasetConfigs.find((d) => d.dataset_id === opt.dataset_id);
-                const dataset = cdc?.Dataset;
-                if (dataset?.conditions) {
-                  const newConditions = dataset.conditions.map((c) => {
+                const cdc = gChart.ChartDatasetConfigs.find((d) => `${d.id}` === `${opt.dataset_id}`
+                  || `${d.dataset_id}` === `${opt.dataset_id}`);
+                const cdcConditions = cdc?.conditions !== undefined && cdc?.conditions !== null
+                  ? cdc.conditions
+                  : cdc?.Dataset?.conditions;
+
+                if (Array.isArray(cdcConditions)) {
+                  const newConditions = cdcConditions.map((c) => {
                     const optCondition = opt.conditions.find((o) => o.field === c.field);
                     let values = (optCondition && optCondition.values) || [];
                     values = optCondition?.hideValues ? [] : values.slice(0, 100);
@@ -546,9 +563,9 @@ class ChartController {
                   });
 
                   datasetsPromises.push(
-                    db.Dataset.update(
+                    db.ChartDatasetConfig.update(
                       { conditions: newConditions },
-                      { where: { id: opt.dataset_id } }
+                      { where: { id: cdc.id } }
                     )
                   );
                 }
@@ -1236,7 +1253,7 @@ class ChartController {
 
     return db.ChartDatasetConfig.create({
       ...data,
-      legend: dataset.legend,
+      legend: data.legend || getDatasetName(dataset),
       chart_id: chartId,
     })
       .then((chartDatasetConfig) => {
@@ -1360,7 +1377,7 @@ class ChartController {
           const cdcToCreate = {
             ...cdcRest,
             chart_id: chart.id,
-            legend: cdcData.legend || dataset?.legend || null
+            legend: cdcData.legend || getDatasetName(dataset) || null
           };
 
           return db.ChartDatasetConfig.create(cdcToCreate);

--- a/server/controllers/DatasetController.js
+++ b/server/controllers/DatasetController.js
@@ -749,9 +749,9 @@ class DatasetController {
 
     const cleanDatasetData = {};
     const allowedFields = [
-      "team_id", "project_ids", "draft", "xAxis", "xAxisOperation", "yAxis",
-      "yAxisOperation", "dateField", "dateFormat", "legend", "conditions",
-      "fieldsSchema"
+      "team_id", "project_ids", "draft", "name", "xAxis", "xAxisOperation",
+      "yAxis", "yAxisOperation", "dateField", "dateFormat", "legend",
+      "conditions", "fieldsSchema"
     ];
 
     allowedFields.forEach((field) => {

--- a/server/models/migrations/20260321090000-add-dataset-name-and-cdc-viz-fields.js
+++ b/server/models/migrations/20260321090000-add-dataset-name-and-cdc-viz-fields.js
@@ -1,0 +1,60 @@
+const Sequelize = require("sequelize");
+const migrateDatasetVizToCdc = require("../scripts/migrateDatasetVizToCdc");
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addColumn("Dataset", "name", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "xAxis", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "xAxisOperation", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "yAxis", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "yAxisOperation", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "dateField", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "dateFormat", {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn("ChartDatasetConfig", "conditions", {
+      type: Sequelize.TEXT("long"),
+      allowNull: true,
+    });
+
+    await migrateDatasetVizToCdc.up(queryInterface);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn("ChartDatasetConfig", "conditions");
+    await queryInterface.removeColumn("ChartDatasetConfig", "dateFormat");
+    await queryInterface.removeColumn("ChartDatasetConfig", "dateField");
+    await queryInterface.removeColumn("ChartDatasetConfig", "yAxisOperation");
+    await queryInterface.removeColumn("ChartDatasetConfig", "yAxis");
+    await queryInterface.removeColumn("ChartDatasetConfig", "xAxisOperation");
+    await queryInterface.removeColumn("ChartDatasetConfig", "xAxis");
+    await queryInterface.removeColumn("Dataset", "name");
+  }
+};

--- a/server/models/models/chartdatasetconfig.js
+++ b/server/models/models/chartdatasetconfig.js
@@ -25,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     /*
     ** Active chart-binding fields.
-    ** Deprecated dataset-side binding fields have been moved off Dataset and do not have CDC equivalents here.
+    ** Deprecated dataset-side binding fields have been moved off Dataset
     */
     xAxis: {
       type: DataTypes.STRING,

--- a/server/models/models/chartdatasetconfig.js
+++ b/server/models/models/chartdatasetconfig.js
@@ -23,6 +23,51 @@ module.exports = (sequelize, DataTypes) => {
         onDelete: "cascade",
       },
     },
+    /*
+    ** Active chart-binding fields.
+    ** Deprecated dataset-side binding fields have been moved off Dataset and do not have CDC equivalents here.
+    */
+    xAxis: {
+      type: DataTypes.STRING,
+      description: "X axis field using traversal syntax - root[].field"
+    },
+    xAxisOperation: {
+      type: DataTypes.STRING,
+      description: "X axis operation"
+    },
+    yAxis: {
+      type: DataTypes.STRING,
+      description: "Y axis field using traversal syntax - root[].field"
+    },
+    yAxisOperation: {
+      type: DataTypes.STRING,
+      description: "Operation to perform on the y-axis - none, sum, avg, min, max, count"
+    },
+    dateField: {
+      type: DataTypes.STRING,
+      description: "Date field using traversal syntax. Specifies which field should be used for date filtering."
+    },
+    dateFormat: {
+      type: DataTypes.STRING,
+      description: "Date format to use for date filtering. e.g YYYY-MM-DD"
+    },
+    conditions: {
+      type: DataTypes.TEXT("long"),
+      set(val) {
+        return this.setDataValue("conditions", JSON.stringify(val));
+      },
+      get() {
+        try {
+          return JSON.parse(this.getDataValue("conditions"));
+        } catch (e) {
+          return this.getDataValue("conditions");
+        }
+      },
+      description: "Chart-specific conditions layered on top of the dataset"
+    },
+    /*
+    ** Active chart presentation fields.
+    */
     formula: {
       type: DataTypes.TEXT,
       description: "The formula (e.g {val / 100}) used transform the data points values. Can be used to pre-(a)pend, strings to numbers too £{val}"

--- a/server/models/models/dataset.js
+++ b/server/models/models/dataset.js
@@ -49,69 +49,9 @@ module.exports = (sequelize, DataTypes) => {
       defaultValue: true,
       description: "Whether the dataset is a draft and should be hidden from dashboard viewers"
     },
-    /*
-    ** Traversal syntax for both x and y axes
-    ** root[].field when root is an array
-    ** root.field when root is an object
-    ** root.field[].field when root is an object and the field is an array
-    ** xAxis also known as the "dimension" field
-    ** yAxis also known as the "metric" field
-    */
-    xAxis: {
+    name: {
       type: DataTypes.STRING,
-      description: "X axis or metric field using traversal syntax - root[].field",
-    },
-    xAxisOperation: {
-      type: DataTypes.STRING,
-      description: "Not in use"
-    },
-    yAxis: {
-      type: DataTypes.STRING,
-      description: "Y axis or metric field using traversal syntax - root[].field",
-    },
-    yAxisOperation: {
-      type: DataTypes.STRING,
-      defaultValue: "none",
-      description: "Operation to perform on the y-axis - none, sum, avg, min, max, count"
-    },
-    dateField: {
-      type: DataTypes.STRING,
-      description: "Date field using traversal syntax. Specifies which field should be used for date filtering."
-    },
-    dateFormat: {
-      type: DataTypes.STRING,
-      description: "Date format to use for date filtering. e.g YYYY-MM-DD"
-    },
-    legend: {
-      type: DataTypes.STRING,
-      description: "Legend label (name) of the dataset"
-    },
-    /*
-    ** Conditions to apply to the dataset - used for filtering
-    ** Each condition is an object with the following properties:
-    ** id: string
-    ** field: string - using traversal syntax - root[].field
-    ** operator: string
-    ** value: string
-    ** displayValues: boolean - whether to display the values in the dropdown UI
-    */
-    conditions: {
-      type: DataTypes.TEXT("long"),
-      set(val) {
-        return this.setDataValue("conditions", JSON.stringify(val));
-      },
-      get() {
-        try {
-          return JSON.parse(this.getDataValue("conditions"));
-        } catch (e) {
-          return this.getDataValue("conditions");
-        }
-      },
-      description: "Conditions to apply to the dataset - used for filtering"
-    },
-    formula: {
-      type: DataTypes.TEXT,
-      description: "[Legacy] Formula to use for the dataset"
+      description: "Canonical name of the dataset"
     },
     fieldsSchema: {
       type: DataTypes.TEXT("long"),
@@ -167,7 +107,61 @@ module.exports = (sequelize, DataTypes) => {
     // ------------------------------------
 
     /*
-    ** LEGACY FIELDS
+    ** LEGACY / COMPATIBILITY FIELDS
+    ** These remain only so older charts and callers can keep working during the CDC migration.
+    */
+    /*
+    ** Legacy chart-binding fields
+    */
+    xAxis: {
+      type: DataTypes.STRING,
+      description: "[Legacy] X axis or metric field using traversal syntax - root[].field",
+    },
+    xAxisOperation: {
+      type: DataTypes.STRING,
+      description: "[Legacy] Not in use"
+    },
+    yAxis: {
+      type: DataTypes.STRING,
+      description: "[Legacy] Y axis or metric field using traversal syntax - root[].field",
+    },
+    yAxisOperation: {
+      type: DataTypes.STRING,
+      defaultValue: "none",
+      description: "[Legacy] Operation to perform on the y-axis - none, sum, avg, min, max, count"
+    },
+    dateField: {
+      type: DataTypes.STRING,
+      description: "[Legacy] Date field using traversal syntax. Specifies which field should be used for date filtering."
+    },
+    dateFormat: {
+      type: DataTypes.STRING,
+      description: "[Legacy] Date format to use for date filtering. e.g YYYY-MM-DD"
+    },
+    legend: {
+      type: DataTypes.STRING,
+      description: "[Legacy] Previous dataset name field"
+    },
+    conditions: {
+      type: DataTypes.TEXT("long"),
+      set(val) {
+        return this.setDataValue("conditions", JSON.stringify(val));
+      },
+      get() {
+        try {
+          return JSON.parse(this.getDataValue("conditions"));
+        } catch (e) {
+          return this.getDataValue("conditions");
+        }
+      },
+      description: "[Legacy] Conditions to apply to the dataset - used for filtering"
+    },
+    formula: {
+      type: DataTypes.TEXT,
+      description: "[Legacy] Formula to use for the dataset"
+    },
+    /*
+    ** Legacy chart-owned fields from the pre-CDC split
     */
     chart_id: {
       type: DataTypes.INTEGER,

--- a/server/models/scripts/migrateDatasetVizToCdc.js
+++ b/server/models/scripts/migrateDatasetVizToCdc.js
@@ -12,22 +12,50 @@ function throttlePromises(promises, chunkSize, index) {
     .catch(() => throttlePromises(promises, chunkSize, index + chunkSize));
 }
 
-module.exports.up = async (queryInterface) => {
-  const dialect = queryInterface.sequelize.getDialect();
-  const tableNames = {
-    dataset: dialect === "postgres" ? "\"Dataset\"" : "Dataset",
-    cdc: dialect === "postgres" ? "\"ChartDatasetConfig\"" : "ChartDatasetConfig",
-  };
+function buildSelectQuery(queryInterface, tableName, columns) {
+  const queryGenerator = queryInterface.queryGenerator
+    || queryInterface.sequelize.getQueryInterface().queryGenerator;
+  const quotedTable = queryGenerator.quoteTable(tableName);
+  const quotedColumns = columns.map((column) => {
+    const quotedColumn = queryGenerator.quoteIdentifier(column);
+    return `${quotedColumn} AS ${quotedColumn}`;
+  });
 
+  return `SELECT ${quotedColumns.join(", ")} FROM ${quotedTable}`;
+}
+
+module.exports.up = async (queryInterface) => {
   const datasets = await queryInterface.sequelize.query(
-    `SELECT id, name, legend, xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat, conditions, formula
-     FROM ${tableNames.dataset}`,
+    buildSelectQuery(queryInterface, "Dataset", [
+      "id",
+      "name",
+      "legend",
+      "xAxis",
+      "xAxisOperation",
+      "yAxis",
+      "yAxisOperation",
+      "dateField",
+      "dateFormat",
+      "conditions",
+      "formula",
+    ]),
     { type: queryInterface.sequelize.QueryTypes.SELECT }
   );
 
   const cdcs = await queryInterface.sequelize.query(
-    `SELECT id, dataset_id, xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat, conditions, formula, legend
-     FROM ${tableNames.cdc}`,
+    buildSelectQuery(queryInterface, "ChartDatasetConfig", [
+      "id",
+      "dataset_id",
+      "xAxis",
+      "xAxisOperation",
+      "yAxis",
+      "yAxisOperation",
+      "dateField",
+      "dateFormat",
+      "conditions",
+      "formula",
+      "legend",
+    ]),
     { type: queryInterface.sequelize.QueryTypes.SELECT }
   );
 

--- a/server/models/scripts/migrateDatasetVizToCdc.js
+++ b/server/models/scripts/migrateDatasetVizToCdc.js
@@ -49,15 +49,33 @@ module.exports.up = async (queryInterface) => {
 
     const updates = {};
 
-    if (isBlank(cdc.xAxis) && !isBlank(dataset.xAxis)) updates.xAxis = dataset.xAxis;
-    if (isBlank(cdc.xAxisOperation) && !isBlank(dataset.xAxisOperation)) updates.xAxisOperation = dataset.xAxisOperation;
-    if (isBlank(cdc.yAxis) && !isBlank(dataset.yAxis)) updates.yAxis = dataset.yAxis;
-    if (isBlank(cdc.yAxisOperation) && !isBlank(dataset.yAxisOperation)) updates.yAxisOperation = dataset.yAxisOperation;
-    if (isBlank(cdc.dateField) && !isBlank(dataset.dateField)) updates.dateField = dataset.dateField;
-    if (isBlank(cdc.dateFormat) && !isBlank(dataset.dateFormat)) updates.dateFormat = dataset.dateFormat;
-    if (isBlank(cdc.conditions) && !isBlank(dataset.conditions)) updates.conditions = dataset.conditions;
-    if (isBlank(cdc.formula) && !isBlank(dataset.formula)) updates.formula = dataset.formula;
-    if (isBlank(cdc.legend) && !isBlank(dataset.legend)) updates.legend = dataset.legend;
+    if (isBlank(cdc.xAxis) && !isBlank(dataset.xAxis)) {
+      updates.xAxis = dataset.xAxis;
+    }
+    if (isBlank(cdc.xAxisOperation) && !isBlank(dataset.xAxisOperation)) {
+      updates.xAxisOperation = dataset.xAxisOperation;
+    }
+    if (isBlank(cdc.yAxis) && !isBlank(dataset.yAxis)) {
+      updates.yAxis = dataset.yAxis;
+    }
+    if (isBlank(cdc.yAxisOperation) && !isBlank(dataset.yAxisOperation)) {
+      updates.yAxisOperation = dataset.yAxisOperation;
+    }
+    if (isBlank(cdc.dateField) && !isBlank(dataset.dateField)) {
+      updates.dateField = dataset.dateField;
+    }
+    if (isBlank(cdc.dateFormat) && !isBlank(dataset.dateFormat)) {
+      updates.dateFormat = dataset.dateFormat;
+    }
+    if (isBlank(cdc.conditions) && !isBlank(dataset.conditions)) {
+      updates.conditions = dataset.conditions;
+    }
+    if (isBlank(cdc.formula) && !isBlank(dataset.formula)) {
+      updates.formula = dataset.formula;
+    }
+    if (isBlank(cdc.legend) && !isBlank(dataset.legend)) {
+      updates.legend = dataset.legend;
+    }
 
     if (Object.keys(updates).length > 0) {
       updatePromises.push(

--- a/server/models/scripts/migrateDatasetVizToCdc.js
+++ b/server/models/scripts/migrateDatasetVizToCdc.js
@@ -1,0 +1,74 @@
+function isBlank(value) {
+  return value === null || value === undefined || value === "";
+}
+
+function throttlePromises(promises, chunkSize, index) {
+  if (index >= promises.length) return Promise.resolve();
+
+  const promisesChunk = promises.slice(index, index + chunkSize);
+
+  return Promise.all(promisesChunk)
+    .then(() => throttlePromises(promises, chunkSize, index + chunkSize))
+    .catch(() => throttlePromises(promises, chunkSize, index + chunkSize));
+}
+
+module.exports.up = async (queryInterface) => {
+  const dialect = queryInterface.sequelize.getDialect();
+  const tableNames = {
+    dataset: dialect === "postgres" ? "\"Dataset\"" : "Dataset",
+    cdc: dialect === "postgres" ? "\"ChartDatasetConfig\"" : "ChartDatasetConfig",
+  };
+
+  const datasets = await queryInterface.sequelize.query(
+    `SELECT id, name, legend, xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat, conditions, formula
+     FROM ${tableNames.dataset}`,
+    { type: queryInterface.sequelize.QueryTypes.SELECT }
+  );
+
+  const cdcs = await queryInterface.sequelize.query(
+    `SELECT id, dataset_id, xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat, conditions, formula, legend
+     FROM ${tableNames.cdc}`,
+    { type: queryInterface.sequelize.QueryTypes.SELECT }
+  );
+
+  const datasetMap = new Map(datasets.map((dataset) => [dataset.id, dataset]));
+  const updatePromises = [];
+
+  datasets.forEach((dataset) => {
+    if (isBlank(dataset.name) && !isBlank(dataset.legend)) {
+      updatePromises.push(
+        queryInterface.bulkUpdate("Dataset", { name: dataset.legend }, { id: dataset.id })
+      );
+    }
+  });
+
+  cdcs.forEach((cdc) => {
+    const dataset = datasetMap.get(cdc.dataset_id);
+
+    if (!dataset) return;
+
+    const updates = {};
+
+    if (isBlank(cdc.xAxis) && !isBlank(dataset.xAxis)) updates.xAxis = dataset.xAxis;
+    if (isBlank(cdc.xAxisOperation) && !isBlank(dataset.xAxisOperation)) updates.xAxisOperation = dataset.xAxisOperation;
+    if (isBlank(cdc.yAxis) && !isBlank(dataset.yAxis)) updates.yAxis = dataset.yAxis;
+    if (isBlank(cdc.yAxisOperation) && !isBlank(dataset.yAxisOperation)) updates.yAxisOperation = dataset.yAxisOperation;
+    if (isBlank(cdc.dateField) && !isBlank(dataset.dateField)) updates.dateField = dataset.dateField;
+    if (isBlank(cdc.dateFormat) && !isBlank(dataset.dateFormat)) updates.dateFormat = dataset.dateFormat;
+    if (isBlank(cdc.conditions) && !isBlank(dataset.conditions)) updates.conditions = dataset.conditions;
+    if (isBlank(cdc.formula) && !isBlank(dataset.formula)) updates.formula = dataset.formula;
+    if (isBlank(cdc.legend) && !isBlank(dataset.legend)) updates.legend = dataset.legend;
+
+    if (Object.keys(updates).length > 0) {
+      updatePromises.push(
+        queryInterface.bulkUpdate("ChartDatasetConfig", updates, { id: cdc.id })
+      );
+    }
+  });
+
+  return throttlePromises(updatePromises, 20, 0);
+};
+
+module.exports.down = async () => {
+  // no-op; the schema rollback removes the columns
+};

--- a/server/modules/ai/orchestrator/entityCreationRules.js
+++ b/server/modules/ai/orchestrator/entityCreationRules.js
@@ -8,17 +8,11 @@
 const ENTITY_CREATION_RULES = `## Entity Creation Rules
 
 **Dataset:**
-- Required: team_id, connection_id, name, dialect, query, xAxis, yAxis
+- Required: team_id, connection_id, name, query
 - Set draft=false (visible), project_ids=[] or [project_id]
 - After DataRequest created, update main_dr_id
-- xAxis: string - X axis field from query results (use 'root[].field_name' for arrays)
-- yAxis: string - Y axis field from query results (use 'root[].field_name' for arrays)
-- IMPORTANT: Always use 'root[].' prefix for database query results since they return arrays
-- Example: For results like [{"month_start": "2024-01", "count": 5}], use xAxis='root[].month_start', yAxis='root[].count'
-- yAxisOperation: string - none, sum, avg, min, max, count (default: none)
-- dateField: string - optional date field for filtering
-- dateFormat: string - optional date format (e.g. YYYY-MM-DD)
-- conditions: array - optional filtering conditions
+- name: string - canonical reusable dataset name
+- Datasets own query/data-shape concerns only. Do not store chart binding fields (xAxis, yAxis, dateField, conditions, formula, legend) on Dataset.
 
 **Supported Connection Types and Subtypes:**
 - MySQL: mysql, rdsMysql
@@ -64,7 +58,17 @@ Note: Currently only MySQL, PostgreSQL, and MongoDB connections are supported. A
 **ChartDatasetConfig:**
 - Required: chart_id, dataset_id
 - Set legend (short and concise, appears on hover), order=1, datasetColor="#4285F4" (all configurable)
-- IMPORTANT: Suggest a separate short legend for ChartDatasetConfig (different from chart name)
+- IMPORTANT: ChartDatasetConfig owns visualization binding fields. Put xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat, and conditions here, not on Dataset.
+- IMPORTANT: Suggest a separate short legend for ChartDatasetConfig (different from chart name). Default to dataset.name || dataset.legend when no custom legend is provided.
+- xAxis: string - X axis field from query results (use 'root[].field_name' for arrays)
+- yAxis: string - Y axis field from query results (use 'root[].field_name' for arrays)
+- IMPORTANT: Always use 'root[].' prefix for database query results since they return arrays
+- Example: For results like [{"month_start": "2024-01", "count": 5}], use xAxis='root[].month_start', yAxis='root[].count'
+- xAxisOperation: string - optional x-axis operation
+- yAxisOperation: string - none, sum, avg, min, max, count (default: none)
+- dateField: string - optional date field for filtering
+- dateFormat: string - optional date format (e.g. YYYY-MM-DD)
+- conditions: array - optional chart-specific filtering conditions
 - formula: string - transform values (e.g. "{val / 100}", "£{val}") (optional)
 - fillColor: string - area/line fill color, fillColor for bar charts (optional)
 - fill: boolean - enable area fill, fill for bar charts (default: false)
@@ -78,8 +82,8 @@ Note: Currently only MySQL, PostgreSQL, and MongoDB connections are supported. A
 - configuration: object - dataset settings (default: {})
 
 **Sequence:**
-1. Create Dataset with DataRequest using quick-create (team_id, connection_id, legend, query, xAxis, yAxis, draft=false, dataRequests array)
-2. Create Chart with ChartDatasetConfig using quick-create (project_id, dataset_id, name, type, draft=false, chartDatasetConfigs array)
+1. Create Dataset with DataRequest using quick-create (team_id, connection_id, name, query, draft=false, dataRequests array)
+2. Create Chart with ChartDatasetConfig using quick-create (project_id, dataset_id, name, type, draft=false, chartDatasetConfigs array including xAxis/yAxis/date bindings on the CDC)
 
 **CRITICAL RULES:**
 - Use the EXACT project specified by the user or context. Never create charts in different projects.
@@ -108,16 +112,13 @@ const SUPPORTED_CONNECTIONS = {
 // Field definitions for reference and validation
 const FIELD_SPECS = {
   Dataset: {
-    required: ["team_id", "connection_id", "name", "dialect", "query", "xAxis", "yAxis"],
+    required: ["team_id", "connection_id", "name", "query"],
     recommended: {
       draft: false,
       project_ids: [],
-      yAxisOperation: "none",
-      dateField: null,
-      dateFormat: null,
-      conditions: []
+      fieldsSchema: null
     },
-    description: "Process and transform data from DataRequests for visualization"
+    description: "Reusable query/data definition backed by DataRequests"
   },
 
   DataRequest: {
@@ -161,6 +162,13 @@ const FIELD_SPECS = {
     required: ["chart_id", "dataset_id"],
     recommended: {
       legend: null, // Use dataset name or chart title
+      xAxis: null,
+      xAxisOperation: null,
+      yAxis: null,
+      yAxisOperation: "none",
+      dateField: null,
+      dateFormat: null,
+      conditions: [],
       order: 1,
       datasetColor: "#4285F4",
       fill: false,
@@ -169,7 +177,7 @@ const FIELD_SPECS = {
       excludedFields: [],
       configuration: {}
     },
-    description: "Link Charts to Datasets with specific configurations"
+    description: "Link Charts to Datasets with chart-specific bindings and presentation settings"
   }
 };
 

--- a/server/modules/ai/orchestrator/orchestrator.js
+++ b/server/modules/ai/orchestrator/orchestrator.js
@@ -170,26 +170,15 @@ async function availableTools() {
     },
     {
       name: "create_dataset",
-      description: "Persist an SQL query as a Chartbrew dataset (before making a chart).",
+      description: "Persist a reusable Chartbrew dataset for query/data retrieval. Dataset names are canonical in Dataset.name; chart bindings belong on ChartDatasetConfig.",
       parameters: {
         type: "object",
         properties: {
           project_id: { type: "string", description: "Project ID where the dataset will be created" },
           connection_id: { type: "string", description: "Connection ID to use for data fetching (must be MySQL, PostgreSQL, or MongoDB)" },
-          name: { type: "string", description: "Dataset name/legend" },
-          xAxis: { type: "string", description: "X axis field using traversal syntax (use 'root[].field_name' for array results, e.g. 'root[].month_start')" },
-          yAxis: { type: "string", description: "Y axis field using traversal syntax (use 'root[].field_name' for array results, e.g. 'root[].count')" },
-          yAxisOperation: {
-            type: "string",
-            enum: ["none", "sum", "avg", "min", "max", "count"],
-            default: "none",
-            description: "Y axis aggregation operation"
-          },
-          dateField: { type: "string", description: "Date field for filtering" },
-          dateFormat: { type: "string", description: "Date format (e.g. YYYY-MM-DD)" },
+          name: { type: "string", description: "Canonical dataset name stored on Dataset.name" },
           query: { type: "string", description: "SQL query for the dataset" },
-          conditions: { type: "array", items: { type: "object" }, description: "Database filtering conditions" },
-          configuration: { type: "object", description: "Dialect-specific settings" },
+          configuration: { type: "object", description: "DataRequest dialect-specific settings" },
           variables: {
             type: "array",
             items: { type: "string" },
@@ -198,7 +187,7 @@ async function availableTools() {
           },
           transform: { type: "object", description: "Data transformation rules" }
         },
-        required: ["connection_id", "name", "xAxis", "yAxis", "query"]
+        required: ["connection_id", "name", "query"]
       }
       // returns: { dataset_id, data_request_id, name, dataset_url }
     },
@@ -211,7 +200,7 @@ async function availableTools() {
           project_id: { type: "string", description: "The EXACT project/dashboard ID specified by the user where the chart will be placed. Use this exact ID - never create charts in other projects for testing or validation." },
           dataset_id: { type: "string" },
           name: { type: "string", description: "Chart name/title" },
-          legend: { type: "string", description: "Short legend text for data points (max 20-30 chars, appears on hover)" },
+          legend: { type: "string", description: "Chart-series label stored on ChartDatasetConfig.legend (max 20-30 chars, appears on hover)" },
           type: { type: "string", enum: ["line", "bar", "pie", "doughnut", "radar", "polar", "table", "kpi", "avg", "gauge", "matrix"] },
           subType: { type: "string", description: "Chart subtype (e.g. 'AddTimeseries' for KPI totals)" },
           displayLegend: { type: "boolean", description: "Show chart legend" },
@@ -240,6 +229,20 @@ async function availableTools() {
             },
             description: "Gauge ranges [{min, max, label, color}]"
           },
+          xAxis: { type: "string", description: "ChartDatasetConfig x-axis field using traversal syntax (use 'root[].field_name' for array results)" },
+          xAxisOperation: { type: "string", description: "ChartDatasetConfig x-axis operation" },
+          yAxis: { type: "string", description: "ChartDatasetConfig y-axis field using traversal syntax (use 'root[].field_name' for array results)" },
+          yAxisOperation: {
+            type: "string",
+            enum: ["none", "sum", "avg", "min", "max", "count"],
+            default: "none",
+            description: "ChartDatasetConfig y-axis aggregation operation"
+          },
+          dateField: { type: "string", description: "ChartDatasetConfig date field for filtering" },
+          dateFormat: { type: "string", description: "ChartDatasetConfig date format (e.g. YYYY-MM-DD)" },
+          conditions: { type: "array", items: { type: "object" }, description: "ChartDatasetConfig chart-specific filtering conditions" },
+          formula: { type: "string", description: "ChartDatasetConfig formula for transforming displayed values" },
+          seriesConfiguration: { type: "object", description: "ChartDatasetConfig.configuration for series-specific settings such as variable overrides" },
           spec: { type: "object", description: "Alternative: Chart specification object (backward compatibility)" }
         },
         required: ["project_id", "dataset_id", "name"]
@@ -248,24 +251,14 @@ async function availableTools() {
     },
     {
       name: "update_dataset",
-      description: "Update an existing dataset and its associated data request with new SQL query, mappings, or configuration.",
+      description: "Update an existing dataset and its associated data request with new reusable dataset metadata, SQL query, or data-request configuration. Do not use this tool for chart binding fields.",
       parameters: {
         type: "object",
         properties: {
           dataset_id: { type: "string", description: "The ID of the dataset to update" },
-          name: { type: "string", description: "New dataset name/legend" },
-          xAxis: { type: "string", description: "X axis field using traversal syntax (use 'root[].field_name' for array results)" },
-          yAxis: { type: "string", description: "Y axis field using traversal syntax (use 'root[].field_name' for array results)" },
-          yAxisOperation: {
-            type: "string",
-            enum: ["none", "sum", "avg", "min", "max", "count"],
-            description: "Y axis aggregation operation"
-          },
-          dateField: { type: "string", description: "Date field for filtering" },
-          dateFormat: { type: "string", description: "Date format (e.g. YYYY-MM-DD)" },
+          name: { type: "string", description: "New canonical dataset name stored on Dataset.name" },
           query: { type: "string", description: "New SQL query for the dataset" },
-          conditions: { type: "array", items: { type: "object" }, description: "Database filtering conditions" },
-          configuration: { type: "object", description: "Dialect-specific settings" },
+          configuration: { type: "object", description: "Updated DataRequest dialect-specific settings" },
           variables: { type: "array", items: { type: "string" }, description: "Query variables/parameters" },
           transform: { type: "object", description: "Data transformation rules" }
         },
@@ -275,14 +268,14 @@ async function availableTools() {
     },
     {
       name: "update_chart",
-      description: "Update an existing chart with new properties, styling, or dataset configuration.",
+      description: "Update an existing chart with new chart properties or ChartDatasetConfig series settings, including CDC-owned bindings like xAxis, yAxis, dateField, and conditions.",
       parameters: {
         type: "object",
         properties: {
           chart_id: { type: "string", description: "The ID of the chart to update" },
           dataset_id: { type: "string", description: "New dataset ID (if changing the dataset)" },
           name: { type: "string", description: "New chart name/title" },
-          legend: { type: "string", description: "Short legend text for data points (max 20-30 chars, appears on hover)" },
+          legend: { type: "string", description: "Chart-series label stored on ChartDatasetConfig.legend (max 20-30 chars, appears on hover)" },
           type: { type: "string", enum: ["line", "bar", "pie", "doughnut", "radar", "polar", "table", "kpi", "avg", "gauge", "matrix"], description: "Chart type" },
           subType: { type: "string", description: "Chart subtype (e.g. 'AddTimeseries' for KPI totals)" },
           displayLegend: { type: "boolean", description: "Show chart legend" },
@@ -311,6 +304,19 @@ async function availableTools() {
             },
             description: "Gauge ranges [{min, max, label, color}]"
           },
+          xAxis: { type: "string", description: "ChartDatasetConfig x-axis field using traversal syntax (use 'root[].field_name' for array results)" },
+          xAxisOperation: { type: "string", description: "ChartDatasetConfig x-axis operation" },
+          yAxis: { type: "string", description: "ChartDatasetConfig y-axis field using traversal syntax (use 'root[].field_name' for array results)" },
+          yAxisOperation: {
+            type: "string",
+            enum: ["none", "sum", "avg", "min", "max", "count"],
+            description: "ChartDatasetConfig y-axis aggregation operation"
+          },
+          dateField: { type: "string", description: "ChartDatasetConfig date field for filtering" },
+          dateFormat: { type: "string", description: "ChartDatasetConfig date format (e.g. YYYY-MM-DD)" },
+          conditions: { type: "array", items: { type: "object" }, description: "ChartDatasetConfig chart-specific filtering conditions" },
+          formula: { type: "string", description: "ChartDatasetConfig formula for transforming displayed values" },
+          seriesConfiguration: { type: "object", description: "ChartDatasetConfig.configuration for series-specific settings such as variable overrides" },
           datasetColor: { type: "string", description: "Color for the dataset in this chart" },
           fillColor: { type: "string", description: "Fill color for area charts" },
           fill: { type: "boolean", description: "Fill area under line" },
@@ -328,13 +334,13 @@ async function availableTools() {
     },
     {
       name: "create_temporary_chart",
-      description: "DEFAULT tool for creating charts. Create a temporary preview chart that shows the data visually without placing it in a visible dashboard. Use this for ALL chart creation requests UNLESS the user explicitly says 'add to [dashboard]' or 'place in [dashboard]'. The chart will be shown as a preview and can later be moved to a dashboard using move_chart_to_dashboard if the user requests it.",
+      description: "DEFAULT tool for creating charts. Create a temporary preview chart that shows the data visually without placing it in a visible dashboard. This creates a reusable dataset plus a ChartDatasetConfig that owns the series bindings. Use this for ALL chart creation requests UNLESS the user explicitly says 'add to [dashboard]' or 'place in [dashboard]'.",
       parameters: {
         type: "object",
         properties: {
           connection_id: { type: "string", description: "Connection ID to use for data fetching (must be MySQL, PostgreSQL, or MongoDB)" },
           name: { type: "string", description: "Chart name/title" },
-          legend: { type: "string", description: "Short legend text for data points (max 20-30 chars, appears on hover)" },
+          legend: { type: "string", description: "Chart-series label stored on ChartDatasetConfig.legend (max 20-30 chars, appears on hover)" },
           type: { type: "string", enum: ["line", "bar", "pie", "doughnut", "radar", "polar", "table", "kpi", "avg", "gauge", "matrix"] },
           subType: { type: "string", description: "Chart subtype (e.g. 'AddTimeseries' for KPI totals)" },
           displayLegend: { type: "boolean", description: "Show chart legend" },
@@ -363,19 +369,20 @@ async function availableTools() {
             },
             description: "Gauge ranges [{min, max, label, color}]"
           },
-          xAxis: { type: "string", description: "X axis field using traversal syntax (use 'root[].field_name' for array results)" },
-          yAxis: { type: "string", description: "Y axis field using traversal syntax (use 'root[].field_name' for array results)" },
+          xAxis: { type: "string", description: "ChartDatasetConfig x-axis field using traversal syntax (use 'root[].field_name' for array results)" },
+          xAxisOperation: { type: "string", description: "ChartDatasetConfig x-axis operation" },
+          yAxis: { type: "string", description: "ChartDatasetConfig y-axis field using traversal syntax (use 'root[].field_name' for array results)" },
           yAxisOperation: {
             type: "string",
             enum: ["none", "sum", "avg", "min", "max", "count"],
             default: "none",
-            description: "Y axis aggregation operation"
+            description: "ChartDatasetConfig y-axis aggregation operation"
           },
-          dateField: { type: "string", description: "Date field for filtering" },
-          dateFormat: { type: "string", description: "Date format (e.g. YYYY-MM-DD)" },
+          dateField: { type: "string", description: "ChartDatasetConfig date field for filtering" },
+          dateFormat: { type: "string", description: "ChartDatasetConfig date format (e.g. YYYY-MM-DD)" },
           query: { type: "string", description: "SQL query for the dataset" },
-          conditions: { type: "array", items: { type: "object" }, description: "Database filtering conditions" },
-          configuration: { type: "object", description: "Dialect-specific settings" },
+          conditions: { type: "array", items: { type: "object" }, description: "ChartDatasetConfig chart-specific filtering conditions" },
+          configuration: { type: "object", description: "DataRequest dialect-specific settings for the reusable dataset" },
           variables: {
             type: "array",
             items: { type: "string" },
@@ -383,6 +390,8 @@ async function availableTools() {
             description: "Query variables/parameters"
           },
           transform: { type: "object", description: "Data transformation rules" },
+          formula: { type: "string", description: "ChartDatasetConfig formula for transforming displayed values" },
+          seriesConfiguration: { type: "object", description: "ChartDatasetConfig.configuration for series-specific settings such as variable overrides" },
           spec: { type: "object", description: "Alternative: Chart specification object (backward compatibility)" }
         },
         required: ["connection_id", "name", "xAxis", "yAxis", "query"]
@@ -503,9 +512,9 @@ ${chartCatalog.map((catalog) => Object.entries(catalog).map(([type, info]) => `-
    - **MongoDB connections**: NoSQL databases with collections/documents
    - *API connections and other sources will be available in future updates*
 2. **DataRequests**: Define how to fetch data using SQL queries
-3. **Datasets**: Process and transform data from DataRequests for visualization
+3. **Datasets**: Reusable query/data definitions backed by DataRequests
 4. **Charts**: Visual representations of Datasets, placed in Projects (dashboards)
-5. **ChartDatasetConfigs**: Link Charts to Datasets with specific configurations
+5. **ChartDatasetConfigs**: Link Charts to Datasets with chart-specific bindings, filters, labels, and display settings
 
 ${ENTITY_CREATION_RULES}
 
@@ -873,10 +882,10 @@ async function buildSemanticLayer(teamId) {
     where: {
       team_id: teamId,
     },
-    attributes: ["id", "legend", "query", "xAxis", "yAxis", "yAxisOperation", "dateFormat"],
+    attributes: ["id", "name", "legend", "main_dr_id"],
     include: [{
       model: db.DataRequest,
-      attributes: ["id", "connection_id", "query", "conditions", "configuration"]
+      attributes: ["id", "connection_id", "query", "conditions", "configuration", "variables", "transform"]
     }]
   });
 

--- a/server/modules/ai/orchestrator/tools/createChart.js
+++ b/server/modules/ai/orchestrator/tools/createChart.js
@@ -1,5 +1,6 @@
 const db = require("../../../../models/models");
 const ChartController = require("../../../../controllers/ChartController");
+const { getDatasetName } = require("../../../resolveChartDatasetOptions");
 
 const chartController = new ChartController();
 
@@ -11,6 +12,8 @@ async function createChart(payload) {
     name, legend, type, subType, displayLegend, pointRadius,
     dataLabels, includeZeros, timeInterval, stacked, horizontal,
     xLabelTicks, showGrowth, invertGrowth, mode, maxValue, minValue, ranges,
+    xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat,
+    conditions, formula, seriesConfiguration,
   } = payload;
 
   if (!project_id) {
@@ -100,12 +103,19 @@ async function createChart(payload) {
       layout: chartSpec.layout, // Will be auto-calculated if not provided
       chartDatasetConfigs: [{
         dataset_id,
-        formula: chartSpec.formula,
+        xAxis: xAxis ?? chartSpec.xAxis,
+        xAxisOperation: xAxisOperation ?? chartSpec.xAxisOperation,
+        yAxis: yAxis ?? chartSpec.yAxis,
+        yAxisOperation: yAxisOperation ?? chartSpec.yAxisOperation,
+        dateField: dateField ?? chartSpec.dateField,
+        dateFormat: dateFormat ?? chartSpec.dateFormat,
+        conditions: conditions ?? chartSpec.conditions,
+        formula: formula ?? chartSpec.formula,
         datasetColor: chartSpec.datasetColor || chartSpec.options?.color || "#4285F4",
         fillColor: chartSpec.fillColor,
         fill: chartSpec.fill || false,
         multiFill: chartSpec.multiFill || false,
-        legend: legend || chartSpec.title || dataset.legend,
+        legend: legend ?? chartSpec.legend ?? getDatasetName(dataset),
         pointRadius: pointRadius || chartSpec.pointRadius || 0,
         excludedFields: chartSpec.excludedFields || [],
         sort: chartSpec.sort,
@@ -113,7 +123,7 @@ async function createChart(payload) {
         order: 1,
         maxRecords: chartSpec.maxRecords,
         goal: chartSpec.goal,
-        configuration: chartSpec.configuration || {}
+        configuration: seriesConfiguration ?? chartSpec.configuration ?? {}
       }]
     }, null); // No user for AI-created charts
 

--- a/server/modules/ai/orchestrator/tools/createDataset.js
+++ b/server/modules/ai/orchestrator/tools/createDataset.js
@@ -8,8 +8,7 @@ const clientUrl = process.env.NODE_ENV === "production" ? process.env.VITE_APP_C
 async function createDataset(payload) {
   const {
     project_id, connection_id, name, team_id,
-    xAxis, yAxis, yAxisOperation = "none", dateField, dateFormat,
-    query, conditions = [], configuration = {}, variables = [], transform = null,
+    query, configuration = {}, variables = [], transform = null,
     variableBindings = []
   } = payload;
 
@@ -32,18 +31,11 @@ async function createDataset(payload) {
       team_id,
       project_ids: projectIds,
       draft: false,
-      legend: name || "AI Generated Dataset",
-      xAxis,
-      yAxis,
-      yAxisOperation,
-      dateField,
-      dateFormat,
-      conditions,
+      name: name || "AI Generated Dataset",
       variableBindings,
       dataRequests: [{
         connection_id,
         query,
-        conditions: conditions || [],
         configuration: configuration || {},
         variables: variables || [],
         transform: transform || null
@@ -59,7 +51,7 @@ async function createDataset(payload) {
     return {
       dataset_id: dataset.id,
       data_request_id: dataRequestId,
-      name: dataset.legend,
+      name: dataset.name || dataset.legend,
       dataset_url: `${clientUrl}/datasets/${dataset.id}`,
     };
   } catch (error) {

--- a/server/modules/ai/orchestrator/tools/createTemporaryChart.js
+++ b/server/modules/ai/orchestrator/tools/createTemporaryChart.js
@@ -1,6 +1,7 @@
 const db = require("../../../../models/models");
 const DatasetController = require("../../../../controllers/DatasetController");
 const ChartController = require("../../../../controllers/ChartController");
+const { getDatasetName } = require("../../../resolveChartDatasetOptions");
 
 const datasetController = new DatasetController();
 const chartController = new ChartController();
@@ -10,9 +11,9 @@ async function createTemporaryChart(payload) {
     connection_id, name, legend, type, subType, displayLegend, pointRadius,
     dataLabels, includeZeros, timeInterval, stacked, horizontal, xLabelTicks,
     showGrowth, invertGrowth, mode, maxValue, minValue, ranges,
-    xAxis, yAxis, yAxisOperation = "none", dateField, dateFormat,
+    xAxis, xAxisOperation, yAxis, yAxisOperation = "none", dateField, dateFormat,
     query, conditions = [], configuration = {}, variables = [], transform = null,
-    variableBindings = [], spec = {}, team_id
+    variableBindings = [], spec = {}, team_id, formula, seriesConfiguration,
   } = payload;
 
   if (!team_id) {
@@ -46,18 +47,11 @@ async function createTemporaryChart(payload) {
       team_id,
       project_ids: [],
       draft: false,
-      legend: name || "AI Generated Dataset",
-      xAxis,
-      yAxis,
-      yAxisOperation,
-      dateField,
-      dateFormat,
-      conditions,
+      name: name || "AI Generated Dataset",
       variableBindings,
       dataRequests: [{
         connection_id,
         query,
-        conditions: conditions || [],
         configuration: configuration || {},
         variables: variables || [],
         transform: transform || null
@@ -103,12 +97,19 @@ async function createTemporaryChart(payload) {
       ranges: ranges || spec.ranges,
       chartDatasetConfigs: [{
         dataset_id: dataset.id,
-        formula: spec.formula,
+        xAxis: xAxis ?? spec.xAxis,
+        xAxisOperation: xAxisOperation ?? spec.xAxisOperation,
+        yAxis: yAxis ?? spec.yAxis,
+        yAxisOperation: yAxisOperation ?? spec.yAxisOperation,
+        dateField: dateField ?? spec.dateField,
+        dateFormat: dateFormat ?? spec.dateFormat,
+        conditions: conditions ?? spec.conditions,
+        formula: formula ?? spec.formula,
         datasetColor: spec.datasetColor || spec.options?.color || "#4285F4",
         fillColor: spec.fillColor,
         fill: spec.fill || false,
         multiFill: spec.multiFill || false,
-        legend: legend || spec.title || dataset.legend,
+        legend: legend ?? spec.legend ?? getDatasetName(dataset),
         pointRadius: pointRadius || spec.pointRadius || 0,
         excludedFields: spec.excludedFields || [],
         sort: spec.sort,
@@ -116,7 +117,7 @@ async function createTemporaryChart(payload) {
         order: 1,
         maxRecords: spec.maxRecords,
         goal: spec.goal,
-        configuration: spec.configuration || {}
+        configuration: seriesConfiguration ?? spec.configuration ?? {}
       }]
     }, null);
 

--- a/server/modules/ai/orchestrator/tools/updateChart.js
+++ b/server/modules/ai/orchestrator/tools/updateChart.js
@@ -7,6 +7,8 @@ async function updateChart(payload) {
     name, legend, type, subType, displayLegend, pointRadius,
     dataLabels, includeZeros, timeInterval, stacked, horizontal,
     xLabelTicks, showGrowth, invertGrowth, mode, maxValue, minValue, ranges,
+    xAxis, xAxisOperation, yAxis, yAxisOperation, dateField, dateFormat,
+    conditions, formula, seriesConfiguration,
     datasetColor, fillColor, fill, multiFill, excludedFields, sort, columnsOrder, maxRecords, goal
   } = payload;
 
@@ -133,12 +135,40 @@ async function updateChart(payload) {
     }
 
     // Find and update the chart dataset config (if dataset_id is provided)
-    if (
-      dataset_id
-      || legend || datasetColor || fillColor || fill || multiFill
-      || excludedFields || sort || columnsOrder || maxRecords || goal
-      || pointRadius !== undefined || chartSpec.pointRadius !== undefined
-    ) {
+    const shouldUpdateCdc = dataset_id !== undefined
+      || legend !== undefined
+      || xAxis !== undefined
+      || xAxisOperation !== undefined
+      || yAxis !== undefined
+      || yAxisOperation !== undefined
+      || dateField !== undefined
+      || dateFormat !== undefined
+      || conditions !== undefined
+      || formula !== undefined
+      || seriesConfiguration !== undefined
+      || datasetColor !== undefined
+      || fillColor !== undefined
+      || fill !== undefined
+      || multiFill !== undefined
+      || excludedFields !== undefined
+      || sort !== undefined
+      || columnsOrder !== undefined
+      || maxRecords !== undefined
+      || goal !== undefined
+      || pointRadius !== undefined
+      || chartSpec.pointRadius !== undefined
+      || chartSpec.legend !== undefined
+      || chartSpec.xAxis !== undefined
+      || chartSpec.xAxisOperation !== undefined
+      || chartSpec.yAxis !== undefined
+      || chartSpec.yAxisOperation !== undefined
+      || chartSpec.dateField !== undefined
+      || chartSpec.dateFormat !== undefined
+      || chartSpec.conditions !== undefined
+      || chartSpec.formula !== undefined
+      || chartSpec.configuration !== undefined;
+
+    if (shouldUpdateCdc) {
       const configWhere = { chart_id };
       if (dataset_id) {
         configWhere.dataset_id = dataset_id;
@@ -153,8 +183,50 @@ async function updateChart(payload) {
 
         if (legend !== undefined) {
           configUpdates.legend = legend;
-        } else if (chartSpec.title !== undefined) {
-          configUpdates.legend = chartSpec.title;
+        } else if (chartSpec.legend !== undefined) {
+          configUpdates.legend = chartSpec.legend;
+        }
+
+        if (xAxis !== undefined) {
+          configUpdates.xAxis = xAxis;
+        } else if (chartSpec.xAxis !== undefined) {
+          configUpdates.xAxis = chartSpec.xAxis;
+        }
+
+        if (xAxisOperation !== undefined) {
+          configUpdates.xAxisOperation = xAxisOperation;
+        } else if (chartSpec.xAxisOperation !== undefined) {
+          configUpdates.xAxisOperation = chartSpec.xAxisOperation;
+        }
+
+        if (yAxis !== undefined) {
+          configUpdates.yAxis = yAxis;
+        } else if (chartSpec.yAxis !== undefined) {
+          configUpdates.yAxis = chartSpec.yAxis;
+        }
+
+        if (yAxisOperation !== undefined) {
+          configUpdates.yAxisOperation = yAxisOperation;
+        } else if (chartSpec.yAxisOperation !== undefined) {
+          configUpdates.yAxisOperation = chartSpec.yAxisOperation;
+        }
+
+        if (dateField !== undefined) {
+          configUpdates.dateField = dateField;
+        } else if (chartSpec.dateField !== undefined) {
+          configUpdates.dateField = chartSpec.dateField;
+        }
+
+        if (dateFormat !== undefined) {
+          configUpdates.dateFormat = dateFormat;
+        } else if (chartSpec.dateFormat !== undefined) {
+          configUpdates.dateFormat = chartSpec.dateFormat;
+        }
+
+        if (conditions !== undefined) {
+          configUpdates.conditions = conditions;
+        } else if (chartSpec.conditions !== undefined) {
+          configUpdates.conditions = chartSpec.conditions;
         }
 
         if (datasetColor !== undefined) {
@@ -213,7 +285,9 @@ async function updateChart(payload) {
           configUpdates.goal = chartSpec.goal;
         }
 
-        if (chartSpec.formula !== undefined) {
+        if (formula !== undefined) {
+          configUpdates.formula = formula;
+        } else if (chartSpec.formula !== undefined) {
           configUpdates.formula = chartSpec.formula;
         }
 
@@ -221,6 +295,12 @@ async function updateChart(payload) {
           configUpdates.pointRadius = pointRadius;
         } else if (chartSpec.pointRadius !== undefined) {
           configUpdates.pointRadius = chartSpec.pointRadius;
+        }
+
+        if (seriesConfiguration !== undefined) {
+          configUpdates.configuration = seriesConfiguration;
+        } else if (chartSpec.configuration !== undefined) {
+          configUpdates.configuration = chartSpec.configuration;
         }
 
         if (Object.keys(configUpdates).length > 0) {
@@ -268,7 +348,7 @@ async function updateChart(payload) {
       snapshot,
       updated_fields: {
         chart: Object.keys(chartUpdates),
-        config: dataset_id || legend || datasetColor || fillColor || fill || multiFill || excludedFields || sort || columnsOrder || maxRecords || goal ? "chart_dataset_config" : null
+        config: shouldUpdateCdc ? "chart_dataset_config" : null
       }
     };
   } catch (error) {

--- a/server/modules/ai/orchestrator/tools/updateDataset.js
+++ b/server/modules/ai/orchestrator/tools/updateDataset.js
@@ -3,8 +3,7 @@ const db = require("../../../../models/models");
 async function updateDataset(payload) {
   const {
     dataset_id, name, team_id,
-    xAxis, yAxis, yAxisOperation, dateField, dateFormat,
-    query, conditions, configuration, variables, transform
+    query, configuration, variables, transform
   } = payload;
 
   if (!dataset_id) {
@@ -29,13 +28,7 @@ async function updateDataset(payload) {
 
     // Update dataset fields (only if provided)
     const datasetUpdates = {};
-    if (name !== undefined) datasetUpdates.legend = name;
-    if (xAxis !== undefined) datasetUpdates.xAxis = xAxis;
-    if (yAxis !== undefined) datasetUpdates.yAxis = yAxis;
-    if (yAxisOperation !== undefined) datasetUpdates.yAxisOperation = yAxisOperation;
-    if (dateField !== undefined) datasetUpdates.dateField = dateField;
-    if (dateFormat !== undefined) datasetUpdates.dateFormat = dateFormat;
-    if (conditions !== undefined) datasetUpdates.conditions = conditions;
+    if (name !== undefined) datasetUpdates.name = name;
 
     if (Object.keys(datasetUpdates).length > 0) {
       await db.Dataset.update(datasetUpdates, { where: { id: dataset_id } });
@@ -50,7 +43,6 @@ async function updateDataset(payload) {
     // Update data request fields (only if provided)
     const drUpdates = {};
     if (query !== undefined) drUpdates.query = query;
-    if (conditions !== undefined) drUpdates.conditions = conditions;
     if (configuration !== undefined) drUpdates.configuration = configuration;
     if (variables !== undefined) drUpdates.variables = variables;
     if (transform !== undefined) drUpdates.transform = transform;
@@ -70,7 +62,7 @@ async function updateDataset(payload) {
     return {
       dataset_id: updatedDataset.id,
       data_request_id: updatedDataset.main_dr_id,
-      name: updatedDataset.legend,
+      name: updatedDataset.name || updatedDataset.legend,
       dataset_url: `${global.clientUrl}/${team_id}/dataset/${updatedDataset.id}`,
       updated_fields: {
         dataset: Object.keys(datasetUpdates),

--- a/server/modules/ai/orchestrator/validateRules.js
+++ b/server/modules/ai/orchestrator/validateRules.js
@@ -24,10 +24,10 @@ const REQUIRED_SECTIONS = [
 ];
 
 const REQUIRED_KEYWORDS = {
-  Dataset: ["Required:", "draft", "main_dr_id", "xAxis", "yAxis"],
+  Dataset: ["Required:", "name", "query", "main_dr_id"],
   DataRequest: ["Required:", "query"],
   Chart: ["Required:", "draft", "type"],
-  ChartDatasetConfig: ["Required:", "chart_id", "dataset_id"]
+  ChartDatasetConfig: ["Required:", "chart_id", "dataset_id", "xAxis", "yAxis"]
 };
 
 function validateRules() {

--- a/server/modules/resolveChartDatasetOptions.js
+++ b/server/modules/resolveChartDatasetOptions.js
@@ -1,0 +1,62 @@
+const CDC_OPTION_FIELDS = [
+  "xAxis",
+  "xAxisOperation",
+  "yAxis",
+  "yAxisOperation",
+  "dateField",
+  "dateFormat",
+  "conditions",
+  "legend",
+  "formula",
+  "excludedFields",
+  "sort",
+  "columnsOrder",
+  "order",
+  "maxRecords",
+  "goal",
+  "datasetColor",
+  "fillColor",
+  "fill",
+  "multiFill",
+  "pointRadius",
+  "configuration",
+];
+
+function toPlainObject(value) {
+  if (!value) return {};
+  if (typeof value.toJSON === "function") return value.toJSON();
+  return { ...value };
+}
+
+function getDatasetName(dataset) {
+  const plainDataset = toPlainObject(dataset);
+  return plainDataset.name || plainDataset.legend || null;
+}
+
+function resolveChartDatasetOptions(cdc, datasetOptions) {
+  const plainDataset = toPlainObject(datasetOptions || cdc?.Dataset);
+  const plainCdc = toPlainObject(cdc);
+  const mergedOptions = { ...plainDataset };
+
+  CDC_OPTION_FIELDS.forEach((field) => {
+    if (plainCdc[field] !== undefined && plainCdc[field] !== null) {
+      mergedOptions[field] = plainCdc[field];
+    }
+  });
+
+  mergedOptions.id = plainCdc.id || mergedOptions.id;
+  mergedOptions.cdc_id = plainCdc.id || mergedOptions.cdc_id || null;
+  mergedOptions.dataset_id = plainCdc.dataset_id || mergedOptions.dataset_id || plainDataset.id || null;
+  mergedOptions.name = getDatasetName(plainDataset);
+
+  if ((plainCdc.legend === undefined || plainCdc.legend === null) && !mergedOptions.legend) {
+    mergedOptions.legend = mergedOptions.name;
+  }
+
+  return mergedOptions;
+}
+
+module.exports = {
+  getDatasetName,
+  resolveChartDatasetOptions,
+};

--- a/server/modules/resolveChartDatasetOptions.js
+++ b/server/modules/resolveChartDatasetOptions.js
@@ -46,7 +46,8 @@ function resolveChartDatasetOptions(cdc, datasetOptions) {
 
   mergedOptions.id = plainCdc.id || mergedOptions.id;
   mergedOptions.cdc_id = plainCdc.id || mergedOptions.cdc_id || null;
-  mergedOptions.dataset_id = plainCdc.dataset_id || mergedOptions.dataset_id || plainDataset.id || null;
+  mergedOptions.dataset_id = plainCdc.dataset_id
+    || mergedOptions.dataset_id || plainDataset.id || null;
   mergedOptions.name = getDatasetName(plainDataset);
 
   if ((plainCdc.legend === undefined || plainCdc.legend === null) && !mergedOptions.legend) {

--- a/server/tests/integration/chartController.cdcBindings.test.js
+++ b/server/tests/integration/chartController.cdcBindings.test.js
@@ -1,0 +1,122 @@
+import {
+  beforeAll, beforeEach, describe, expect, it, vi,
+} from "vitest";
+import { createRequire } from "module";
+
+import { getModels } from "../helpers/dbHelpers.js";
+import { testDbManager } from "../helpers/testDbManager.js";
+
+const require = createRequire(import.meta.url);
+
+describe("ChartController CDC bindings", () => {
+  let models;
+  let ChartController;
+
+  beforeAll(async () => {
+    if (!testDbManager.getSequelize()) {
+      await testDbManager.start();
+    }
+
+    models = await getModels();
+    ChartController = require("../../controllers/ChartController.js");
+  });
+
+  beforeEach(async () => {
+    await models.sequelize.sync({ force: true });
+  });
+
+  it("merges CDC binding fields over legacy dataset fields and persists condition options to the CDC", async () => {
+    const team = await models.Team.create({
+      name: "CDC Team",
+    });
+
+    const project = await models.Project.create({
+      team_id: team.id,
+      name: "CDC Project",
+      brewName: "cdc-project",
+      ghost: false,
+    });
+
+    const chart = await models.Chart.create({
+      project_id: project.id,
+      name: "Revenue Chart",
+      type: "bar",
+      draft: false,
+    });
+
+    const dataset = await models.Dataset.create({
+      team_id: team.id,
+      project_ids: [project.id],
+      draft: false,
+      name: "Orders Dataset",
+      legend: "Legacy Dataset",
+      xAxis: "root[].month",
+      yAxis: "root[].count",
+      yAxisOperation: "none",
+      conditions: [{
+        field: "root[].status",
+        operator: "is",
+        value: "pending",
+        exposed: true,
+      }],
+      fieldsSchema: {
+        "root[].month": "string",
+        "root[].count": "number",
+        "root[].amount": "number",
+        "root[].status": "string",
+      },
+    });
+
+    const cdc = await models.ChartDatasetConfig.create({
+      chart_id: chart.id,
+      dataset_id: dataset.id,
+      xAxis: "root[].month",
+      yAxis: "root[].amount",
+      yAxisOperation: "none",
+      legend: "Revenue",
+      conditions: [{
+        field: "root[].status",
+        operator: "is",
+        value: "paid",
+        exposed: true,
+      }],
+    });
+
+    const controller = new ChartController();
+    const runRequestSpy = vi.spyOn(controller.datasetController, "runRequest")
+      .mockResolvedValue({
+        options: dataset.toJSON(),
+        data: [
+          { month: "Jan", count: 1, amount: 100, status: "paid" },
+          { month: "Feb", count: 2, amount: 200, status: "pending" },
+        ],
+      });
+
+    const updatedChart = await controller.updateChartData(chart.id, null, {
+      skipSave: true,
+      getCache: true,
+    });
+
+    runRequestSpy.mockRestore();
+
+    expect(updatedChart.chartData.data.datasets[0].data).toEqual([100]);
+    expect(updatedChart.chartData.data.datasets[0].label).toBe("Revenue");
+
+    const refreshedCdc = await models.ChartDatasetConfig.findByPk(cdc.id);
+    const refreshedDataset = await models.Dataset.findByPk(dataset.id);
+
+    expect(refreshedCdc.conditions).toEqual([{
+      field: "root[].status",
+      operator: "is",
+      value: "paid",
+      exposed: true,
+      values: ["paid", "pending"],
+    }]);
+    expect(refreshedDataset.conditions).toEqual([{
+      field: "root[].status",
+      operator: "is",
+      value: "pending",
+      exposed: true,
+    }]);
+  });
+});

--- a/server/tests/integration/chartController.cdcBindings.test.js
+++ b/server/tests/integration/chartController.cdcBindings.test.js
@@ -87,8 +87,12 @@ describe("ChartController CDC bindings", () => {
       .mockResolvedValue({
         options: dataset.toJSON(),
         data: [
-          { month: "Jan", count: 1, amount: 100, status: "paid" },
-          { month: "Feb", count: 2, amount: 200, status: "pending" },
+          {
+            month: "Jan", count: 1, amount: 100, status: "paid"
+          },
+          {
+            month: "Feb", count: 2, amount: 200, status: "pending"
+          },
         ],
       });
 

--- a/server/tests/unit/resolveChartDatasetOptions.test.js
+++ b/server/tests/unit/resolveChartDatasetOptions.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { resolveChartDatasetOptions, getDatasetName } = require("../../modules/resolveChartDatasetOptions.js");
+
+describe("resolveChartDatasetOptions", () => {
+  it("prefers CDC binding fields over legacy dataset fields", () => {
+    const options = resolveChartDatasetOptions(
+      {
+        id: "cdc-1",
+        dataset_id: 10,
+        xAxis: "root[].created_at",
+        yAxis: "root[].revenue",
+        yAxisOperation: "sum",
+        dateField: "root[].created_at",
+        legend: "Revenue",
+        conditions: [{ field: "root[].status", operator: "is", value: "paid" }],
+      },
+      {
+        id: 10,
+        name: "Orders",
+        legend: "Legacy Orders",
+        xAxis: "root[].day",
+        yAxis: "root[].count",
+        yAxisOperation: "count",
+        dateField: "root[].day",
+        conditions: [{ field: "root[].status", operator: "is", value: "open" }],
+      }
+    );
+
+    expect(options.id).toBe("cdc-1");
+    expect(options.cdc_id).toBe("cdc-1");
+    expect(options.dataset_id).toBe(10);
+    expect(options.name).toBe("Orders");
+    expect(options.legend).toBe("Revenue");
+    expect(options.xAxis).toBe("root[].created_at");
+    expect(options.yAxis).toBe("root[].revenue");
+    expect(options.yAxisOperation).toBe("sum");
+    expect(options.conditions).toEqual([{ field: "root[].status", operator: "is", value: "paid" }]);
+  });
+
+  it("uses dataset name fallback when CDC legend is absent", () => {
+    const options = resolveChartDatasetOptions(
+      {
+        id: "cdc-2",
+        dataset_id: 11,
+      },
+      {
+        id: 11,
+        legend: "Legacy Dataset Name",
+      }
+    );
+
+    expect(options.name).toBe("Legacy Dataset Name");
+    expect(options.legend).toBe("Legacy Dataset Name");
+  });
+
+  it("treats empty arrays and empty strings on CDC as explicit overrides", () => {
+    const options = resolveChartDatasetOptions(
+      {
+        id: "cdc-3",
+        dataset_id: 12,
+        legend: "",
+        conditions: [],
+      },
+      {
+        id: 12,
+        name: "Dataset Name",
+        legend: "Legacy Legend",
+        conditions: [{ field: "root[].status", operator: "is", value: "paid" }],
+      }
+    );
+
+    expect(options.legend).toBe("");
+    expect(options.conditions).toEqual([]);
+  });
+});
+
+describe("getDatasetName", () => {
+  it("prefers name over legacy legend", () => {
+    expect(getDatasetName({ name: "Canonical Name", legend: "Legacy" })).toBe("Canonical Name");
+    expect(getDatasetName({ legend: "Legacy" })).toBe("Legacy");
+  });
+});


### PR DESCRIPTION
### Description

Datasets should not be concerned with the visualzation layer to make them truly re-usable. This update touches on a few user journey points and re-thinks how the visualization setup works:

- Datasets only allow users to set up data requests
- Datasets will now prompt the users to create a new chart
- The metric/dimension fields and filters can now be set up in the Chart Editor so multiple charts can use the same datasets, but with different breakdowns and complete filter control
- Re-design Dataset UI
- Re-design Chart Editor UI
- Re-design the Quick-Create API
- Updated AI orchestrator

### Spec or ADR

- FS-20260321-cdc-viz-binding
