### PR TITLE
fix: require invitation token at /user/invited to prevent unauthorized signup

### DIFF
--- a/server/api/UserRoute.js
+++ b/server/api/UserRoute.js
@@ -122,6 +122,14 @@ module.exports = (app) => {
   */
   app.post("/user/invited", (req, res) => {
     if (!req.body.email || !req.body.password) return res.status(400).send("no email or password");
+    if (!req.body.token) return res.status(400).send("invitation token is required");
+
+    // Verify the invitation token before allowing account creation
+    try {
+      jwt.verify(req.body.token, app.settings.encryptionKey);
+    } catch (err) {
+      return res.status(401).send("Invalid or expired invitation token");
+    }
 
     const icon = req.body.name.substring(0, 2);
 


### PR DESCRIPTION
## Summary

Require a valid invitation JWT token at the `/user/invited` endpoint to prevent unauthorized account creation that bypasses signup restrictions.

## Problem

The `/user/invited` endpoint creates new user accounts with `active: true` but **does not validate any invitation token**:

```js
app.post("/user/invited", (req, res) => {
    // No authentication, no token validation
    const userObj = {
      ...
      active: true,  // Immediately active
    };
    return userController.createUser(userObj)
```

Compare with the normal signup at `POST /user`:
```js
app.post("/user", async (req, res) => {
    if (app.settings.signupRestricted === "1") {
      // Checks signup restriction
    }
    const userObj = { ...active: false };  // Not immediately active
```

This allows an attacker to:
1. Send `POST /user/invited` with any email/password — **no invitation required**
2. Receive an active account with a valid JWT token
3. Bypass `signupRestricted` setting entirely
4. Create unlimited accounts on any Chartbrew instance

## Fix

Validate the invitation token (JWT signed with the app's encryption key) before allowing account creation:

```js
if (!req.body.token) return res.status(400).send("invitation token is required");
try {
    jwt.verify(req.body.token, app.settings.encryptionKey);
} catch (err) {
    return res.status(401).send("Invalid or expired invitation token");
}
```

The invitation token is already generated by the `POST /team/:id/invite` endpoint and passed to the client via the invite URL. This fix ensures the token must be present and valid before an account can be created through the invitation flow.

## Impact

- **Type**: Authentication Bypass / Unauthorized Account Creation (CWE-287)
- **Affected endpoint**: `POST /user/invited`
- **Risk**: Unlimited active account creation bypassing signup restrictions on any Chartbrew instance
- **OWASP**: A07:2021 — Identification and Authentication Failures