### PR TITLE
Add a Jira connection type

### DIFF
--- a/client/src/containers/AddChart/components/ChartDatasetDataSetup.jsx
+++ b/client/src/containers/AddChart/components/ChartDatasetDataSetup.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import toast from "react-hot-toast";
@@ -10,7 +10,6 @@ import { LuLayers, LuSettings } from "react-icons/lu";
 import Row from "../../../components/Row";
 import Text from "../../../components/Text";
 import DatasetFilters from "../../../components/DatasetFilters";
-import autoFieldSelector from "../../../modules/autoFieldSelector";
 import { getDatasetFieldOptionsFromResponse, getDatasetFieldOptionsFromSchema } from "../../../modules/getDatasetFieldOptions";
 import { operations } from "../../../modules/filterOperations";
 import { runRequest as runDatasetRequest, updateDataset } from "../../../slices/dataset";
@@ -18,12 +17,6 @@ import getDatasetDisplayName from "../../../modules/getDatasetDisplayName";
 import canAccess from "../../../config/canAccess";
 import { selectUser } from "../../../slices/user";
 import { selectTeam } from "../../../slices/team";
-
-function getStripeOfficialDateField(configuration = {}) {
-  if (configuration.mode === "compiled_metric") return "root[].period";
-  if (configuration.mode === "aggregate") return "root[].period";
-  return `root[].${configuration.dateRange?.field || "created"}`;
-}
 
 function ChartDatasetDataSetup({
   cdc,
@@ -42,7 +35,6 @@ function ChartDatasetDataSetup({
 
   const [fieldOptions, setFieldOptions] = useState([]);
   const [loadingFields, setLoadingFields] = useState(false);
-  const autoSuggestedRef = useRef({});
 
   const user = useSelector(selectUser);
   const team = useSelector(selectTeam);
@@ -82,7 +74,6 @@ function ChartDatasetDataSetup({
 
   useEffect(() => {
     if (!dataset?.id) return;
-    if (autoSuggestedRef.current[cdc?.id] && cdc?.id) return;
 
     let nextFieldOptions = [];
     let nextFieldsSchema = null;
@@ -106,48 +97,12 @@ function ChartDatasetDataSetup({
         data: { fieldsSchema: nextFieldsSchema },
       }));
     }
-
-    if (!cdc?.id) return;
-
-    const autoFields = autoFieldSelector(nextFieldOptions);
-    const autoUpdates = {};
-    const stripeDateField = isStripeOfficialDataset
-      ? getStripeOfficialDateField(sourceConfiguration)
-      : null;
-
-    if (!cdc.xAxis && autoFields.xAxis) autoUpdates.xAxis = autoFields.xAxis;
-    if (!cdc.yAxis && autoFields.yAxis) autoUpdates.yAxis = autoFields.yAxis;
-    if (!cdc.dateField && (stripeDateField || autoFields.dateField)) {
-      autoUpdates.dateField = stripeDateField || autoFields.dateField;
-    }
-    if (!cdc.yAxisOperation && autoFields.yAxisOperation) autoUpdates.yAxisOperation = autoFields.yAxisOperation;
-
-    if (Object.keys(autoUpdates).length > 0) {
-      autoSuggestedRef.current[cdc.id] = true;
-      onUpdateCdc(autoUpdates);
-    } else {
-      autoSuggestedRef.current[cdc.id] = true;
-    }
   }, [
-    cdc?.id,
-    cdc?.xAxis,
-    cdc?.yAxis,
-    cdc?.dateField,
-    cdc?.yAxisOperation,
     dataset?.id,
     dataset?.fieldsSchema,
     datasetResponse,
     teamId,
-    isStripeOfficialDataset,
-    sourceConfiguration.mode,
-    sourceConfiguration.dateRange?.field,
   ]);
-
-  useEffect(() => {
-    if (cdc?.id && autoSuggestedRef.current[cdc.id] === undefined) {
-      autoSuggestedRef.current[cdc.id] = false;
-    }
-  }, [cdc?.id]);
 
   const filterDataset = useMemo(() => {
     return {

--- a/client/src/sources/definitions.js
+++ b/client/src/sources/definitions.js
@@ -2,6 +2,7 @@ import apiSource from "./api/api.source";
 import clickhouseSource from "./clickhouse/clickhouse.source";
 import firestoreSource from "./firestore/firestore.source";
 import googleAnalyticsSource from "./googleAnalytics/googleAnalytics.source";
+import jiraSource from "./jira/jira.source";
 import mongodbSource from "./mongodb/mongodb.source";
 import mysqlSource from "./mysql/mysql.source";
 import postgresSource from "./postgres/postgres.source";
@@ -30,6 +31,8 @@ const SOURCE_DEFINITIONS = [{
   ...realtimeDbSource,
 }, {
   ...googleAnalyticsSource,
+}, {
+  ...jiraSource,
 }, {
   ...strapiSource,
 }, {

--- a/client/src/sources/index.js
+++ b/client/src/sources/index.js
@@ -9,6 +9,7 @@ import RdsMysqlConnectionForm from "./rdsmysql/rdsmysql-connection-form";
 import FirestoreConnectionForm from "./firestore/firestore-connection-form";
 import RealtimeDbConnectionForm from "./realtimedb/realtimedb-connection-form";
 import GaConnectionForm from "./googleAnalytics/googleAnalytics-connection-form";
+import JiraConnectionForm from "./jira/jira-connection-form";
 import StrapiConnectionForm from "./strapi/strapi-connection-form";
 import StripeConnectionForm from "./stripe/stripe-connection-form";
 import StripeTemplateSetup from "./stripe/stripe-template-setup";
@@ -26,10 +27,12 @@ import MongoQueryBuilder from "./mongodb/mongodb-builder";
 import RealtimeDbBuilder from "./realtimedb/realtimedb-builder";
 import FirestoreBuilder from "./firestore/firestore-builder";
 import GaBuilder from "./googleAnalytics/googleAnalytics-builder";
+import JiraBuilder from "./jira/jira-builder";
 import CustomerioBuilder from "./customerio/customerio-builder";
 import ClickHouseBuilder from "./clickhouse/clickhouse-builder";
 import StripeOfficialBuilder from "./stripeOfficial/stripeOfficial-builder";
 import StripeOfficialTemplateSetup from "./stripeOfficial/stripeOfficial-template-setup";
+import JiraTemplateSetup from "./jira/jira-template-setup";
 import SOURCE_DEFINITIONS, {
   findSourceDefinitionForConnection,
   getSourceDefinition,
@@ -66,6 +69,11 @@ const FRONTEND_BY_SOURCE_ID = {
   googleAnalytics: {
     ConnectionForm: GaConnectionForm,
     DataRequestBuilder: GaBuilder,
+  },
+  jira: {
+    ConnectionForm: JiraConnectionForm,
+    DataRequestBuilder: JiraBuilder,
+    ChartTemplateSetup: JiraTemplateSetup,
   },
   strapi: {
     ConnectionForm: StrapiConnectionForm,

--- a/client/src/sources/jira/assets/jira-dark.svg
+++ b/client/src/sources/jira/assets/jira-dark.svg
@@ -1,0 +1,17 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="500" fill="black" style="fill:black;fill-opacity:1;"/>
+<g clip-path="url(#clip0_2820_2765)">
+<path d="M69 159.5C69 109.518 109.518 69 159.5 69H340.5C390.482 69 431 109.518 431 159.5V340.5C431 390.482 390.482 431 340.5 431H159.5C109.518 431 69 390.482 69 340.5V159.5Z" fill="#1868DB" style="fill:#1868DB;fill:color(display-p3 0.0941 0.4078 0.8588);fill-opacity:1;"/>
+<mask id="mask0_2820_2765" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="131" y="147" width="228" height="230">
+<path d="M358.838 147.358H131.125V376.837H358.838V147.358Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</mask>
+<g mask="url(#mask0_2820_2765)">
+<path d="M204.354 303.143H183.957C153.194 303.143 131.125 284.301 131.125 256.709H240.802C246.487 256.709 250.165 260.747 250.165 266.467V376.832C222.745 376.832 204.354 354.625 204.354 323.669V303.143ZM258.524 248.297H238.127C207.364 248.297 185.295 229.791 185.295 202.199H294.971C300.656 202.199 304.669 205.901 304.669 211.621V321.986C277.249 321.986 258.524 299.779 258.524 268.822V248.297ZM313.028 193.787H292.631C261.868 193.787 239.799 174.945 239.799 147.354H349.476C355.16 147.354 358.838 151.391 358.838 156.775V267.14C331.419 267.14 313.028 244.932 313.028 213.976V193.787Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_2820_2765">
+<rect width="362" height="362" fill="white" style="fill:white;fill-opacity:1;" transform="translate(69 69)"/>
+</clipPath>
+</defs>
+</svg>

--- a/client/src/sources/jira/assets/jira.svg
+++ b/client/src/sources/jira/assets/jira.svg
@@ -1,0 +1,17 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="500" height="500" fill="white" style="fill:white;fill-opacity:1;"/>
+<g clip-path="url(#clip0_2820_2742)">
+<path d="M69 159.5C69 109.518 109.518 69 159.5 69H340.5C390.482 69 431 109.518 431 159.5V340.5C431 390.482 390.482 431 340.5 431H159.5C109.518 431 69 390.482 69 340.5V159.5Z" fill="#1868DB" style="fill:#1868DB;fill:color(display-p3 0.0941 0.4078 0.8588);fill-opacity:1;"/>
+<mask id="mask0_2820_2742" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="131" y="147" width="228" height="230">
+<path d="M358.838 147.358H131.125V376.837H358.838V147.358Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</mask>
+<g mask="url(#mask0_2820_2742)">
+<path d="M204.354 303.143H183.957C153.194 303.143 131.125 284.301 131.125 256.709H240.802C246.487 256.709 250.165 260.747 250.165 266.467V376.832C222.745 376.832 204.354 354.625 204.354 323.669V303.143ZM258.524 248.297H238.127C207.364 248.297 185.295 229.791 185.295 202.199H294.971C300.656 202.199 304.669 205.901 304.669 211.621V321.986C277.249 321.986 258.524 299.779 258.524 268.822V248.297ZM313.028 193.787H292.631C261.868 193.787 239.799 174.945 239.799 147.354H349.476C355.16 147.354 358.838 151.391 358.838 156.775V267.14C331.419 267.14 313.028 244.932 313.028 213.976V193.787Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_2820_2742">
+<rect width="362" height="362" fill="white" style="fill:white;fill-opacity:1;" transform="translate(69 69)"/>
+</clipPath>
+</defs>
+</svg>

--- a/client/src/sources/jira/components/jira-builder-autocomplete-field.jsx
+++ b/client/src/sources/jira/components/jira-builder-autocomplete-field.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import {
   Autocomplete,
@@ -29,13 +29,19 @@ function JiraBuilderAutocompleteField(props) {
     emptyLabel,
   } = props;
   const { contains } = useFilter({ sensitivity: "base" });
-  const selectedValues = selectionMode === "multiple"
-    ? (Array.isArray(value) ? value.map((item) => `${item}`) : [])
-    : (value ? `${value}` : null);
-  const selectedKeys = selectionMode === "multiple"
-    ? selectedValues
-    : (selectedValues ? [selectedValues] : []);
-  const displayItems = [
+  const selectedValues = useMemo(() => {
+    if (selectionMode === "multiple") {
+      return Array.isArray(value) ? value.map((item) => `${item}`) : [];
+    }
+
+    return value ? `${value}` : null;
+  }, [selectionMode, value]);
+  const selectedKeys = useMemo(() => (
+    selectionMode === "multiple"
+      ? selectedValues
+      : (selectedValues ? [selectedValues] : [])
+  ), [selectedValues, selectionMode]);
+  const displayItems = useMemo(() => [
     ...items,
     ...selectedKeys
       .filter((key) => !findItem(items, key))
@@ -45,12 +51,15 @@ function JiraBuilderAutocompleteField(props) {
         shortLabel: key,
         searchText: key,
       })),
-  ];
+  ], [items, selectedKeys]);
 
-  const removeTags = (keys) => {
+  const removeTags = useCallback((keys) => {
     const nextKeys = (selectedValues || []).filter((key) => !keys.has(key));
     onChange(nextKeys);
-  };
+  }, [onChange, selectedValues]);
+  const handleChange = useCallback((keys) => {
+    onChange(selectionMode === "multiple" ? (keys || []) : keys);
+  }, [onChange, selectionMode]);
 
   return (
     <Autocomplete
@@ -62,7 +71,7 @@ function JiraBuilderAutocompleteField(props) {
       placeholder={placeholder}
       selectionMode={selectionMode}
       value={selectedValues}
-      onChange={(keys) => onChange(selectionMode === "multiple" ? (keys || []) : keys)}
+      onChange={handleChange}
       variant="secondary"
     >
       <Label>{label}</Label>

--- a/client/src/sources/jira/components/jira-builder-autocomplete-field.jsx
+++ b/client/src/sources/jira/components/jira-builder-autocomplete-field.jsx
@@ -1,0 +1,147 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Autocomplete,
+  EmptyState,
+  Label,
+  ListBox,
+  SearchField,
+  Tag,
+  TagGroup,
+  useFilter,
+} from "@heroui/react";
+
+function findItem(items, key) {
+  return items.find((item) => `${item.id}` === `${key}`);
+}
+
+function JiraBuilderAutocompleteField(props) {
+  const {
+    label,
+    name,
+    placeholder,
+    items,
+    value,
+    selectionMode,
+    onChange,
+    className,
+    isDisabled,
+    emptyLabel,
+  } = props;
+  const { contains } = useFilter({ sensitivity: "base" });
+  const selectedValues = selectionMode === "multiple"
+    ? (Array.isArray(value) ? value.map((item) => `${item}`) : [])
+    : (value ? `${value}` : null);
+  const selectedKeys = selectionMode === "multiple"
+    ? selectedValues
+    : (selectedValues ? [selectedValues] : []);
+  const displayItems = [
+    ...items,
+    ...selectedKeys
+      .filter((key) => !findItem(items, key))
+      .map((key) => ({
+        id: key,
+        label: key,
+        shortLabel: key,
+        searchText: key,
+      })),
+  ];
+
+  const removeTags = (keys) => {
+    const nextKeys = (selectedValues || []).filter((key) => !keys.has(key));
+    onChange(nextKeys);
+  };
+
+  return (
+    <Autocomplete
+      allowsEmptyCollection
+      className={className}
+      fullWidth
+      isDisabled={isDisabled}
+      name={name}
+      placeholder={placeholder}
+      selectionMode={selectionMode}
+      value={selectedValues}
+      onChange={(keys) => onChange(selectionMode === "multiple" ? (keys || []) : keys)}
+      variant="secondary"
+    >
+      <Label>{label}</Label>
+      <Autocomplete.Trigger>
+        <Autocomplete.Value>
+          {({ defaultChildren, isPlaceholder, state }) => {
+            if (selectionMode !== "multiple" || isPlaceholder || state.selectedItems.length === 0) {
+              return defaultChildren;
+            }
+
+            const selectedKeys = state.selectedItems.map((item) => item.key);
+            return (
+              <TagGroup size="sm" onRemove={removeTags} variant="surface">
+                <TagGroup.List>
+                  {selectedKeys.map((selectedKey) => {
+                    const item = findItem(displayItems, selectedKey);
+                    return (
+                      <Tag key={selectedKey} id={selectedKey}>
+                        {item?.shortLabel || item?.label || selectedKey}
+                      </Tag>
+                    );
+                  })}
+                </TagGroup.List>
+              </TagGroup>
+            );
+          }}
+        </Autocomplete.Value>
+        <Autocomplete.ClearButton />
+        <Autocomplete.Indicator />
+      </Autocomplete.Trigger>
+      <Autocomplete.Popover>
+        <Autocomplete.Filter filter={contains}>
+          <SearchField autoFocus name={`${name}-search`} variant="secondary">
+            <SearchField.Group>
+              <SearchField.SearchIcon />
+              <SearchField.Input placeholder="Search..." />
+              <SearchField.ClearButton />
+            </SearchField.Group>
+          </SearchField>
+          <ListBox renderEmptyState={() => <EmptyState>{emptyLabel}</EmptyState>}>
+            {displayItems.map((item) => (
+              <ListBox.Item key={item.id} id={`${item.id}`} textValue={item.searchText || item.label}>
+                <div className="flex min-w-0 flex-col">
+                  <span className="truncate text-sm font-medium text-foreground">{item.label}</span>
+                  {item.description && (
+                    <span className="truncate text-xs text-muted">{item.description}</span>
+                  )}
+                </div>
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </Autocomplete.Filter>
+      </Autocomplete.Popover>
+    </Autocomplete>
+  );
+}
+
+JiraBuilderAutocompleteField.propTypes = {
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  items: PropTypes.array,
+  value: PropTypes.oneOfType([PropTypes.array, PropTypes.string, PropTypes.number]),
+  selectionMode: PropTypes.oneOf(["single", "multiple"]),
+  onChange: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  isDisabled: PropTypes.bool,
+  emptyLabel: PropTypes.string,
+};
+
+JiraBuilderAutocompleteField.defaultProps = {
+  placeholder: "Select...",
+  items: [],
+  value: null,
+  selectionMode: "single",
+  className: "",
+  isDisabled: false,
+  emptyLabel: "No results found",
+};
+
+export default JiraBuilderAutocompleteField;

--- a/client/src/sources/jira/components/jira-builder-context.jsx
+++ b/client/src/sources/jira/components/jira-builder-context.jsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from "react";
+import PropTypes from "prop-types";
+
+const JiraBuilderContext = createContext(null);
+
+export function JiraBuilderProvider({ value, children }) {
+  return (
+    <JiraBuilderContext.Provider value={value}>
+      {children}
+    </JiraBuilderContext.Provider>
+  );
+}
+
+JiraBuilderProvider.propTypes = {
+  value: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export function useJiraBuilder() {
+  const context = useContext(JiraBuilderContext);
+  if (!context) {
+    throw new Error("useJiraBuilder must be used inside JiraBuilderProvider");
+  }
+  return context;
+}

--- a/client/src/sources/jira/components/jira-builder-select-field.jsx
+++ b/client/src/sources/jira/components/jira-builder-select-field.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Label,
+  ListBox,
+  Select,
+} from "@heroui/react";
+
+function getOptionValue(option) {
+  if (option.value !== undefined) return String(option.value);
+  return String(option.id);
+}
+
+function JiraBuilderSelectField({
+  label,
+  value,
+  onChange,
+  options,
+  name,
+  className,
+  isDisabled,
+}) {
+  return (
+    <Select
+      fullWidth
+      isDisabled={isDisabled}
+      name={name}
+      variant="secondary"
+      value={value !== undefined && value !== null ? String(value) : null}
+      onChange={(nextValue) => onChange(nextValue)}
+      className={className}
+    >
+      <Label>{label}</Label>
+      <Select.Trigger>
+        <Select.Value />
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          {options.map((option) => {
+            const optionValue = getOptionValue(option);
+            return (
+              <ListBox.Item key={optionValue} id={optionValue} textValue={option.label}>
+                {option.label}
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            );
+          })}
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+}
+
+JiraBuilderSelectField.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  isDisabled: PropTypes.bool,
+};
+
+JiraBuilderSelectField.defaultProps = {
+  value: "",
+  className: "",
+  isDisabled: false,
+};
+
+export default JiraBuilderSelectField;

--- a/client/src/sources/jira/components/jira-config-step.jsx
+++ b/client/src/sources/jira/components/jira-config-step.jsx
@@ -1,0 +1,458 @@
+import React, { useEffect } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Label,
+  Separator,
+  Switch,
+  TextField,
+  Tooltip,
+} from "@heroui/react";
+import { LuInfo } from "react-icons/lu";
+
+import AceEditor from "../../../components/CodeEditor";
+import {
+  BOARD_TYPE_OPTIONS,
+  DATE_FIELD_OPTIONS,
+  GROUP_BY_OPTIONS,
+  METRIC_OPTIONS,
+  MODE_OPTIONS,
+  RESOURCE_TRANSFORM_OPTIONS,
+  SPRINT_STATE_OPTIONS,
+  TRANSFORM_OPTIONS,
+} from "../jira-builder.constants";
+import JiraBuilderAutocompleteField from "./jira-builder-autocomplete-field";
+import JiraBuilderSelectField from "./jira-builder-select-field";
+import JiraDateRangeFields from "./jira-date-range-fields";
+import { useJiraBuilder } from "./jira-builder-context";
+
+function parseCsvKeys(value = "") {
+  return String(value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getProjectItems(projects) {
+  return projects.map((project) => ({
+    id: project.key,
+    label: `${project.key} - ${project.name}`,
+    shortLabel: project.key,
+    description: project.name,
+    searchText: `${project.key} ${project.name}`,
+  }));
+}
+
+function getBoardItems(boards) {
+  return boards.map((board) => ({
+    id: `${board.id}`,
+    label: board.name,
+    shortLabel: `${board.id}`,
+    description: `${board.type || "board"} #${board.id}`,
+    searchText: `${board.id} ${board.name} ${board.type || ""}`,
+  }));
+}
+
+function getSprintItems(sprints) {
+  return sprints.map((sprint) => ({
+    id: `${sprint.id}`,
+    label: sprint.name,
+    shortLabel: `${sprint.id}`,
+    description: `${sprint.state || "sprint"} #${sprint.id}`,
+    searchText: `${sprint.id} ${sprint.name} ${sprint.state || ""}`,
+  }));
+}
+
+function JiraConfigStep() {
+  const {
+    configuration,
+    jiraBoards,
+    jiraProjects,
+    jiraSprints,
+    loadBoards,
+    loadSprints,
+    metadataLoading,
+    mode,
+    setMode,
+    updateConfiguration,
+    updateTransform,
+    updateVisual,
+  } = useJiraBuilder();
+  const visual = configuration.visual || {};
+  const projectItems = getProjectItems(jiraProjects || []);
+  const boardItems = getBoardItems(jiraBoards || []);
+  const sprintItems = getSprintItems(jiraSprints || []);
+  const selectedProjectKeys = parseCsvKeys(visual.projects);
+  const resource = configuration.resource || "issues";
+  const supportsJql = ["issues", "sprint_issues"].includes(resource);
+  const availableModeOptions = supportsJql
+    ? MODE_OPTIONS
+    : MODE_OPTIONS.filter((option) => option.id !== "jql");
+  const transformOptions = RESOURCE_TRANSFORM_OPTIONS[resource] || TRANSFORM_OPTIONS;
+  const selectedTransform = transformOptions.some((option) => option.value === configuration.transform?.type)
+    ? configuration.transform?.type
+    : transformOptions[0]?.value || "raw";
+  const showGroupOptions = selectedTransform === "grouped";
+  const supportsDoneAt = ["issues", "sprint_issues"].includes(resource);
+  const doneAtAutoEnabled = ["created_resolved_trend", "sprint_summary"].includes(selectedTransform);
+  const doneAtEnabled = doneAtAutoEnabled || Boolean(configuration.includeDoneAt);
+  const dateFieldOptions = doneAtEnabled
+    ? DATE_FIELD_OPTIONS
+    : DATE_FIELD_OPTIONS.filter((option) => option.value !== "doneAt");
+
+  useEffect(() => {
+    if (!supportsJql && mode === "jql") {
+      setMode("visual");
+      updateConfiguration({ mode: "visual" });
+    }
+  }, [mode, supportsJql]);
+
+  useEffect(() => {
+    if (!doneAtEnabled && visual.dateField === "doneAt") {
+      updateVisual({ dateField: "created" });
+    }
+  }, [doneAtEnabled, visual.dateField]);
+
+  useEffect(() => {
+    if (selectedTransform !== configuration.transform?.type) {
+      updateTransform({ type: selectedTransform });
+    }
+  }, [configuration.transform?.type, selectedTransform]);
+
+  const updateIssueProjects = (keys) => {
+    const projectKeys = Array.isArray(keys) ? keys.map((key) => `${key}`) : [];
+    updateVisual({ projects: projectKeys.join(", ") });
+    loadBoards(projectKeys[0] || "");
+  };
+
+  const updateProjectFilter = (projectKeyOrId) => {
+    const nextProject = projectKeyOrId ? `${projectKeyOrId}` : "";
+    updateConfiguration({ projectIdOrKey: nextProject });
+    loadBoards(nextProject);
+  };
+
+  const updateBoard = (boardId) => {
+    const nextBoardId = boardId ? `${boardId}` : "";
+    updateConfiguration({
+      boardId: nextBoardId,
+      sprintId: "",
+    });
+    loadSprints(nextBoardId);
+  };
+
+  const updateSprint = (sprintId) => {
+    updateConfiguration({ sprintId: sprintId ? `${sprintId}` : "" });
+  };
+
+  return (
+    <Card className="border border-divider bg-surface p-0 shadow-none">
+      <Card.Content className="flex flex-col gap-5 p-5">
+        <div className="flex flex-row flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-row flex-wrap items-baseline gap-2">
+            <span className="text-sm font-semibold text-accent">Step 2</span>
+            <span className="text-base font-semibold text-foreground">Configure your dataset</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {availableModeOptions.map((option) => (
+              <Button
+                key={option.id}
+                size="sm"
+                className="rounded-full"
+                variant={mode === option.id ? "primary" : "secondary"}
+                onPress={() => {
+                  setMode(option.id);
+                  updateConfiguration({ mode: option.id });
+                }}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {mode === "visual" && (
+          <div className="flex flex-col gap-5">
+            {resource === "issues" && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <JiraBuilderAutocompleteField
+                  label="Project keys"
+                  name="jira-projects"
+                  placeholder={metadataLoading ? "Loading projects..." : "Select projects"}
+                  items={projectItems}
+                  value={selectedProjectKeys}
+                  selectionMode="multiple"
+                  onChange={updateIssueProjects}
+                  isDisabled={metadataLoading && projectItems.length === 0}
+                  emptyLabel="No Jira projects found"
+                />
+                <TextField fullWidth name="jira-issue-type">
+                  <Label>Issue type</Label>
+                  <Input
+                    placeholder="Bug, Story, Task"
+                    value={visual.issueType || ""}
+                    onChange={(event) => updateVisual({ issueType: event.target.value })}
+                    variant="secondary"
+                  />
+                </TextField>
+                <TextField fullWidth name="jira-status-category">
+                  <Label>Status category</Label>
+                  <Input
+                    placeholder="To Do, In Progress, Done"
+                    value={visual.statusCategory || ""}
+                    onChange={(event) => updateVisual({ statusCategory: event.target.value })}
+                    variant="secondary"
+                  />
+                </TextField>
+                <TextField fullWidth name="jira-assignee">
+                  <Label>Assignee</Label>
+                  <Input
+                    placeholder="account id or username"
+                    value={visual.assignee || ""}
+                    onChange={(event) => updateVisual({ assignee: event.target.value })}
+                    variant="secondary"
+                  />
+                </TextField>
+                <TextField fullWidth name="jira-priority">
+                  <Label>Priority</Label>
+                  <Input
+                    placeholder="High"
+                    value={visual.priority || ""}
+                    onChange={(event) => updateVisual({ priority: event.target.value })}
+                    variant="secondary"
+                  />
+                </TextField>
+                <TextField fullWidth name="jira-fix-version">
+                  <Label>Fix version</Label>
+                  <Input
+                    placeholder="v5.2.0"
+                    value={visual.fixVersion || ""}
+                    onChange={(event) => updateVisual({ fixVersion: event.target.value })}
+                    variant="secondary"
+                  />
+                </TextField>
+                <JiraBuilderSelectField
+                  label="Date field"
+                  name="jira-date-field"
+                  value={visual.dateField || "created"}
+                  options={dateFieldOptions}
+                  onChange={(value) => updateVisual({ dateField: value })}
+                />
+                <div className="md:col-span-2">
+                  <JiraDateRangeFields />
+                </div>
+              </div>
+            )}
+
+            {resource === "sprint_issues" && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <TextField fullWidth name="jira-sprint-jql">
+                  <Label>JQL filter</Label>
+                  <Input
+                    placeholder="statusCategory != Done"
+                    value={configuration.jql || ""}
+                    onChange={(event) => updateConfiguration({ jql: event.target.value })}
+                    variant="secondary"
+                  />
+                </TextField>
+                <JiraBuilderAutocompleteField
+                  label="Board"
+                  name="jira-sprint-issues-board"
+                  placeholder={metadataLoading ? "Loading boards..." : "Select board"}
+                  items={boardItems}
+                  value={configuration.boardId || ""}
+                  selectionMode="single"
+                  onChange={updateBoard}
+                  isDisabled={metadataLoading && boardItems.length === 0}
+                  emptyLabel="No Jira boards found"
+                />
+                <JiraBuilderAutocompleteField
+                  label="Sprint"
+                  name="jira-sprint-id"
+                  placeholder={configuration.boardId ? "Select sprint" : "Select a board first"}
+                  items={sprintItems}
+                  value={configuration.sprintId || ""}
+                  selectionMode="single"
+                  onChange={updateSprint}
+                  isDisabled={!configuration.boardId || (metadataLoading && sprintItems.length === 0)}
+                  emptyLabel="No Jira sprints found"
+                />
+              </div>
+            )}
+
+            {resource === "boards" && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <JiraBuilderAutocompleteField
+                  label="Project"
+                  name="jira-board-project"
+                  placeholder={metadataLoading ? "Loading projects..." : "Filter by project"}
+                  items={projectItems}
+                  value={configuration.projectIdOrKey || ""}
+                  selectionMode="single"
+                  onChange={updateProjectFilter}
+                  isDisabled={metadataLoading && projectItems.length === 0}
+                  emptyLabel="No Jira projects found"
+                />
+                <JiraBuilderSelectField
+                  label="Board type"
+                  name="jira-board-type"
+                  value={configuration.boardType || ""}
+                  options={BOARD_TYPE_OPTIONS}
+                  onChange={(value) => updateConfiguration({ boardType: value })}
+                />
+              </div>
+            )}
+
+            {resource === "sprints" && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <JiraBuilderAutocompleteField
+                  label="Board"
+                  name="jira-board-id"
+                  placeholder={metadataLoading ? "Loading boards..." : "Select board"}
+                  items={boardItems}
+                  value={configuration.boardId || ""}
+                  selectionMode="single"
+                  onChange={updateBoard}
+                  isDisabled={metadataLoading && boardItems.length === 0}
+                  emptyLabel="No Jira boards found"
+                />
+                <JiraBuilderSelectField
+                  label="Sprint state"
+                  name="jira-sprint-state"
+                  value={configuration.state || "active"}
+                  options={SPRINT_STATE_OPTIONS}
+                  onChange={(value) => updateConfiguration({ state: value })}
+                />
+              </div>
+            )}
+
+            {resource === "versions" && (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <JiraBuilderAutocompleteField
+                  label="Project"
+                  name="jira-version-project"
+                  placeholder={metadataLoading ? "Loading projects..." : "Select project"}
+                  items={projectItems}
+                  value={configuration.projectIdOrKey || ""}
+                  selectionMode="single"
+                  onChange={(projectKeyOrId) => updateConfiguration({ projectIdOrKey: projectKeyOrId ? `${projectKeyOrId}` : "" })}
+                  isDisabled={metadataLoading && projectItems.length === 0}
+                  emptyLabel="No Jira projects found"
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        {mode === "jql" && (
+          <div className="flex flex-col gap-3">
+            <div>
+              <p className="text-sm font-semibold text-foreground">JQL</p>
+              <p className="text-sm text-muted">Use Jira query language while keeping Chartbrew in charge of API details.</p>
+            </div>
+            <AceEditor
+              mode="sql"
+              theme="tomorrow"
+              value={configuration.jql || ""}
+              onChange={(value) => updateConfiguration({ jql: value })}
+              height="180px"
+              width="100%"
+            />
+          </div>
+        )}
+
+        {mode === "advanced" && (
+          <div className="flex flex-col gap-3">
+            <div>
+              <p className="text-sm font-semibold text-foreground">Jira configuration</p>
+              <p className="text-sm text-muted">Edit the source-owned configuration object directly.</p>
+            </div>
+            <AceEditor
+              mode="json"
+              theme="tomorrow"
+              value={JSON.stringify(configuration, null, 2)}
+              onChange={(value) => {
+                try {
+                  updateConfiguration(JSON.parse(value));
+                } catch (error) {
+                  // Keep editing until valid JSON is entered.
+                }
+              }}
+              height="260px"
+              width="100%"
+            />
+          </div>
+        )}
+
+        {supportsDoneAt && (
+          <div className="flex flex-row flex-wrap items-center justify-between gap-3 rounded-lg border border-divider bg-surface-secondary/40 p-3">
+            <Switch
+              isSelected={doneAtEnabled}
+              isDisabled={doneAtAutoEnabled}
+              onChange={(isSelected) => updateConfiguration({ includeDoneAt: isSelected })}
+            >
+              <Switch.Control>
+                <Switch.Thumb />
+              </Switch.Control>
+              <Switch.Content>
+                <Label className="text-sm">Fetch done date from status history</Label>
+              </Switch.Content>
+            </Switch>
+            <div className="flex items-center gap-2">
+              {doneAtAutoEnabled && (
+                <span className="text-xs text-muted">Enabled for this transform</span>
+              )}
+              <Tooltip>
+                <Tooltip.Trigger>
+                  <Button
+                    isIconOnly
+                    aria-label="Explain done date fetching"
+                    size="sm"
+                    variant="tertiary"
+                  >
+                    <LuInfo size={15} />
+                  </Button>
+                </Tooltip.Trigger>
+                <Tooltip.Content className="max-w-xs">
+                  Fetches Jira status history to populate doneAt when resolutiondate is empty. This adds changelog data to issue requests.
+                </Tooltip.Content>
+              </Tooltip>
+            </div>
+          </div>
+        )}
+
+        <Separator variant="tertiary" />
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <JiraBuilderSelectField
+            label="Transform"
+            name="jira-transform"
+            value={selectedTransform}
+            options={transformOptions}
+            onChange={(value) => updateTransform({ type: value })}
+          />
+          {showGroupOptions && (
+            <>
+              <JiraBuilderSelectField
+                label="Group by"
+                name="jira-group-by"
+                value={configuration.transform?.groupBy || "status"}
+                options={GROUP_BY_OPTIONS}
+                onChange={(value) => updateTransform({ groupBy: value })}
+              />
+              <JiraBuilderSelectField
+                label="Metric"
+                name="jira-metric"
+                value={configuration.transform?.metric || "count"}
+                options={METRIC_OPTIONS}
+                onChange={(value) => updateTransform({ metric: value })}
+              />
+            </>
+          )}
+        </div>
+      </Card.Content>
+    </Card>
+  );
+}
+
+export default JiraConfigStep;

--- a/client/src/sources/jira/components/jira-config-step.jsx
+++ b/client/src/sources/jira/components/jira-config-step.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import {
   Button,
   Card,
@@ -74,16 +74,22 @@ function JiraConfigStep() {
     loadSprints,
     metadataLoading,
     mode,
+    resolveVariableValue,
     setMode,
     updateConfiguration,
     updateTransform,
     updateVisual,
   } = useJiraBuilder();
   const visual = configuration.visual || {};
-  const projectItems = getProjectItems(jiraProjects || []);
-  const boardItems = getBoardItems(jiraBoards || []);
-  const sprintItems = getSprintItems(jiraSprints || []);
-  const selectedProjectKeys = parseCsvKeys(visual.projects);
+  const projectItems = useMemo(() => getProjectItems(jiraProjects || []), [jiraProjects]);
+  const boardItems = useMemo(() => getBoardItems(jiraBoards || []), [jiraBoards]);
+  const sprintItems = useMemo(() => getSprintItems(jiraSprints || []), [jiraSprints]);
+  const selectedProjectKeys = useMemo(() => parseCsvKeys(resolveVariableValue(visual.projects)), [
+    resolveVariableValue,
+    visual.projects,
+  ]);
+  const selectedBoardId = resolveVariableValue(configuration.boardId);
+  const selectedSprintId = resolveVariableValue(configuration.sprintId);
   const resource = configuration.resource || "issues";
   const supportsJql = ["issues", "sprint_issues"].includes(resource);
   const availableModeOptions = supportsJql
@@ -120,30 +126,30 @@ function JiraConfigStep() {
     }
   }, [configuration.transform?.type, selectedTransform]);
 
-  const updateIssueProjects = (keys) => {
+  const updateIssueProjects = useCallback((keys) => {
     const projectKeys = Array.isArray(keys) ? keys.map((key) => `${key}`) : [];
     updateVisual({ projects: projectKeys.join(", ") });
     loadBoards(projectKeys[0] || "");
-  };
+  }, [loadBoards, updateVisual]);
 
-  const updateProjectFilter = (projectKeyOrId) => {
+  const updateProjectFilter = useCallback((projectKeyOrId) => {
     const nextProject = projectKeyOrId ? `${projectKeyOrId}` : "";
     updateConfiguration({ projectIdOrKey: nextProject });
     loadBoards(nextProject);
-  };
+  }, [loadBoards, updateConfiguration]);
 
-  const updateBoard = (boardId) => {
+  const updateBoard = useCallback((boardId) => {
     const nextBoardId = boardId ? `${boardId}` : "";
     updateConfiguration({
       boardId: nextBoardId,
       sprintId: "",
     });
     loadSprints(nextBoardId);
-  };
+  }, [loadSprints, updateConfiguration]);
 
-  const updateSprint = (sprintId) => {
+  const updateSprint = useCallback((sprintId) => {
     updateConfiguration({ sprintId: sprintId ? `${sprintId}` : "" });
-  };
+  }, [updateConfiguration]);
 
   return (
     <Card className="border border-divider bg-surface p-0 shadow-none">
@@ -260,7 +266,7 @@ function JiraConfigStep() {
                   name="jira-sprint-issues-board"
                   placeholder={metadataLoading ? "Loading boards..." : "Select board"}
                   items={boardItems}
-                  value={configuration.boardId || ""}
+                  value={selectedBoardId}
                   selectionMode="single"
                   onChange={updateBoard}
                   isDisabled={metadataLoading && boardItems.length === 0}
@@ -269,12 +275,12 @@ function JiraConfigStep() {
                 <JiraBuilderAutocompleteField
                   label="Sprint"
                   name="jira-sprint-id"
-                  placeholder={configuration.boardId ? "Select sprint" : "Select a board first"}
+                  placeholder={selectedBoardId ? "Select sprint" : "Select a board first"}
                   items={sprintItems}
-                  value={configuration.sprintId || ""}
+                  value={selectedSprintId}
                   selectionMode="single"
                   onChange={updateSprint}
-                  isDisabled={!configuration.boardId || (metadataLoading && sprintItems.length === 0)}
+                  isDisabled={!selectedBoardId || (metadataLoading && sprintItems.length === 0)}
                   emptyLabel="No Jira sprints found"
                 />
               </div>
@@ -310,7 +316,7 @@ function JiraConfigStep() {
                   name="jira-board-id"
                   placeholder={metadataLoading ? "Loading boards..." : "Select board"}
                   items={boardItems}
-                  value={configuration.boardId || ""}
+                  value={selectedBoardId}
                   selectionMode="single"
                   onChange={updateBoard}
                   isDisabled={metadataLoading && boardItems.length === 0}

--- a/client/src/sources/jira/components/jira-date-range-fields.jsx
+++ b/client/src/sources/jira/components/jira-date-range-fields.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import {
+  Button,
+  Calendar,
+  DateField,
+  DatePicker,
+  Label,
+  Tooltip,
+} from "@heroui/react";
+import { parseDate } from "@internationalized/date";
+import { LuVariable } from "react-icons/lu";
+
+import { DATE_VARIABLES } from "../jira-builder.constants";
+import { getPlaceholderVariableName } from "../jira-builder.utils";
+import { useJiraBuilder } from "./jira-builder-context";
+
+function JiraDatePickerField({ datePart, label }) {
+  const {
+    configuration,
+    getDatePickerValue,
+    openDateVariableSettings,
+    updateVisual,
+  } = useJiraBuilder();
+  const variableName = getPlaceholderVariableName(configuration.visual?.[datePart])
+    || DATE_VARIABLES[datePart];
+  const isUsingVariable = Boolean(getPlaceholderVariableName(configuration.visual?.[datePart]));
+  const dateValue = getDatePickerValue(datePart);
+
+  return (
+    <div className="flex items-end gap-2">
+      <DatePicker
+        name={`jira-${datePart}`}
+        value={parseDate(dateValue)}
+        onChange={(date) => {
+          if (date) updateVisual({ [datePart]: date.toString() });
+        }}
+        className="min-w-0 flex-1"
+      >
+        <Label>{label}</Label>
+        <DateField.Group fullWidth variant="secondary">
+          <DateField.Input>
+            {(segment) => <DateField.Segment segment={segment} />}
+          </DateField.Input>
+          <DateField.Suffix>
+            <DatePicker.Trigger>
+              <DatePicker.TriggerIndicator />
+            </DatePicker.Trigger>
+          </DateField.Suffix>
+        </DateField.Group>
+        <DatePicker.Popover>
+          <Calendar aria-label={`${label} date`}>
+            <Calendar.Header>
+              <Calendar.YearPickerTrigger>
+                <Calendar.YearPickerTriggerHeading />
+                <Calendar.YearPickerTriggerIndicator />
+              </Calendar.YearPickerTrigger>
+              <Calendar.NavButton slot="previous" />
+              <Calendar.NavButton slot="next" />
+            </Calendar.Header>
+            <Calendar.Grid>
+              <Calendar.GridHeader>
+                {(day) => <Calendar.HeaderCell>{day}</Calendar.HeaderCell>}
+              </Calendar.GridHeader>
+              <Calendar.GridBody>
+                {(date) => <Calendar.Cell date={date} />}
+              </Calendar.GridBody>
+            </Calendar.Grid>
+            <Calendar.YearPickerGrid>
+              <Calendar.YearPickerGridBody>
+                {({ year }) => <Calendar.YearPickerCell year={year} />}
+              </Calendar.YearPickerGridBody>
+            </Calendar.YearPickerGrid>
+          </Calendar>
+        </DatePicker.Popover>
+      </DatePicker>
+      <Tooltip>
+        <Tooltip.Trigger>
+          <Button
+            isIconOnly
+            aria-label={`Configure ${label.toLowerCase()} variable`}
+            size="sm"
+            variant={isUsingVariable ? "primary" : "secondary"}
+            onPress={() => openDateVariableSettings(datePart)}
+          >
+            <LuVariable size={16} />
+          </Button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>
+          {isUsingVariable ? `Using {{${variableName}}}` : "Click to set a variable"}
+        </Tooltip.Content>
+      </Tooltip>
+    </div>
+  );
+}
+
+function JiraDateRangeFields() {
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <JiraDatePickerField datePart="startDate" label="Start date" />
+      <JiraDatePickerField datePart="endDate" label="End date" />
+    </div>
+  );
+}
+
+export default JiraDateRangeFields;

--- a/client/src/sources/jira/components/jira-preview-step.jsx
+++ b/client/src/sources/jira/components/jira-preview-step.jsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { Button, Card, Table } from "@heroui/react";
+import { LuPlay } from "react-icons/lu";
+
+import AceEditor from "../../../components/CodeEditor";
+import { ButtonSpinner } from "../../../components/ButtonSpinner";
+import { PREVIEW_ROW_LIMIT } from "../jira-builder.constants";
+import { formatPreviewValue } from "../jira-builder.utils";
+import { useJiraBuilder } from "./jira-builder-context";
+
+function JiraPreviewStep() {
+  const {
+    hasPreviewResult,
+    previewFallback,
+    previewColumns,
+    previewRows,
+    previewSummary,
+    requestLoading,
+    testRequest,
+  } = useJiraBuilder();
+
+  return (
+    <Card className="border border-divider bg-surface p-0 shadow-none">
+      <Card.Content className="flex flex-col gap-5 p-5">
+        <div className="flex flex-row flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-row flex-wrap items-baseline gap-2">
+            <span className="text-sm font-semibold text-accent">Step 3</span>
+            <span className="text-base font-semibold text-foreground">Test your configuration</span>
+          </div>
+          <Button
+            isPending={requestLoading}
+            onPress={testRequest}
+            variant="primary"
+          >
+            {requestLoading ? <ButtonSpinner /> : <LuPlay size={16} />}
+            {hasPreviewResult ? "Re-run" : "Run test"}
+          </Button>
+        </div>
+
+        {!hasPreviewResult && (
+          <div className="flex min-h-[190px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-divider bg-surface-secondary/50 p-6 text-center">
+            <span className="flex h-14 w-14 items-center justify-center rounded-full bg-surface text-muted">
+              <LuPlay size={24} />
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                Run a test to see a live sample of your Jira data
+              </p>
+              <p className="text-sm text-muted">
+                Uses your current configuration to fetch a preview.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {hasPreviewResult && previewRows.length > 0 && previewColumns.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-row flex-wrap items-center justify-between gap-2 text-sm">
+              <span className="font-medium text-foreground">Preview rows</span>
+              <span className="text-muted">{previewSummary}</span>
+            </div>
+
+            <Table className="border border-divider shadow-none">
+              <Table.ScrollContainer>
+                <Table.Content aria-label="Jira configuration preview" className="min-w-[760px]">
+                  <Table.Header>
+                    {previewColumns.map((column, index) => (
+                      <Table.Column key={column} id={column} isRowHeader={index === 0}>
+                        {column}
+                      </Table.Column>
+                    ))}
+                  </Table.Header>
+                  <Table.Body>
+                    {previewRows.slice(0, PREVIEW_ROW_LIMIT).map((row, index) => (
+                      <Table.Row key={`${row.key || row.period || "row"}-${index}`} id={`${row.key || row.period || "row"}-${index}`}>
+                        {previewColumns.map((column) => (
+                          <Table.Cell key={column}>
+                            <span className="block max-w-[220px] truncate" title={formatPreviewValue(row[column])}>
+                              {formatPreviewValue(row[column])}
+                            </span>
+                          </Table.Cell>
+                        ))}
+                      </Table.Row>
+                    ))}
+                  </Table.Body>
+                </Table.Content>
+              </Table.ScrollContainer>
+            </Table>
+          </div>
+        )}
+
+        {hasPreviewResult && (previewRows.length === 0 || previewColumns.length === 0) && (
+          <AceEditor
+            mode="json"
+            theme="tomorrow"
+            value={previewFallback}
+            readOnly
+            height="260px"
+            width="100%"
+          />
+        )}
+      </Card.Content>
+    </Card>
+  );
+}
+
+export default JiraPreviewStep;

--- a/client/src/sources/jira/components/jira-resource-step.jsx
+++ b/client/src/sources/jira/components/jira-resource-step.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Button, Card } from "@heroui/react";
+
+import { RESOURCE_OPTIONS } from "../jira-builder.constants";
+import { useJiraBuilder } from "./jira-builder-context";
+
+function JiraResourceStep() {
+  const { configuration, selectResource } = useJiraBuilder();
+
+  return (
+    <Card className="border border-divider bg-surface p-0 shadow-none">
+      <Card.Content className="flex flex-col gap-5 p-5">
+        <div className="flex flex-row flex-wrap items-center gap-2">
+          <span className="text-sm font-semibold text-accent">Step 1</span>
+          <span className="font-semibold text-foreground">Choose a Jira resource</span>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-5">
+          {RESOURCE_OPTIONS.map((resource) => {
+            const Icon = resource.icon;
+            const selected = configuration.resource === resource.id;
+
+            return (
+              <Button
+                key={resource.id}
+                variant={selected ? "secondary" : "outline"}
+                className={`h-28 min-w-0 flex-col items-start justify-start gap-3 rounded-2xl border p-4 text-left ${
+                  selected
+                    ? "border-accent bg-accent/10 text-accent"
+                    : "border-divider bg-surface text-foreground"
+                }`}
+                onPress={() => selectResource(resource.id)}
+                fullWidth
+              >
+                <span className={`flex h-10 w-10 items-center justify-center rounded-xl ${resource.iconClassName}`}>
+                  <Icon size={20} />
+                </span>
+                <span className="flex min-w-0 flex-col items-start gap-1">
+                  <span className="w-full truncate text-sm font-semibold">{resource.label}</span>
+                  <span className={`line-clamp-2 text-xs ${selected ? "text-accent/80" : "text-muted"}`}>
+                    {resource.description}
+                  </span>
+                </span>
+              </Button>
+            );
+          })}
+        </div>
+      </Card.Content>
+    </Card>
+  );
+}
+
+export default JiraResourceStep;

--- a/client/src/sources/jira/components/jira-summary-sidebar.jsx
+++ b/client/src/sources/jira/components/jira-summary-sidebar.jsx
@@ -1,0 +1,127 @@
+import React from "react";
+import {
+  Button,
+  Card,
+  Disclosure,
+  Separator,
+} from "@heroui/react";
+import {
+  LuBraces,
+  LuEye,
+  LuSave,
+  LuTrash,
+} from "react-icons/lu";
+
+import AceEditor from "../../../components/CodeEditor";
+import { ButtonSpinner } from "../../../components/ButtonSpinner";
+import { getSuggestedCharts } from "../jira-builder.utils";
+import { useJiraBuilder } from "./jira-builder-context";
+
+function JiraSummarySidebar() {
+  const {
+    configuration,
+    groupByLabel,
+    metricLabel,
+    modeLabel,
+    onDelete,
+    previewSummary,
+    resourceLabel,
+    saveConfiguration,
+    saveLoading,
+    setShowConfigPreview,
+    setShowTransform,
+    showConfigPreview,
+    showTransform,
+    transformLabel,
+  } = useJiraBuilder();
+  const suggestedCharts = getSuggestedCharts(configuration);
+
+  return (
+    <aside className="col-span-12 xl:col-span-4 2xl:col-span-3">
+      <div className="sticky top-4 flex flex-col gap-4">
+        <Card className="border border-divider bg-surface p-0 shadow-none">
+          <Card.Content className="flex flex-col gap-4 p-5">
+            <Card.Title className="text-lg">Dataset summary</Card.Title>
+            <div className="flex flex-col gap-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">Mode</span>
+                <span className="text-right font-medium text-foreground">{modeLabel}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">Resource</span>
+                <span className="text-right font-medium text-foreground">{resourceLabel}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">Transform</span>
+                <span className="text-right font-medium text-foreground">{transformLabel}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">Grouped by</span>
+                <span className="text-right font-medium text-foreground">{groupByLabel}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">Metric</span>
+                <span className="text-right font-medium text-foreground">{metricLabel}</span>
+              </div>
+              <Separator variant="tertiary" />
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted">Preview</span>
+                <span className="text-right font-medium text-emerald-600 dark:text-emerald-300">{previewSummary}</span>
+              </div>
+              <div className="flex items-start justify-between gap-3">
+                <span className="text-muted">Suggested charts</span>
+                <span className="text-right font-medium text-foreground">{suggestedCharts.join(", ")}</span>
+              </div>
+            </div>
+          </Card.Content>
+        </Card>
+
+        <Disclosure isExpanded={showConfigPreview} onExpandedChange={setShowConfigPreview}>
+          <Disclosure.Heading>
+            <Button slot="trigger" variant="ghost" className="w-full justify-between text-muted">
+              <span className="flex items-center gap-2">
+                <LuEye size={16} />
+                Config preview
+              </span>
+              <Disclosure.Indicator />
+            </Button>
+          </Disclosure.Heading>
+          <Disclosure.Content>
+            <Disclosure.Body className="pt-2">
+              <AceEditor
+                mode="json"
+                theme="tomorrow"
+                value={JSON.stringify(configuration, null, 2)}
+                readOnly
+                height="260px"
+                width="100%"
+              />
+            </Disclosure.Body>
+          </Disclosure.Content>
+        </Disclosure>
+
+        <div className="flex flex-col gap-3">
+          <Button
+            fullWidth
+            isPending={saveLoading}
+            onPress={saveConfiguration}
+            variant="primary"
+          >
+            {saveLoading ? <ButtonSpinner /> : <LuSave size={16} />}
+            Save configuration
+          </Button>
+          <Button fullWidth onPress={() => setShowTransform(!showTransform)} variant="secondary">
+            <LuBraces size={16} />
+            {showTransform ? "Hide transform" : "Transform data"}
+          </Button>
+          <Button fullWidth variant="danger-soft" onPress={onDelete}>
+            <LuTrash size={16} />
+            Delete request
+          </Button>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export default JiraSummarySidebar;

--- a/client/src/sources/jira/jira-builder.constants.jsx
+++ b/client/src/sources/jira/jira-builder.constants.jsx
@@ -1,0 +1,109 @@
+import {
+  LuActivity,
+  LuBug,
+  LuCalendarDays,
+  LuChartBar,
+  LuClipboardList,
+  LuColumns3,
+  LuFlag,
+  LuListChecks,
+  LuTable,
+} from "react-icons/lu";
+
+export const DATE_VARIABLES = {
+  startDate: "start_date",
+  endDate: "end_date",
+};
+
+export const RESOURCE_OPTIONS = [{
+  id: "issues",
+  label: "Issues",
+  description: "Issue lists, trends, and breakdowns",
+  icon: LuClipboardList,
+  iconClassName: "bg-blue-500/10 text-blue-600 dark:text-blue-300",
+}, {
+  id: "sprint_issues",
+  label: "Sprint issues",
+  description: "Sprint completion, carryover, and workload",
+  icon: LuListChecks,
+  iconClassName: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
+}, {
+  id: "boards",
+  label: "Boards",
+  description: "Available Jira Agile boards",
+  icon: LuColumns3,
+  iconClassName: "bg-violet-500/10 text-violet-600 dark:text-violet-300",
+}, {
+  id: "sprints",
+  label: "Sprints",
+  description: "Sprints for a selected board",
+  icon: LuCalendarDays,
+  iconClassName: "bg-amber-500/10 text-amber-600 dark:text-amber-300",
+}, {
+  id: "versions",
+  label: "Versions",
+  description: "Project releases and fix versions",
+  icon: LuFlag,
+  iconClassName: "bg-rose-500/10 text-rose-600 dark:text-rose-300",
+}];
+
+export const MODE_OPTIONS = [
+  { id: "visual", label: "Visual" },
+  { id: "jql", label: "JQL" },
+  { id: "advanced", label: "Advanced" },
+];
+
+export const BOARD_TYPE_OPTIONS = [
+  { value: "", label: "Any board type" },
+  { value: "scrum", label: "Scrum" },
+  { value: "kanban", label: "Kanban" },
+  { value: "simple", label: "Simple" },
+];
+
+export const SPRINT_STATE_OPTIONS = [
+  { value: "", label: "All states" },
+  { value: "active", label: "Active" },
+  { value: "future", label: "Future" },
+  { value: "closed", label: "Closed" },
+];
+
+export const GROUP_BY_OPTIONS = [
+  { value: "status", label: "Status" },
+  { value: "statusCategory", label: "Status category" },
+  { value: "assignee", label: "Assignee" },
+  { value: "priority", label: "Priority" },
+  { value: "issueType", label: "Issue type" },
+  { value: "projectKey", label: "Project" },
+];
+
+export const METRIC_OPTIONS = [
+  { value: "count", label: "Count issues" },
+  { value: "storyPoints", label: "Sum story points" },
+  { value: "averageAge", label: "Average age" },
+  { value: "leadTime", label: "Lead time" },
+];
+
+export const DATE_FIELD_OPTIONS = [
+  { value: "created", label: "Created" },
+  { value: "updated", label: "Updated" },
+  { value: "resolved", label: "Resolved" },
+  { value: "doneAt", label: "Done date" },
+];
+
+export const TRANSFORM_OPTIONS = [
+  { value: "raw", label: "Raw table", icon: LuTable },
+  { value: "grouped", label: "Grouped breakdown", icon: LuChartBar },
+  { value: "created_resolved_trend", label: "Created vs resolved", icon: LuActivity },
+  { value: "sprint_summary", label: "Sprint summary", icon: LuListChecks },
+  { value: "stale_table", label: "Stale issue table", icon: LuBug },
+];
+
+export const RESOURCE_TRANSFORM_OPTIONS = {
+  issues: TRANSFORM_OPTIONS.filter((option) => option.value !== "sprint_summary"),
+  sprint_issues: TRANSFORM_OPTIONS.filter((option) => option.value !== "created_resolved_trend"),
+  boards: TRANSFORM_OPTIONS.filter((option) => option.value === "raw"),
+  sprints: TRANSFORM_OPTIONS.filter((option) => option.value === "raw"),
+  versions: TRANSFORM_OPTIONS.filter((option) => option.value === "raw"),
+};
+
+export const PREVIEW_ROW_LIMIT = 25;

--- a/client/src/sources/jira/jira-builder.jsx
+++ b/client/src/sources/jira/jira-builder.jsx
@@ -1,0 +1,493 @@
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import PropTypes from "prop-types";
+import toast from "react-hot-toast";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import VariableSettingsDrawer from "../../components/VariableSettingsDrawer";
+import DataTransform from "../../containers/Dataset/DataTransform";
+import {
+  createVariableBinding,
+  deleteVariableBinding,
+  runDataRequest,
+  selectDataRequests,
+  updateVariableBinding,
+} from "../../slices/dataset";
+import { runSourceAction } from "../../slices/connection";
+import { selectTeam } from "../../slices/team";
+import { JiraBuilderProvider } from "./components/jira-builder-context";
+import JiraConfigStep from "./components/jira-config-step";
+import JiraPreviewStep from "./components/jira-preview-step";
+import JiraResourceStep from "./components/jira-resource-step";
+import JiraSummarySidebar from "./components/jira-summary-sidebar";
+import {
+  DATE_VARIABLES,
+  GROUP_BY_OPTIONS,
+  METRIC_OPTIONS,
+  MODE_OPTIONS,
+  RESOURCE_OPTIONS,
+  TRANSFORM_OPTIONS,
+} from "./jira-builder.constants";
+import {
+  getDefaultDateRange,
+  getDefaultsForResource,
+  getPlaceholderVariableName,
+  getPreviewColumns,
+  getPreviewRows,
+  mergeConfiguration,
+  normalizeDateRangeValue,
+  withVisualJql,
+} from "./jira-builder.utils";
+
+function getOptionLabel(options, value, fallback = "Not set") {
+  const match = options.find((option) => (option.value || option.id) === value);
+  return match?.label || fallback;
+}
+
+function JiraBuilder(props) {
+  const {
+    dataRequest, onChangeRequest, onSave, onDelete,
+  } = props;
+
+  const [jiraRequest, setJiraRequest] = useState(dataRequest || {});
+  const [configuration, setConfiguration] = useState(mergeConfiguration(dataRequest));
+  const [mode, setMode] = useState(configuration.mode || "visual");
+  const [previewPayload, setPreviewPayload] = useState(null);
+  const [requestLoading, setRequestLoading] = useState(false);
+  const [saveLoading, setSaveLoading] = useState(false);
+  const [showTransform, setShowTransform] = useState(false);
+  const [showConfigPreview, setShowConfigPreview] = useState(false);
+  const [metadataLoading, setMetadataLoading] = useState(false);
+  const [jiraProjects, setJiraProjects] = useState([]);
+  const [jiraBoards, setJiraBoards] = useState([]);
+  const [jiraSprints, setJiraSprints] = useState([]);
+  const [variableSettings, setVariableSettings] = useState(null);
+  const [variableDatePart, setVariableDatePart] = useState(null);
+  const [variableLoading, setVariableLoading] = useState(false);
+  const [variableDeleteLoading, setVariableDeleteLoading] = useState(false);
+
+  const params = useParams();
+  const dispatch = useDispatch();
+  const team = useSelector(selectTeam);
+  const stateDrs = useSelector((state) => selectDataRequests(state, params.datasetId));
+  const connectionId = jiraRequest.connection_id
+    || dataRequest.connection_id
+    || dataRequest.Connection?.id
+    || dataRequest.connection?.id;
+
+  useEffect(() => {
+    const nextRequest = {
+      ...jiraRequest,
+      method: "GET",
+      route: null,
+      pagination: true,
+      items: configuration.resource === "sprint_issues" ? "issues" : "issues",
+      itemsLimit: configuration.pagination?.maxRecords || 5000,
+      offset: "startAt",
+      paginationField: null,
+      template: "jira",
+      useGlobalHeaders: true,
+      configuration: {
+        ...configuration,
+        mode,
+      },
+    };
+    setJiraRequest(nextRequest);
+    onChangeRequest(nextRequest);
+  }, [configuration, mode]);
+
+  useEffect(() => {
+    if (!dataRequest?.id) return;
+
+    const nextConfiguration = mergeConfiguration(dataRequest);
+    setJiraRequest(dataRequest);
+    setConfiguration(nextConfiguration);
+    setMode(nextConfiguration.mode || "visual");
+  }, [dataRequest?.id]);
+
+  useEffect(() => {
+    if (stateDrs && stateDrs.length > 0) {
+      const selectedResponse = stateDrs.find((item) => item.id === dataRequest.id);
+      if (selectedResponse?.response) {
+        setPreviewPayload(selectedResponse.response);
+      }
+    }
+  }, [stateDrs, dataRequest.id]);
+
+  const updateConfiguration = (updates) => {
+    setConfiguration((current) => ({
+      ...current,
+      ...updates,
+    }));
+  };
+
+  const updateVisual = (updates) => {
+    setConfiguration((current) => withVisualJql(current, updates));
+  };
+
+  const getVariableBinding = (name) => {
+    return [
+      ...(jiraRequest.VariableBindings || []),
+      ...(dataRequest.VariableBindings || []),
+    ]
+      .find((variableBinding) => variableBinding.name === name);
+  };
+
+  const getDatePickerValue = (datePart) => {
+    const value = configuration.visual?.[datePart];
+    const variableName = getPlaceholderVariableName(value);
+    const defaultRange = getDefaultDateRange();
+    const fallback = defaultRange[datePart];
+
+    if (variableName) {
+      return normalizeDateRangeValue(getVariableBinding(variableName)?.default_value, fallback);
+    }
+
+    return normalizeDateRangeValue(value, fallback);
+  };
+
+  const openDateVariableSettings = (datePart) => {
+    const variableName = getPlaceholderVariableName(configuration.visual?.[datePart])
+      || DATE_VARIABLES[datePart];
+    const selectedVariable = getVariableBinding(variableName);
+
+    setVariableDatePart(datePart);
+    setVariableSettings(selectedVariable || {
+      name: variableName,
+      type: "date",
+      default_value: getDatePickerValue(datePart),
+      required: false,
+    });
+  };
+
+  const onVariableSave = async () => {
+    setVariableLoading(true);
+
+    try {
+      let currentRequest = jiraRequest;
+
+      if (!currentRequest.id) {
+        const savedRequest = await onSave(currentRequest);
+        currentRequest = {
+          ...currentRequest,
+          ...(savedRequest?.payload || {}),
+        };
+        setJiraRequest(currentRequest);
+      }
+
+      let response;
+      if (variableSettings.id) {
+        response = await dispatch(updateVariableBinding({
+          team_id: team.id,
+          dataset_id: currentRequest.dataset_id,
+          dataRequest_id: currentRequest.id,
+          variable_id: variableSettings.id,
+          data: variableSettings,
+        }));
+      } else {
+        response = await dispatch(createVariableBinding({
+          team_id: team.id,
+          dataset_id: currentRequest.dataset_id,
+          dataRequest_id: currentRequest.id,
+          data: variableSettings,
+        }));
+      }
+
+      if (response.payload) {
+        setJiraRequest({
+          ...currentRequest,
+          ...response.payload,
+          configuration,
+        });
+      }
+
+      if (variableDatePart && variableSettings?.name) {
+        updateVisual({ [variableDatePart]: `{{${variableSettings.name}}}` });
+      }
+
+      setVariableLoading(false);
+      setVariableDatePart(null);
+      setVariableSettings(null);
+      toast.success("Variable saved successfully");
+    } catch (error) {
+      setVariableLoading(false);
+      toast.error("Failed to save variable");
+    }
+  };
+
+  const onVariableDelete = async () => {
+    if (!variableSettings?.id) return;
+
+    setVariableDeleteLoading(true);
+
+    try {
+      const response = await dispatch(deleteVariableBinding({
+        team_id: team.id,
+        dataset_id: jiraRequest.dataset_id,
+        dataRequest_id: jiraRequest.id,
+        variable_id: variableSettings.id,
+      }));
+
+      if (response.payload) {
+        setJiraRequest({
+          ...jiraRequest,
+          ...response.payload,
+          configuration,
+        });
+      }
+
+      if (variableDatePart) {
+        updateVisual({ [variableDatePart]: getDatePickerValue(variableDatePart) });
+      }
+
+      setVariableDeleteLoading(false);
+      setVariableDatePart(null);
+      setVariableSettings(null);
+      toast.success("Variable deleted successfully");
+    } catch (error) {
+      setVariableDeleteLoading(false);
+      toast.error("Failed to delete variable");
+    }
+  };
+
+  const updateTransform = (updates) => {
+    setConfiguration((current) => ({
+      ...current,
+      transform: {
+        ...current.transform,
+        ...updates,
+      },
+    }));
+  };
+
+  const runJiraAction = (action, actionParams = {}) => {
+    if (!team?.id || !connectionId) return Promise.resolve([]);
+
+    return dispatch(runSourceAction({
+      team_id: team.id,
+      connection_id: connectionId,
+      action,
+      params: actionParams,
+    })).unwrap().then((result) => {
+      if (Array.isArray(result)) return result;
+      if (result?.error) throw new Error(result.error);
+      return [];
+    });
+  };
+
+  const loadProjects = () => {
+    if (!team?.id || !connectionId) return;
+
+    setMetadataLoading(true);
+    runJiraAction("listProjects")
+      .then((projects) => setJiraProjects(projects))
+      .catch(() => toast.error("Could not load Jira projects."))
+      .finally(() => setMetadataLoading(false));
+  };
+
+  const loadBoards = (projectKeyOrId = "") => {
+    if (!team?.id || !connectionId) return;
+
+    setMetadataLoading(true);
+    runJiraAction("listBoards", {
+      projectKeyOrId: projectKeyOrId || undefined,
+      maxResults: 50,
+    })
+      .then((boards) => setJiraBoards(boards))
+      .catch(() => toast.error("Could not load Jira boards."))
+      .finally(() => setMetadataLoading(false));
+  };
+
+  const loadSprints = (boardId) => {
+    if (!team?.id || !connectionId || !boardId) {
+      setJiraSprints([]);
+      return;
+    }
+
+    setMetadataLoading(true);
+    runJiraAction("listSprints", {
+      boardId,
+      maxResults: 50,
+      state: configuration.state || undefined,
+    })
+      .then((sprints) => setJiraSprints(sprints))
+      .catch(() => toast.error("Could not load Jira sprints."))
+      .finally(() => setMetadataLoading(false));
+  };
+
+  const selectResource = (resource) => {
+    setConfiguration((current) => {
+      const defaults = getDefaultsForResource(resource, current);
+      return {
+        ...current,
+        ...defaults,
+        fields: defaults.fields || current.fields,
+        pagination: {
+          ...current.pagination,
+          ...(defaults.pagination || {}),
+        },
+        transform: {
+          ...(defaults.transform || { type: "raw" }),
+        },
+      };
+    });
+    setMode("visual");
+  };
+
+  useEffect(() => {
+    loadProjects();
+    loadBoards();
+  }, [team?.id, connectionId]);
+
+  useEffect(() => {
+    if (configuration.resource === "sprints" || configuration.resource === "sprint_issues") {
+      loadSprints(configuration.boardId);
+    }
+  }, [configuration.resource, configuration.boardId, configuration.state]);
+
+  const saveConfiguration = () => {
+    setSaveLoading(true);
+    onSave(jiraRequest)
+      .then(() => setSaveLoading(false))
+      .catch(() => setSaveLoading(false));
+  };
+
+  const testRequest = () => {
+    setRequestLoading(true);
+    onSave(jiraRequest).then((savedRequest) => {
+      dispatch(runDataRequest({
+        team_id: team?.id,
+        dataset_id: savedRequest?.payload?.dataset_id || jiraRequest.dataset_id,
+        dataRequest_id: savedRequest?.payload?.id || jiraRequest.id,
+        getCache: false,
+      }))
+        .then((data) => {
+          const response = data.payload?.response?.dataRequest?.responseData;
+          const payload = response || data.payload;
+          setPreviewPayload(payload);
+          setRequestLoading(false);
+        })
+        .catch((error) => {
+          toast.error("The Jira request failed. Please check your configuration.");
+          setPreviewPayload(error);
+          setRequestLoading(false);
+        });
+    }).catch((error) => {
+      toast.error("The Jira request could not be saved before testing.");
+      setPreviewPayload(error);
+      setRequestLoading(false);
+    });
+  };
+
+  const previewRows = useMemo(() => getPreviewRows(previewPayload), [previewPayload]);
+  const previewColumns = useMemo(() => getPreviewColumns(previewPayload), [previewPayload]);
+  const previewSummary = previewRows.length > 0 ? `${previewRows.length} rows` : "Run preview";
+  const hasPreviewResult = previewPayload !== null;
+  const previewFallback = hasPreviewResult ? JSON.stringify(previewPayload, null, 2) : "";
+  const modeLabel = getOptionLabel(MODE_OPTIONS, mode, mode);
+  const resourceLabel = getOptionLabel(RESOURCE_OPTIONS, configuration.resource, configuration.resource);
+  const transformLabel = getOptionLabel(
+    TRANSFORM_OPTIONS,
+    configuration.transform?.type || "raw",
+    configuration.transform?.type || "Raw table",
+  );
+  const groupByLabel = getOptionLabel(
+    GROUP_BY_OPTIONS,
+    configuration.transform?.groupBy || "status",
+    configuration.transform?.groupBy || "Status",
+  );
+  const metricLabel = getOptionLabel(
+    METRIC_OPTIONS,
+    configuration.transform?.metric || "count",
+    configuration.transform?.metric || "Count issues",
+  );
+
+  const contextValue = {
+    configuration,
+    getDatePickerValue,
+    groupByLabel,
+    hasPreviewResult,
+    metricLabel,
+    mode,
+    modeLabel,
+    metadataLoading,
+    onDelete,
+    previewColumns,
+    previewFallback,
+    previewRows,
+    previewSummary,
+    requestLoading,
+    resourceLabel,
+    saveConfiguration,
+    saveLoading,
+    selectResource,
+    jiraBoards,
+    jiraProjects,
+    jiraSprints,
+    loadBoards,
+    loadSprints,
+    setMode,
+    setShowConfigPreview,
+    setShowTransform,
+    openDateVariableSettings,
+    showConfigPreview,
+    showTransform,
+    testRequest,
+    transformLabel,
+    updateConfiguration,
+    updateTransform,
+    updateVisual,
+  };
+
+  return (
+    <JiraBuilderProvider value={contextValue}>
+      <div className="grid grid-cols-12 gap-5 px-2 pb-5 lg:px-4">
+        <div className="col-span-12 flex flex-col gap-5 xl:col-span-8 2xl:col-span-9">
+          <JiraResourceStep />
+          <JiraConfigStep />
+          <JiraPreviewStep />
+        </div>
+
+        <JiraSummarySidebar />
+
+        {showTransform && (
+          <DataTransform
+            isOpen={showTransform}
+            onClose={() => setShowTransform(false)}
+            initialTransform={jiraRequest.transform}
+            onSave={(transform) => {
+              setJiraRequest({ ...jiraRequest, transform });
+              onChangeRequest({ ...jiraRequest, transform });
+            }}
+          />
+        )}
+
+        <VariableSettingsDrawer
+          variable={variableSettings}
+          onClose={() => {
+            setVariableDatePart(null);
+            setVariableSettings(null);
+          }}
+          onPatch={(patch) => setVariableSettings((variable) => (variable ? { ...variable, ...patch } : variable))}
+          onSave={onVariableSave}
+          onDelete={onVariableDelete}
+          savePending={variableLoading}
+          deletePending={variableDeleteLoading}
+        />
+      </div>
+    </JiraBuilderProvider>
+  );
+}
+
+JiraBuilder.propTypes = {
+  dataRequest: PropTypes.object.isRequired,
+  onChangeRequest: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+export default JiraBuilder;

--- a/client/src/sources/jira/jira-builder.jsx
+++ b/client/src/sources/jira/jira-builder.jsx
@@ -1,6 +1,8 @@
 import React, {
+  useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import PropTypes from "prop-types";
@@ -69,6 +71,7 @@ function JiraBuilder(props) {
   const [variableDatePart, setVariableDatePart] = useState(null);
   const [variableLoading, setVariableLoading] = useState(false);
   const [variableDeleteLoading, setVariableDeleteLoading] = useState(false);
+  const hydratedRequestRef = useRef({ id: null, signature: null });
 
   const params = useParams();
   const dispatch = useDispatch();
@@ -78,6 +81,18 @@ function JiraBuilder(props) {
     || dataRequest.connection_id
     || dataRequest.Connection?.id
     || dataRequest.connection?.id;
+  const dataRequestHydrationSignature = useMemo(() => {
+    return JSON.stringify({
+      configuration: dataRequest?.configuration || {},
+      variableBindings: (dataRequest?.VariableBindings || []).map((binding) => ({
+        id: binding.id,
+        name: binding.name,
+        default_value: binding.default_value,
+        required: binding.required,
+        type: binding.type,
+      })),
+    });
+  }, [dataRequest?.configuration, dataRequest?.VariableBindings]);
 
   useEffect(() => {
     const nextRequest = {
@@ -102,12 +117,29 @@ function JiraBuilder(props) {
 
   useEffect(() => {
     if (!dataRequest?.id) return;
+    const requestId = String(dataRequest.id);
 
+    if (
+      hydratedRequestRef.current.id === requestId
+      && hydratedRequestRef.current.signature === dataRequestHydrationSignature
+    ) {
+      return;
+    }
+
+    const previousRequestId = hydratedRequestRef.current.id;
     const nextConfiguration = mergeConfiguration(dataRequest);
+    hydratedRequestRef.current = {
+      id: requestId,
+      signature: dataRequestHydrationSignature,
+    };
     setJiraRequest(dataRequest);
     setConfiguration(nextConfiguration);
     setMode(nextConfiguration.mode || "visual");
-  }, [dataRequest?.id]);
+
+    if (previousRequestId && previousRequestId !== requestId) {
+      setPreviewPayload(null);
+    }
+  }, [dataRequest, dataRequestHydrationSignature]);
 
   useEffect(() => {
     if (stateDrs && stateDrs.length > 0) {
@@ -118,24 +150,34 @@ function JiraBuilder(props) {
     }
   }, [stateDrs, dataRequest.id]);
 
-  const updateConfiguration = (updates) => {
+  const updateConfiguration = useCallback((updates) => {
     setConfiguration((current) => ({
       ...current,
       ...updates,
     }));
-  };
+  }, []);
 
-  const updateVisual = (updates) => {
+  const updateVisual = useCallback((updates) => {
     setConfiguration((current) => withVisualJql(current, updates));
-  };
+  }, []);
 
-  const getVariableBinding = (name) => {
+  const getVariableBinding = useCallback((name) => {
     return [
       ...(jiraRequest.VariableBindings || []),
       ...(dataRequest.VariableBindings || []),
     ]
       .find((variableBinding) => variableBinding.name === name);
-  };
+  }, [dataRequest.VariableBindings, jiraRequest.VariableBindings]);
+
+  const resolveVariableValue = useCallback((value, fallback = "") => {
+    const variableName = getPlaceholderVariableName(value);
+    if (!variableName) return value || fallback;
+
+    const variableValue = getVariableBinding(variableName)?.default_value;
+    return variableValue === undefined || variableValue === null || variableValue === ""
+      ? fallback
+      : variableValue;
+  }, [getVariableBinding]);
 
   const getDatePickerValue = (datePart) => {
     const value = configuration.visual?.[datePart];
@@ -144,7 +186,7 @@ function JiraBuilder(props) {
     const fallback = defaultRange[datePart];
 
     if (variableName) {
-      return normalizeDateRangeValue(getVariableBinding(variableName)?.default_value, fallback);
+      return normalizeDateRangeValue(resolveVariableValue(value), fallback);
     }
 
     return normalizeDateRangeValue(value, fallback);
@@ -254,7 +296,7 @@ function JiraBuilder(props) {
     }
   };
 
-  const updateTransform = (updates) => {
+  const updateTransform = useCallback((updates) => {
     setConfiguration((current) => ({
       ...current,
       transform: {
@@ -262,7 +304,7 @@ function JiraBuilder(props) {
         ...updates,
       },
     }));
-  };
+  }, []);
 
   const runJiraAction = (action, actionParams = {}) => {
     if (!team?.id || !connectionId) return Promise.resolve([]);
@@ -289,7 +331,7 @@ function JiraBuilder(props) {
       .finally(() => setMetadataLoading(false));
   };
 
-  const loadBoards = (projectKeyOrId = "") => {
+  const loadBoards = useCallback((projectKeyOrId = "") => {
     if (!team?.id || !connectionId) return;
 
     setMetadataLoading(true);
@@ -300,9 +342,9 @@ function JiraBuilder(props) {
       .then((boards) => setJiraBoards(boards))
       .catch(() => toast.error("Could not load Jira boards."))
       .finally(() => setMetadataLoading(false));
-  };
+  }, [connectionId, team?.id]);
 
-  const loadSprints = (boardId) => {
+  const loadSprints = useCallback((boardId) => {
     if (!team?.id || !connectionId || !boardId) {
       setJiraSprints([]);
       return;
@@ -317,7 +359,7 @@ function JiraBuilder(props) {
       .then((sprints) => setJiraSprints(sprints))
       .catch(() => toast.error("Could not load Jira sprints."))
       .finally(() => setMetadataLoading(false));
-  };
+  }, [configuration.state, connectionId, team?.id]);
 
   const selectResource = (resource) => {
     setConfiguration((current) => {
@@ -409,6 +451,7 @@ function JiraBuilder(props) {
   const contextValue = {
     configuration,
     getDatePickerValue,
+    resolveVariableValue,
     groupByLabel,
     hasPreviewResult,
     metricLabel,

--- a/client/src/sources/jira/jira-builder.utils.js
+++ b/client/src/sources/jira/jira-builder.utils.js
@@ -20,10 +20,37 @@ export function getDefaultDateRange() {
   };
 }
 
+function resolveRelativeDateValue(value) {
+  const normalizedValue = String(value || "").trim().toLowerCase();
+  const today = new Date();
+
+  if (["now", "now()", "today"].includes(normalizedValue)) {
+    return formatDateValue(today);
+  }
+
+  const lastDaysMatch = normalizedValue.match(/^last_(\d+)_days$/);
+  if (lastDaysMatch) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - Number(lastDaysMatch[1]));
+    return formatDateValue(date);
+  }
+
+  const relativeDaysMatch = normalizedValue.match(/^([+-]?\d+)d$/);
+  if (relativeDaysMatch) {
+    const date = new Date(today);
+    date.setDate(date.getDate() + Number(relativeDaysMatch[1]));
+    return formatDateValue(date);
+  }
+
+  return null;
+}
+
 export function normalizeDateRangeValue(value, fallback) {
   if (!value) return fallback;
   if (/^\{\{[^}]+\}\}$/.test(String(value || "").trim())) return value;
   if (/^\d{4}-\d{2}-\d{2}$/.test(String(value || ""))) return value;
+  const relativeDate = resolveRelativeDateValue(value);
+  if (relativeDate) return relativeDate;
   const parsedDate = new Date(value);
   if (!Number.isNaN(parsedDate.getTime())) return formatDateValue(parsedDate);
   return fallback;
@@ -32,6 +59,28 @@ export function normalizeDateRangeValue(value, fallback) {
 export function getPlaceholderVariableName(value) {
   const match = String(value || "").trim().match(/^\{\{([^}]+)\}\}$/);
   return match?.[1]?.trim() || null;
+}
+
+function inferVisualValueFromJql(jql = "", fieldNames = [], operator = "=") {
+  const fields = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
+  const escapedFields = fields
+    .filter(Boolean)
+    .map((field) => String(field).replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|");
+
+  if (!escapedFields) return "";
+
+  const escapedOperator = String(operator).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = String(jql || "").match(new RegExp(`(?:${escapedFields})\\s*${escapedOperator}\\s*([^\\s)]+)`, "i"));
+  return match?.[1]?.trim() || "";
+}
+
+function inferProjectValueFromJql(jql = "") {
+  const inMatch = String(jql || "").match(/project\s+IN\s*\(([^)]+)\)/i);
+  if (inMatch) return inMatch[1].trim();
+
+  const equalsMatch = String(jql || "").match(/project\s*=\s*([^\s)]+)/i);
+  return equalsMatch?.[1]?.trim() || "";
 }
 
 export function normalizeVisualConfig(visual = {}) {
@@ -46,21 +95,39 @@ export function normalizeVisualConfig(visual = {}) {
 }
 
 export function mergeConfiguration(dataRequest) {
+  const requestConfiguration = dataRequest?.configuration || {};
+  const requestVisual = requestConfiguration.visual || {};
+  const inferredVisual = {
+    projects: requestVisual.projects || inferProjectValueFromJql(requestConfiguration.jql),
+    startDate: requestVisual.startDate || inferVisualValueFromJql(requestConfiguration.jql, [
+      "created",
+      "updated",
+      "resolutiondate",
+      "statusCategoryChangedDate",
+    ], ">="),
+    endDate: requestVisual.endDate || inferVisualValueFromJql(requestConfiguration.jql, [
+      "created",
+      "updated",
+      "resolutiondate",
+      "statusCategoryChangedDate",
+    ], "<="),
+  };
   const mergedConfiguration = {
     ...DEFAULT_CONFIGURATION,
-    ...(dataRequest?.configuration || {}),
-    fields: dataRequest?.configuration?.fields || DEFAULT_CONFIGURATION.fields,
+    ...requestConfiguration,
+    fields: requestConfiguration.fields || DEFAULT_CONFIGURATION.fields,
     transform: {
       ...DEFAULT_CONFIGURATION.transform,
-      ...(dataRequest?.configuration?.transform || {}),
+      ...(requestConfiguration.transform || {}),
     },
     pagination: {
       ...DEFAULT_CONFIGURATION.pagination,
-      ...(dataRequest?.configuration?.pagination || {}),
+      ...(requestConfiguration.pagination || {}),
     },
     visual: normalizeVisualConfig({
       ...(DEFAULT_CONFIGURATION.visual || {}),
-      ...(dataRequest?.configuration?.visual || {}),
+      ...inferredVisual,
+      ...requestVisual,
     }),
   };
 

--- a/client/src/sources/jira/jira-builder.utils.js
+++ b/client/src/sources/jira/jira-builder.utils.js
@@ -1,0 +1,229 @@
+import { DEFAULT_CONFIGURATION } from "./jira.source";
+
+export function formatDateValue(date) {
+  if (!date) return "";
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+export function getDefaultDateRange() {
+  const end = new Date();
+  const start = new Date(end);
+  start.setDate(start.getDate() - 30);
+
+  return {
+    startDate: formatDateValue(start),
+    endDate: formatDateValue(end),
+  };
+}
+
+export function normalizeDateRangeValue(value, fallback) {
+  if (!value) return fallback;
+  if (/^\{\{[^}]+\}\}$/.test(String(value || "").trim())) return value;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(String(value || ""))) return value;
+  const parsedDate = new Date(value);
+  if (!Number.isNaN(parsedDate.getTime())) return formatDateValue(parsedDate);
+  return fallback;
+}
+
+export function getPlaceholderVariableName(value) {
+  const match = String(value || "").trim().match(/^\{\{([^}]+)\}\}$/);
+  return match?.[1]?.trim() || null;
+}
+
+export function normalizeVisualConfig(visual = {}) {
+  const defaultRange = getDefaultDateRange();
+
+  return {
+    ...visual,
+    dateField: visual.dateField || "created",
+    startDate: normalizeDateRangeValue(visual.startDate, defaultRange.startDate),
+    endDate: normalizeDateRangeValue(visual.endDate, defaultRange.endDate),
+  };
+}
+
+export function mergeConfiguration(dataRequest) {
+  const mergedConfiguration = {
+    ...DEFAULT_CONFIGURATION,
+    ...(dataRequest?.configuration || {}),
+    fields: dataRequest?.configuration?.fields || DEFAULT_CONFIGURATION.fields,
+    transform: {
+      ...DEFAULT_CONFIGURATION.transform,
+      ...(dataRequest?.configuration?.transform || {}),
+    },
+    pagination: {
+      ...DEFAULT_CONFIGURATION.pagination,
+      ...(dataRequest?.configuration?.pagination || {}),
+    },
+    visual: normalizeVisualConfig({
+      ...(DEFAULT_CONFIGURATION.visual || {}),
+      ...(dataRequest?.configuration?.visual || {}),
+    }),
+  };
+
+  if ((mergedConfiguration.mode || "visual") === "visual") {
+    return {
+      ...mergedConfiguration,
+      jql: buildJqlFromVisualConfig(mergedConfiguration),
+    };
+  }
+
+  return mergedConfiguration;
+}
+
+function quoteJqlValue(value) {
+  if (value === undefined || value === null || value === "") return null;
+  return `"${String(value).replace(/"/g, "\\\"")}"`;
+}
+
+function addClause(clauses, clause) {
+  if (clause) clauses.push(clause);
+}
+
+function getJqlDateField(dateField) {
+  if (dateField === "doneAt") return "statusCategoryChangedDate";
+  return dateField || "created";
+}
+
+export function buildJqlFromVisualConfig(configuration) {
+  const visual = configuration.visual || {};
+  const clauses = [];
+  const dateField = visual.dateField || "created";
+  const jqlDateField = getJqlDateField(dateField);
+  const isDoneDateField = dateField === "doneAt";
+
+  addClause(clauses, visual.projects ? `project IN (${visual.projects})` : null);
+  addClause(clauses, visual.issueType ? `issuetype = ${quoteJqlValue(visual.issueType)}` : null);
+  addClause(clauses, isDoneDateField ? "statusCategory = Done" : null);
+  addClause(clauses, !isDoneDateField && visual.statusCategory ? `statusCategory = ${quoteJqlValue(visual.statusCategory)}` : null);
+  addClause(clauses, visual.assignee ? `assignee = ${quoteJqlValue(visual.assignee)}` : null);
+  addClause(clauses, visual.priority ? `priority = ${quoteJqlValue(visual.priority)}` : null);
+  addClause(clauses, visual.fixVersion ? `fixVersion = ${quoteJqlValue(visual.fixVersion)}` : null);
+  addClause(clauses, visual.startDate ? `${jqlDateField} >= ${visual.startDate}` : null);
+  addClause(clauses, visual.endDate ? `${jqlDateField} <= ${visual.endDate}` : null);
+
+  const query = clauses.join(" AND ");
+  return query ? `${query} ORDER BY ${isDoneDateField ? "updated" : jqlDateField} DESC` : "ORDER BY updated DESC";
+}
+
+export function withVisualJql(configuration, visualUpdates = {}) {
+  const nextConfiguration = {
+    ...configuration,
+    visual: {
+      ...(configuration.visual || {}),
+      ...visualUpdates,
+    },
+  };
+
+  return {
+    ...nextConfiguration,
+    jql: buildJqlFromVisualConfig(nextConfiguration),
+  };
+}
+
+export function getDefaultsForResource(resource, currentConfiguration = {}) {
+  const currentVisual = currentConfiguration.visual || {};
+  const currentTransform = currentConfiguration.transform || {};
+  const base = {
+    resource,
+    mode: "visual",
+    transform: {
+      type: "raw",
+    },
+  };
+
+  if (resource === "issues") {
+    const issueTransform = currentConfiguration.resource === "issues"
+      && ["grouped", "created_resolved_trend", "stale_table", "raw"].includes(currentTransform.type)
+      ? currentTransform
+      : { type: "raw" };
+    const nextConfiguration = {
+      ...currentConfiguration,
+      ...base,
+      visual: currentVisual,
+      transform: issueTransform,
+    };
+
+    return {
+      ...nextConfiguration,
+      jql: buildJqlFromVisualConfig(nextConfiguration),
+    };
+  }
+
+  if (resource === "sprint_issues") {
+    const sprintIssueTransform = currentConfiguration.resource === "sprint_issues"
+      && ["grouped", "sprint_summary", "stale_table", "raw"].includes(currentTransform.type)
+      ? currentTransform
+      : { type: "sprint_summary" };
+    return {
+      ...base,
+      sprintId: currentConfiguration.sprintId || "",
+      jql: currentConfiguration.jql || "",
+      transform: sprintIssueTransform,
+      pagination: currentConfiguration.pagination,
+    };
+  }
+
+  if (resource === "boards") {
+    return {
+      ...base,
+      projectIdOrKey: currentConfiguration.projectIdOrKey || currentVisual.projects || "",
+      boardType: currentConfiguration.boardType || "",
+      jql: "",
+      pagination: currentConfiguration.pagination,
+    };
+  }
+
+  if (resource === "sprints") {
+    return {
+      ...base,
+      boardId: currentConfiguration.boardId || "",
+      state: currentConfiguration.state || "active",
+      jql: "",
+      pagination: currentConfiguration.pagination,
+    };
+  }
+
+  if (resource === "versions") {
+    return {
+      ...base,
+      projectIdOrKey: currentConfiguration.projectIdOrKey || currentVisual.projects || "",
+      jql: "",
+      pagination: currentConfiguration.pagination,
+    };
+  }
+
+  return base;
+}
+
+export function getPreviewRows(payload) {
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.response?.data)) return payload.response.data;
+  if (Array.isArray(payload?.response?.dataRequest?.responseData?.data)) {
+    return payload.response.dataRequest.responseData.data;
+  }
+  return [];
+}
+
+export function getPreviewColumns(payload) {
+  const firstRow = getPreviewRows(payload)[0];
+  return firstRow ? Object.keys(firstRow) : [];
+}
+
+export function getSuggestedCharts(configuration) {
+  if (configuration.transform?.type === "grouped") return ["Bar", "Doughnut", "Table"];
+  if (configuration.transform?.type === "created_resolved_trend") return ["Line", "Bar"];
+  if (configuration.transform?.type === "sprint_summary") return ["KPI", "Gauge"];
+  if (configuration.transform?.type === "stale_table") return ["Table"];
+  return ["Table"];
+}
+
+export function formatPreviewValue(value) {
+  if (Array.isArray(value)) return value.join(", ");
+  if (value && typeof value === "object") return JSON.stringify(value);
+  if (value === null || value === undefined || value === "") return "-";
+  return String(value);
+}

--- a/client/src/sources/jira/jira-connection-form.jsx
+++ b/client/src/sources/jira/jira-connection-form.jsx
@@ -1,0 +1,317 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Alert,
+  Button,
+  FieldError,
+  Input,
+  Label,
+  Link,
+  TextField,
+} from "@heroui/react";
+import { LuEye, LuEyeOff } from "react-icons/lu";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router";
+
+import Row from "../../components/Row";
+import { ButtonSpinner } from "../../components/ButtonSpinner";
+import { testRequest } from "../../slices/connection";
+import { selectTeam } from "../../slices/team";
+
+function normalizeSiteUrl(value = "") {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function JiraConnectionForm(props) {
+  const { editConnection, onComplete, addError } = props;
+
+  const [loading, setLoading] = useState(false);
+  const [testLoading, setTestLoading] = useState(false);
+  const [connection, setConnection] = useState({
+    type: "jira",
+    subType: "jira",
+    host: "",
+    name: "Jira",
+    authentication: {
+      type: "api_token",
+      email: "",
+      apiToken: "",
+    },
+    options: {
+      jira: {},
+    },
+  });
+  const [errors, setErrors] = useState({});
+  const [testResult, setTestResult] = useState(null);
+  const [tokenVisible, setTokenVisible] = useState(false);
+
+  const dispatch = useDispatch();
+  const team = useSelector(selectTeam);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (editConnection) {
+      setConnection({
+        ...editConnection,
+        type: "jira",
+        subType: "jira",
+        host: editConnection.host || editConnection.options?.jira?.siteUrl || "",
+        authentication: {
+          type: "api_token",
+          email: editConnection.authentication?.email || editConnection.authentication?.user || "",
+          apiToken: editConnection.authentication?.apiToken || editConnection.authentication?.token || "",
+        },
+        options: {
+          ...(editConnection.options || {}),
+          jira: {
+            ...(editConnection.options?.jira || {}),
+          },
+        },
+      });
+    }
+  }, [editConnection]);
+
+  const validate = () => {
+    const nextErrors = {};
+    const siteUrl = normalizeSiteUrl(connection.host || "");
+    const email = connection.authentication?.email || "";
+    const apiToken = connection.authentication?.apiToken || "";
+
+    if (!connection.name || connection.name.length > 24) {
+      nextErrors.name = "Please enter a name which is less than 24 characters";
+    }
+
+    if (!/^https:\/\/[^/]+\.atlassian\.net$/i.test(siteUrl)) {
+      nextErrors.host = "Enter a Jira Cloud URL like https://example.atlassian.net";
+    }
+
+    if (!email) {
+      nextErrors.email = "Enter your Jira account email";
+    }
+
+    if (!apiToken) {
+      nextErrors.apiToken = "Enter your Jira API token";
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const buildConnection = () => {
+    const siteUrl = normalizeSiteUrl(connection.host || "");
+
+    return {
+      ...connection,
+      type: "jira",
+      subType: "jira",
+      host: siteUrl,
+      authentication: {
+        type: "api_token",
+        email: connection.authentication?.email || "",
+        apiToken: connection.authentication?.apiToken || "",
+      },
+      options: {
+        ...(connection.options || {}),
+        jira: {
+          ...(connection.options?.jira || {}),
+          siteUrl,
+        },
+      },
+    };
+  };
+
+  const onChangeAuthentication = (updates) => {
+    setConnection({
+      ...connection,
+      authentication: {
+        ...connection.authentication,
+        type: "api_token",
+        ...updates,
+      },
+    });
+  };
+
+  const onTestRequest = () => {
+    if (!validate()) return;
+
+    setTestLoading(true);
+    setTestResult(null);
+    dispatch(testRequest({ team_id: team?.id, connection: buildConnection() }))
+      .then(async (response) => {
+        const body = await response.payload.text();
+        setTestResult({
+          status: response.payload.status,
+          ok: response.payload.ok,
+          body,
+        });
+      })
+      .catch(() => {
+        setTestResult({ ok: false, status: 400, body: "Jira connection test failed" });
+      })
+      .finally(() => setTestLoading(false));
+  };
+
+  const onCreateConnection = () => {
+    if (!validate()) return;
+
+    setLoading(true);
+    onComplete(buildConnection())
+      .then(() => setLoading(false))
+      .catch(() => setLoading(false));
+  };
+
+  return (
+    <div className="p-6 bg-surface border border-divider rounded-3xl">
+      <div className="flex flex-row items-center justify-between">
+        <p className="text-lg font-semibold">
+          {!editConnection && "Connect to Jira"}
+          {editConnection && `Edit ${editConnection.name}`}
+        </p>
+        {editConnection && (
+          <Button
+            variant="secondary"
+            onPress={() => navigate("templates")}
+          >
+            Browse templates
+          </Button>
+        )}
+      </div>
+
+      <div className="mt-5 mb-5">
+        <Row>
+          <TextField fullWidth className="max-w-[500px]" name="jira-name" isInvalid={Boolean(errors.name)}>
+            <Label>Enter a name for your connection</Label>
+            <Input
+              placeholder="Enter a name you can recognize later"
+              value={connection.name || ""}
+              onChange={(e) => setConnection({ ...connection, name: e.target.value })}
+              variant="secondary"
+            />
+            {errors.name ? <FieldError>{errors.name}</FieldError> : null}
+          </TextField>
+        </Row>
+
+        <div className="h-4" />
+        <Row>
+          <TextField fullWidth className="max-w-[500px]" name="jira-site-url" isInvalid={Boolean(errors.host)}>
+            <Label>Jira Cloud site URL</Label>
+            <Input
+              placeholder="https://example.atlassian.net"
+              value={connection.host || ""}
+              onChange={(e) => setConnection({ ...connection, host: e.target.value })}
+              variant="secondary"
+            />
+            {errors.host ? <FieldError>{errors.host}</FieldError> : null}
+          </TextField>
+        </Row>
+
+        <div className="h-4" />
+        <Row>
+          <TextField fullWidth className="max-w-[500px]" name="jira-email" isInvalid={Boolean(errors.email)}>
+            <Label>Jira account email</Label>
+            <Input
+              placeholder="you@example.com"
+              value={connection.authentication?.email || ""}
+              onChange={(e) => onChangeAuthentication({ email: e.target.value })}
+              variant="secondary"
+            />
+            {errors.email ? <FieldError>{errors.email}</FieldError> : null}
+          </TextField>
+        </Row>
+
+        <div className="h-4" />
+        <Row>
+          <TextField fullWidth className="max-w-[500px]" name="jira-api-token" isInvalid={Boolean(errors.apiToken)}>
+            <Label>Jira API token</Label>
+            <div className="flex flex-row gap-2">
+              <Input
+                placeholder="Paste your Jira API token"
+                type={tokenVisible ? "text" : "password"}
+                value={connection.authentication?.apiToken || ""}
+                onChange={(e) => onChangeAuthentication({ apiToken: e.target.value })}
+                variant="secondary"
+              />
+              <Button
+                isIconOnly
+                aria-label={tokenVisible ? "Hide Jira API token" : "Show Jira API token"}
+                variant="tertiary"
+                onPress={() => setTokenVisible(!tokenVisible)}
+              >
+                {tokenVisible ? <LuEyeOff /> : <LuEye />}
+              </Button>
+            </div>
+            {errors.apiToken ? <FieldError>{errors.apiToken}</FieldError> : null}
+          </TextField>
+        </Row>
+
+        <div className="h-4" />
+        <p className="max-w-[560px] text-sm text-foreground-500">
+          Use a Jira Cloud API token for a user that can read the projects, boards, sprints, fields, and issues you want to chart.
+        </p>
+        <p className="max-w-[560px] text-sm text-foreground-500 mt-2">
+          <Link href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener noreferrer">Create or manage Jira API tokens</Link>
+        </p>
+
+        {testResult && (
+          <>
+            <div className="h-4" />
+            <Alert status={testResult.ok ? "success" : "danger"} className="shadow-none border border-divider">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Title>
+                  {testResult.ok ? "Jira connection test succeeded" : `Jira connection test failed (${testResult.status})`}
+                </Alert.Title>
+              </Alert.Content>
+            </Alert>
+          </>
+        )}
+
+        {addError && (
+          <>
+            <div className="h-4" />
+            <Alert status="danger">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Title>Server error while trying to save your connection</Alert.Title>
+                <Alert.Description>Please try again.</Alert.Description>
+              </Alert.Content>
+            </Alert>
+          </>
+        )}
+
+        <div className="h-4" />
+        <div className="flex flex-row gap-2">
+          <Button
+            isPending={testLoading}
+            onPress={onTestRequest}
+            variant="tertiary"
+          >
+            {testLoading ? <ButtonSpinner /> : null}
+            Test connection
+          </Button>
+          <Button
+            isPending={loading}
+            onPress={onCreateConnection}
+            variant="primary"
+          >
+            {loading ? <ButtonSpinner /> : null}
+            Save connection
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+JiraConnectionForm.defaultProps = {
+  editConnection: null,
+  addError: null,
+};
+
+JiraConnectionForm.propTypes = {
+  onComplete: PropTypes.func.isRequired,
+  editConnection: PropTypes.object,
+  addError: PropTypes.bool,
+};
+
+export default JiraConnectionForm;

--- a/client/src/sources/jira/jira-template-setup.jsx
+++ b/client/src/sources/jira/jira-template-setup.jsx
@@ -1,0 +1,803 @@
+import React, { useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Chip,
+  Input,
+  Label,
+  ListBox,
+  Select,
+  Separator,
+  Surface,
+  Tabs,
+  TextField,
+} from "@heroui/react";
+import {
+  LuActivity,
+  LuBug,
+  LuChartArea,
+  LuChartBar,
+  LuChartLine,
+  LuChartPie,
+  LuCheck,
+  LuCircleCheck,
+  LuClock,
+  LuGauge,
+  LuListChecks,
+  LuPlus,
+  LuTable,
+  LuUsers,
+} from "react-icons/lu";
+import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router";
+
+import { createFromChartTemplate, getChartTemplate } from "../../slices/chartTemplate";
+import { getProjectCharts } from "../../slices/chart";
+import { ButtonSpinner } from "../../components/ButtonSpinner";
+
+const DASHBOARD_CREATE_SETTLE_DELAY_MS = 10000;
+
+const GROUPS = [{
+  id: "overview",
+  label: "Project overview",
+  description: "Issue trends, status breakdowns, workload, and recently completed work.",
+}, {
+  id: "sprint",
+  label: "Sprint health",
+  description: "Sprint completion, completed story points, carryover, and assignee workload.",
+}, {
+  id: "bugs",
+  label: "Bug tracking",
+  description: "Open bugs, priority breakdowns, oldest bugs, and bug trends.",
+}, {
+  id: "workload",
+  label: "Team workload",
+  description: "Open work, work in progress, and stale issues by assignee.",
+}];
+
+const TEMPLATE_ORDER = {
+  "project-overview": 0,
+  "sprint-health": 1,
+  "bug-tracking": 2,
+  "team-workload": 3,
+};
+
+const TEMPLATE_ICONS = {
+  Activity: LuActivity,
+  BadgeCheck: LuCircleCheck,
+  BarChart3: LuChartBar,
+  Bug: LuBug,
+  Clock: LuClock,
+  Gauge: LuGauge,
+  LineChart: LuChartLine,
+  ListChecks: LuListChecks,
+  PieChart: LuChartPie,
+  Table: LuTable,
+  Users: LuUsers,
+};
+
+const RESOURCE_LABELS = {
+  boards: "Boards",
+  issues: "Issues",
+  sprint_issues: "Sprint issues",
+  sprints: "Sprints",
+  versions: "Versions",
+};
+
+const CARD_META = {
+  "project-overview:created-vs-resolved": {
+    group: "overview",
+    filters: ["Project", "Date range"],
+    recommended: true,
+  },
+  "project-overview:issues-by-status": {
+    group: "overview",
+    filters: ["Open issues"],
+    recommended: true,
+  },
+  "project-overview:issues-by-assignee": {
+    group: "overview",
+    filters: ["Open issues"],
+    recommended: true,
+  },
+  "project-overview:recent-completed-work": {
+    group: "overview",
+    filters: ["Resolved recently"],
+    recommended: true,
+  },
+  "sprint-health:sprint-completion": {
+    group: "sprint",
+    filters: ["Sprint ID"],
+    recommended: true,
+  },
+  "sprint-health:story-points-completed": {
+    group: "sprint",
+    filters: ["Sprint ID"],
+    recommended: true,
+  },
+  "sprint-health:sprint-work-by-assignee": {
+    group: "sprint",
+    filters: ["Sprint ID"],
+    recommended: true,
+  },
+  "sprint-health:sprint-status-breakdown": {
+    group: "sprint",
+    filters: ["Sprint ID"],
+  },
+  "sprint-health:carryover-issues": {
+    group: "sprint",
+    filters: ["Not done", "Sprint ID"],
+    recommended: true,
+  },
+  "bug-tracking:bugs-by-priority": {
+    group: "bugs",
+    filters: ["Bug", "Open"],
+    recommended: true,
+  },
+  "bug-tracking:bug-trend": {
+    group: "bugs",
+    filters: ["Bug", "Date range"],
+    recommended: true,
+  },
+  "bug-tracking:oldest-open-bugs": {
+    group: "bugs",
+    filters: ["Bug", "Open"],
+    recommended: true,
+  },
+  "team-workload:open-issues-by-assignee": {
+    group: "workload",
+    filters: ["Open issues"],
+    recommended: true,
+  },
+  "team-workload:wip-by-assignee": {
+    group: "workload",
+    filters: ["In progress"],
+    recommended: true,
+  },
+  "team-workload:stale-issues": {
+    group: "workload",
+    filters: ["Open", "Not updated 14d"],
+    recommended: true,
+  },
+};
+
+function sortTemplates(templatesToSort) {
+  return [...templatesToSort].sort((left, right) => {
+    return (TEMPLATE_ORDER[left.slug] ?? 100) - (TEMPLATE_ORDER[right.slug] ?? 100);
+  });
+}
+
+function wait(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function uniq(values) {
+  return [...new Set(values)];
+}
+
+function formatCreatedSummary(result) {
+  const datasetCount = result.datasets.length;
+  const chartCount = result.charts.length;
+  const parts = [];
+
+  if (datasetCount > 0) parts.push(`${datasetCount} dataset${datasetCount === 1 ? "" : "s"}`);
+  if (chartCount > 0) parts.push(`${chartCount} chart${chartCount === 1 ? "" : "s"}`);
+
+  return parts.join(" and ");
+}
+
+function formatFieldName(field) {
+  return String(field || "")
+    .replace(/_/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function getChartTypeLabel(type) {
+  const labels = {
+    bar: "Bar chart",
+    doughnut: "Doughnut chart",
+    gauge: "Gauge",
+    kpi: "KPI",
+    line: "Line chart",
+    table: "Table",
+  };
+
+  return labels[type] || `${formatFieldName(type)} chart`;
+}
+
+function getTemplateIcon(iconName) {
+  return TEMPLATE_ICONS[iconName] || LuChartArea;
+}
+
+function getSourceLabel(config) {
+  return RESOURCE_LABELS[config?.resource] || formatFieldName(config?.resource || "issues");
+}
+
+function getMetricLabel(config) {
+  const transform = config?.transform || {};
+
+  if (transform.type === "created_resolved_trend") return "Created vs resolved";
+  if (transform.type === "sprint_summary") return "Sprint summary";
+  if (transform.type === "stale_table") return "Stale issues";
+  if (transform.type === "raw") return "Issue rows";
+  if (transform.metric === "storyPoints") return "Sum story points";
+  if (transform.metric === "averageAge") return "Average age";
+  if (transform.metric === "leadTime") return "Lead time";
+  return "Count issues";
+}
+
+function cardUsesVariable(card, variableName) {
+  return card.datasets.some((dataset) => {
+    const bindings = dataset.dataRequest?.variableBindings || [];
+    return bindings.some((binding) => binding.name === variableName || binding.variableName === variableName);
+  });
+}
+
+function buildCards(templates) {
+  return templates.flatMap((template) => {
+    return (template.charts || []).map((chart) => {
+      const key = `${template.slug}:${chart.id}`;
+      const meta = CARD_META[key] || {};
+      const datasets = (template.datasets || []).filter((dataset) => {
+        return (chart.requiredDatasetIds || []).includes(dataset.id);
+      });
+      const primaryDataset = datasets[0] || {};
+      const config = primaryDataset.dataRequest?.configuration || {};
+
+      return {
+        key,
+        id: chart.id,
+        template,
+        chart,
+        datasets,
+        group: meta.group || template.slug || "overview",
+        filters: meta.filters || [],
+        recommended: meta.recommended === true,
+        sourceLabel: getSourceLabel(config),
+        metricLabel: getMetricLabel(config),
+      };
+    });
+  });
+}
+
+function JiraChartCard(props) {
+  const { card, isSelected, onToggle } = props;
+  const Icon = getTemplateIcon(card.chart.icon);
+  const _onKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onToggle(card.key);
+    }
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      onClick={() => onToggle(card.key)}
+      onKeyDown={_onKeyDown}
+      className={[
+        "cursor-pointer",
+        "flex min-h-[224px] w-full flex-col rounded-lg border p-4 text-left transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+        isSelected
+          ? "border-primary bg-primary/5"
+          : "border-divider bg-surface hover:border-primary/50 hover:bg-content2/30",
+      ].join(" ")}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-divider bg-surface-secondary text-foreground">
+          <Icon size={18} />
+        </span>
+        <span onClick={(event) => event.stopPropagation()}>
+          <Checkbox isSelected={isSelected} onPress={() => onToggle(card.key)} variant="secondary">
+            <Checkbox.Control>
+              <Checkbox.Indicator />
+            </Checkbox.Control>
+          </Checkbox>
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-2">
+        <span className="text-sm font-semibold text-foreground">{card.chart.name}</span>
+        <p className="text-xs text-muted">{card.chart.description}</p>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-2 text-xs">
+        <div className="flex flex-row items-center justify-between gap-3">
+          <span className="text-muted">Creates</span>
+          <span className="text-right font-medium text-foreground">
+            {card.datasets.length} dataset{card.datasets.length === 1 ? "" : "s"} + {getChartTypeLabel(card.chart.type)}
+          </span>
+        </div>
+        <div className="flex flex-row items-center justify-between gap-3">
+          <span className="text-muted">Resource</span>
+          <span className="text-right font-medium text-foreground">{card.sourceLabel}</span>
+        </div>
+        <div className="flex flex-row items-center justify-between gap-3">
+          <span className="text-muted">Default</span>
+          <span className="text-right font-medium text-foreground">{card.metricLabel}</span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {card.filters.length > 0 ? card.filters.map((filter) => (
+          <Chip key={filter} size="sm" variant="secondary">{filter}</Chip>
+        )) : (
+          <Chip size="sm" variant="secondary">No filters</Chip>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function JiraTemplateSetup(props) {
+  const {
+    connection,
+    error,
+    fixedProjectId,
+    loading,
+    projects,
+    teamId,
+    templates,
+    title,
+  } = props;
+
+  const [dashboardMode, setDashboardMode] = useState("existing");
+  const [selectedProjectId, setSelectedProjectId] = useState(fixedProjectId ? `${fixedProjectId}` : null);
+  const [newDashboardName, setNewDashboardName] = useState("Jira Dashboard");
+  const [fullTemplates, setFullTemplates] = useState([]);
+  const [selectedCardKeys, setSelectedCardKeys] = useState([]);
+  const [initializedCardsSignature, setInitializedCardsSignature] = useState(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState(null);
+  const [createResult, setCreateResult] = useState(null);
+  const [actionMode, setActionMode] = useState("dashboard");
+  const [jiraProjectKeys, setJiraProjectKeys] = useState("");
+  const [jiraSprintId, setJiraSprintId] = useState("");
+
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const visibleProjects = useMemo(() => (projects || []).filter((project) => !project.ghost), [projects]);
+  const fixedProject = visibleProjects.find((project) => `${project.id}` === `${fixedProjectId}`);
+  const templatesSignature = useMemo(() => templates.map((template) => `${template.source}:${template.slug}`).join("|"), [templates]);
+  const cards = useMemo(() => buildCards(fullTemplates), [fullTemplates]);
+  const cardsSignature = useMemo(() => cards.map((card) => card.key).join("|"), [cards]);
+  const selectedCards = useMemo(() => {
+    return cards.filter((card) => selectedCardKeys.includes(card.key));
+  }, [cards, selectedCardKeys]);
+  const selectedDatasetCount = useMemo(() => {
+    return uniq(selectedCards.flatMap((card) => card.datasets.map((dataset) => `${card.template.slug}:${dataset.id}`))).length;
+  }, [selectedCards]);
+  const selectedChartCount = selectedCards.length;
+  const needsProjectKeys = useMemo(() => {
+    return selectedCards.some((card) => cardUsesVariable(card, "projects"));
+  }, [selectedCards]);
+  const needsSprintId = useMemo(() => {
+    return selectedCards.some((card) => cardUsesVariable(card, "sprint_id"));
+  }, [selectedCards]);
+
+  useEffect(() => {
+    if (fixedProjectId) {
+      setDashboardMode("existing");
+      setSelectedProjectId(`${fixedProjectId}`);
+    }
+  }, [fixedProjectId]);
+
+  useEffect(() => {
+    if (!fixedProjectId && !selectedProjectId && visibleProjects.length > 0) {
+      setSelectedProjectId(`${visibleProjects[0].id}`);
+    }
+  }, [fixedProjectId, selectedProjectId, visibleProjects]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!teamId || !templatesSignature) {
+      setFullTemplates([]);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    Promise.all(templates.map((template) => dispatch(getChartTemplate({
+      team_id: teamId,
+      source: template.source,
+      slug: template.slug,
+    })).unwrap()))
+      .then((loadedTemplates) => {
+        if (!isMounted) return;
+        setFullTemplates(sortTemplates(loadedTemplates));
+      })
+      .catch((loadError) => {
+        if (!isMounted) return;
+        setCreateError(loadError.message || "Could not load Jira templates");
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [dispatch, teamId, templatesSignature]);
+
+  useEffect(() => {
+    if (cards.length === 0 || initializedCardsSignature === cardsSignature) return;
+
+    const recommendedCards = cards.filter((card) => card.recommended);
+    setSelectedCardKeys((recommendedCards.length > 0 ? recommendedCards : cards).map((card) => card.key));
+    setInitializedCardsSignature(cardsSignature);
+  }, [cards, cardsSignature, initializedCardsSignature]);
+
+  const _toggleCard = (cardKey) => {
+    setSelectedCardKeys((currentKeys) => (
+      currentKeys.includes(cardKey)
+        ? currentKeys.filter((key) => key !== cardKey)
+        : [...currentKeys, cardKey]
+    ));
+  };
+
+  const _toggleGroup = (groupCards) => {
+    const allSelected = groupCards.every((card) => selectedCardKeys.includes(card.key));
+    if (allSelected) {
+      setSelectedCardKeys(selectedCardKeys.filter((key) => !groupCards.some((card) => card.key === key)));
+      return;
+    }
+
+    setSelectedCardKeys(uniq([...selectedCardKeys, ...groupCards.map((card) => card.key)]));
+  };
+
+  const _selectAllCards = () => {
+    setSelectedCardKeys(cards.map((card) => card.key));
+    setInitializedCardsSignature(cardsSignature);
+  };
+
+  const _deselectAllCards = () => {
+    setSelectedCardKeys([]);
+    setInitializedCardsSignature(cardsSignature);
+  };
+
+  const createSelected = async (mode) => {
+    setActionMode(mode);
+    setIsCreating(true);
+    setCreateError(null);
+    setCreateResult(null);
+
+    try {
+      let projectId = dashboardMode === "existing" ? selectedProjectId : null;
+      const aggregatedResult = {
+        project_id: projectId,
+        datasets: [],
+        charts: [],
+      };
+
+      const templatesToCreate = sortTemplates(fullTemplates.filter((template) => {
+        return selectedCards.some((card) => card.template.slug === template.slug);
+      }));
+
+      for (const template of templatesToCreate) {
+        const cardsForTemplate = selectedCards.filter((card) => card.template.slug === template.slug);
+        const dashboard = projectId
+          ? { type: "existing", project_id: projectId }
+          : { type: "new", name: newDashboardName || "Jira Dashboard" };
+        const result = await dispatch(createFromChartTemplate({
+          team_id: teamId,
+          source: template.source,
+          slug: template.slug,
+          data: {
+            connection_id: connection.id,
+            dashboard,
+            dataset_template_ids: uniq(cardsForTemplate.flatMap((card) => card.datasets.map((dataset) => dataset.id))),
+            chart_template_ids: mode === "dashboard" ? cardsForTemplate.map((card) => card.chart.id) : [],
+            variable_defaults: {
+              projects: jiraProjectKeys.trim(),
+              sprint_id: jiraSprintId.trim(),
+            },
+          },
+        })).unwrap();
+
+        projectId = result.project_id;
+        aggregatedResult.project_id = result.project_id;
+        aggregatedResult.datasets.push(...(result.datasets || []));
+        aggregatedResult.charts.push(...(result.charts || []));
+      }
+
+      if (mode === "dashboard") {
+        await wait(DASHBOARD_CREATE_SETTLE_DELAY_MS);
+        await dispatch(getProjectCharts({ project_id: projectId })).unwrap().catch(() => null);
+      }
+
+      setCreateResult(aggregatedResult);
+    } catch (createTemplateError) {
+      setCreateError(createTemplateError.message || "Could not create Jira templates");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const openCreatedContent = () => {
+    if (actionMode === "dashboard" && createResult?.project_id) {
+      navigate(`/dashboard/${createResult.project_id}`);
+      return;
+    }
+
+    navigate("/datasets");
+  };
+
+  const isLoadPending = loading || (templates.length > 0 && fullTemplates.length === 0);
+  const createDisabled = isCreating
+    || selectedCards.length === 0
+    || (dashboardMode === "existing" && !selectedProjectId)
+    || (needsProjectKeys && !jiraProjectKeys.trim())
+    || (needsSprintId && !jiraSprintId.trim());
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="lg:col-span-2">
+        <Surface className="rounded-3xl border border-divider p-5" variant="default">
+          <div className="flex flex-col gap-5">
+            <div>
+              <p className="font-semibold">{title || "What do you want to track?"}</p>
+              <p className="text-sm text-muted">
+                Choose Jira charts and Chartbrew will create the matching datasets and charts.
+              </p>
+              {!isLoadPending && cards.length > 0 && (
+                <div className="mt-3 flex flex-row flex-wrap gap-2">
+                  <Button size="sm" variant="secondary" onPress={_selectAllCards}>
+                    Select all
+                  </Button>
+                  <Button size="sm" variant="tertiary" onPress={_deselectAllCards}>
+                    Deselect all
+                  </Button>
+                </div>
+              )}
+            </div>
+
+            {(error || createError) && (
+              <Alert status="danger">
+                <Alert.Indicator />
+                <Alert.Content>
+                  <Alert.Title>Could not prepare Jira templates</Alert.Title>
+                  <Alert.Description>{error || createError}</Alert.Description>
+                </Alert.Content>
+              </Alert>
+            )}
+
+            {isLoadPending && (
+              <span className="text-sm text-foreground-500">Loading Jira chart templates...</span>
+            )}
+
+            {!isLoadPending && GROUPS.map((group) => {
+              const groupCards = cards.filter((card) => card.group === group.id);
+              if (groupCards.length === 0) return null;
+              const groupSelectedCount = groupCards.filter((card) => selectedCardKeys.includes(card.key)).length;
+
+              return (
+                <section key={group.id} className="flex flex-col gap-3">
+                  <div className="flex flex-row flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="flex flex-row items-center gap-2">
+                        <p className="text-sm font-semibold text-foreground">{group.label}</p>
+                        <Chip size="sm" variant="secondary">
+                          {groupSelectedCount}/{groupCards.length}
+                        </Chip>
+                      </div>
+                      <p className="text-sm text-muted">{group.description}</p>
+                    </div>
+                    <Button size="sm" variant="tertiary" onPress={() => _toggleGroup(groupCards)}>
+                      {groupSelectedCount === groupCards.length ? "Clear group" : "Select group"}
+                    </Button>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    {groupCards.map((card) => (
+                      <JiraChartCard
+                        key={card.key}
+                        card={card}
+                        isSelected={selectedCardKeys.includes(card.key)}
+                        onToggle={_toggleCard}
+                      />
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </Surface>
+      </div>
+
+      <aside>
+        <div className="sticky top-16 flex flex-col gap-4">
+          <Surface className="rounded-3xl border border-divider p-5" variant="default">
+            <div className="flex flex-col gap-4">
+              <p className="text-lg font-semibold">Summary</p>
+              <div className="flex flex-col gap-2 text-sm">
+                <div className="flex flex-row items-center justify-between gap-3">
+                  <span className="text-muted">Charts</span>
+                  <span className="font-medium text-foreground">{selectedChartCount}</span>
+                </div>
+                <div className="flex flex-row items-center justify-between gap-3">
+                  <span className="text-muted">Datasets</span>
+                  <span className="font-medium text-foreground">{selectedDatasetCount}</span>
+                </div>
+              </div>
+
+              <Separator />
+
+              <div className="flex flex-col gap-3">
+                {(needsProjectKeys || needsSprintId) && (
+                  <div className="flex flex-col gap-3 rounded-lg border border-divider bg-surface-secondary p-3">
+                    <p className="text-sm font-semibold">Jira filters</p>
+                    {needsProjectKeys && (
+                      <TextField fullWidth name="jira-template-project-keys">
+                        <Label>Project key(s)</Label>
+                        <Input
+                          placeholder="CHART or CHART, OPS"
+                          value={jiraProjectKeys}
+                          onChange={(event) => setJiraProjectKeys(event.target.value)}
+                          variant="secondary"
+                        />
+                      </TextField>
+                    )}
+                    {needsSprintId && (
+                      <TextField fullWidth name="jira-template-sprint-id">
+                        <Label>Sprint ID</Label>
+                        <Input
+                          placeholder="123"
+                          value={jiraSprintId}
+                          onChange={(event) => setJiraSprintId(event.target.value)}
+                          variant="secondary"
+                        />
+                      </TextField>
+                    )}
+                  </div>
+                )}
+
+                <p className="text-sm font-semibold">Add selected to</p>
+                {fixedProjectId ? (
+                  <Chip variant="secondary" className="max-w-fit">
+                    {fixedProject?.name || "Current dashboard"}
+                  </Chip>
+                ) : (
+                  <>
+                    <Tabs
+                      selectedKey={dashboardMode}
+                      onSelectionChange={(key) => setDashboardMode(key)}
+                      className="w-full"
+                    >
+                      <Tabs.ListContainer>
+                        <Tabs.List>
+                          <Tabs.Tab id="existing">
+                            Existing
+                            <Tabs.Indicator />
+                          </Tabs.Tab>
+                          <Tabs.Tab id="new">
+                            New
+                            <LuPlus size={16} className="ml-2" />
+                            <Tabs.Indicator />
+                          </Tabs.Tab>
+                        </Tabs.List>
+                      </Tabs.ListContainer>
+                    </Tabs>
+
+                    {dashboardMode === "existing" && (
+                      <Select
+                        placeholder="Select dashboard"
+                        fullWidth
+                        selectionMode="single"
+                        value={selectedProjectId}
+                        onChange={(value) => setSelectedProjectId(value)}
+                        variant="secondary"
+                      >
+                        <Label>Select a dashboard</Label>
+                        <Select.Trigger>
+                          <Select.Value />
+                          <Select.Indicator />
+                        </Select.Trigger>
+                        <Select.Popover>
+                          <ListBox>
+                            {visibleProjects.map((project) => (
+                              <ListBox.Item key={project.id} id={`${project.id}`} textValue={project.name}>
+                                {project.name}
+                                <ListBox.ItemIndicator />
+                              </ListBox.Item>
+                            ))}
+                          </ListBox>
+                        </Select.Popover>
+                      </Select>
+                    )}
+
+                    {dashboardMode === "new" && (
+                      <TextField fullWidth name="jira-template-dashboard-name">
+                        <Label>Dashboard name</Label>
+                        <Input
+                          value={newDashboardName}
+                          onChange={(event) => setNewDashboardName(event.target.value)}
+                          variant="secondary"
+                        />
+                      </TextField>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {createResult && (
+                <Alert status="success">
+                  <Alert.Indicator />
+                  <Alert.Content>
+                    <Alert.Title>Jira content created</Alert.Title>
+                    <Alert.Description>{formatCreatedSummary(createResult)} created successfully.</Alert.Description>
+                  </Alert.Content>
+                </Alert>
+              )}
+            </div>
+          </Surface>
+
+          {!createResult && (
+            <div className="flex flex-col gap-2">
+              <Button
+                fullWidth
+                isDisabled={createDisabled}
+                isPending={isCreating && actionMode === "dashboard"}
+                variant="primary"
+                onPress={() => createSelected("dashboard")}
+              >
+                {isCreating && actionMode === "dashboard" ? <ButtonSpinner /> : null}
+                Create and add to dashboard
+              </Button>
+              <Button
+                fullWidth
+                isDisabled={createDisabled}
+                isPending={isCreating && actionMode === "datasets"}
+                variant="secondary"
+                onPress={() => createSelected("datasets")}
+              >
+                {isCreating && actionMode === "datasets" ? <ButtonSpinner /> : null}
+                Create datasets only
+              </Button>
+            </div>
+          )}
+
+          {createResult && (
+            <Button fullWidth variant="primary" onPress={openCreatedContent}>
+              <LuCheck />
+              {actionMode === "dashboard" ? "Open dashboard" : "Open datasets"}
+            </Button>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+JiraChartCard.propTypes = {
+  card: PropTypes.object.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+};
+
+JiraTemplateSetup.propTypes = {
+  connection: PropTypes.object.isRequired,
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  fixedProjectId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  loading: PropTypes.bool,
+  projects: PropTypes.array,
+  teamId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  templates: PropTypes.array,
+  title: PropTypes.string,
+};
+
+JiraTemplateSetup.defaultProps = {
+  error: null,
+  fixedProjectId: null,
+  loading: false,
+  projects: [],
+  templates: [],
+  title: null,
+};
+
+export default JiraTemplateSetup;

--- a/client/src/sources/jira/jira-template-setup.jsx
+++ b/client/src/sources/jira/jira-template-setup.jsx
@@ -35,7 +35,9 @@ import { useNavigate } from "react-router";
 
 import { createFromChartTemplate, getChartTemplate } from "../../slices/chartTemplate";
 import { getProjectCharts } from "../../slices/chart";
+import { runSourceAction } from "../../slices/connection";
 import { ButtonSpinner } from "../../components/ButtonSpinner";
+import JiraBuilderAutocompleteField from "./components/jira-builder-autocomplete-field";
 
 const DASHBOARD_CREATE_SETTLE_DELAY_MS = 10000;
 
@@ -177,6 +179,43 @@ function wait(ms) {
 
 function uniq(values) {
   return [...new Set(values)];
+}
+
+function parseCsvValues(value = "") {
+  return String(value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getProjectItems(jiraProjects) {
+  return jiraProjects.map((project) => ({
+    id: project.key,
+    label: `${project.key} - ${project.name}`,
+    shortLabel: project.key,
+    description: project.name,
+    searchText: `${project.key} ${project.name}`,
+  }));
+}
+
+function getBoardItems(jiraBoards) {
+  return jiraBoards.map((board) => ({
+    id: `${board.id}`,
+    label: board.name,
+    shortLabel: `${board.id}`,
+    description: `${board.type || "board"} #${board.id}`,
+    searchText: `${board.id} ${board.name} ${board.type || ""}`,
+  }));
+}
+
+function getSprintItems(jiraSprints) {
+  return jiraSprints.map((sprint) => ({
+    id: `${sprint.id}`,
+    label: sprint.name,
+    shortLabel: `${sprint.id}`,
+    description: `${sprint.state || "sprint"} #${sprint.id}`,
+    searchText: `${sprint.id} ${sprint.name} ${sprint.state || ""}`,
+  }));
 }
 
 function formatCreatedSummary(result) {
@@ -360,7 +399,12 @@ function JiraTemplateSetup(props) {
   const [createResult, setCreateResult] = useState(null);
   const [actionMode, setActionMode] = useState("dashboard");
   const [jiraProjectKeys, setJiraProjectKeys] = useState("");
+  const [jiraBoardId, setJiraBoardId] = useState("");
   const [jiraSprintId, setJiraSprintId] = useState("");
+  const [metadataLoading, setMetadataLoading] = useState(false);
+  const [jiraProjects, setJiraProjects] = useState([]);
+  const [jiraBoards, setJiraBoards] = useState([]);
+  const [jiraSprints, setJiraSprints] = useState([]);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -382,6 +426,66 @@ function JiraTemplateSetup(props) {
   const needsSprintId = useMemo(() => {
     return selectedCards.some((card) => cardUsesVariable(card, "sprint_id"));
   }, [selectedCards]);
+  const selectedProjectKeys = useMemo(() => parseCsvValues(jiraProjectKeys), [jiraProjectKeys]);
+  const selectedProjectKeysSignature = selectedProjectKeys.join(",");
+  const projectItems = useMemo(() => getProjectItems(jiraProjects), [jiraProjects]);
+  const boardItems = useMemo(() => getBoardItems(jiraBoards), [jiraBoards]);
+  const sprintItems = useMemo(() => getSprintItems(jiraSprints), [jiraSprints]);
+
+  const runJiraAction = (action, actionParams = {}) => {
+    if (!teamId || !connection?.id) return Promise.resolve([]);
+
+    return dispatch(runSourceAction({
+      team_id: teamId,
+      connection_id: connection.id,
+      action,
+      params: actionParams,
+    })).unwrap().then((result) => {
+      if (Array.isArray(result)) return result;
+      if (result?.error) throw new Error(result.error);
+      return [];
+    });
+  };
+
+  const loadProjects = () => {
+    if (!teamId || !connection?.id) return;
+
+    setMetadataLoading(true);
+    runJiraAction("listProjects")
+      .then((loadedProjects) => setJiraProjects(loadedProjects))
+      .catch(() => setCreateError("Could not load Jira projects."))
+      .finally(() => setMetadataLoading(false));
+  };
+
+  const loadBoards = (projectKeyOrId = "") => {
+    if (!teamId || !connection?.id) return;
+
+    setMetadataLoading(true);
+    runJiraAction("listBoards", {
+      projectKeyOrId: projectKeyOrId || undefined,
+      maxResults: 50,
+    })
+      .then((loadedBoards) => setJiraBoards(loadedBoards))
+      .catch(() => setCreateError("Could not load Jira boards."))
+      .finally(() => setMetadataLoading(false));
+  };
+
+  const loadSprints = (boardId) => {
+    if (!teamId || !connection?.id || !boardId) {
+      setJiraSprints([]);
+      return;
+    }
+
+    setMetadataLoading(true);
+    runJiraAction("listSprints", {
+      boardId,
+      maxResults: 50,
+      state: "active",
+    })
+      .then((loadedSprints) => setJiraSprints(loadedSprints))
+      .catch(() => setCreateError("Could not load Jira sprints."))
+      .finally(() => setMetadataLoading(false));
+  };
 
   useEffect(() => {
     if (fixedProjectId) {
@@ -395,6 +499,25 @@ function JiraTemplateSetup(props) {
       setSelectedProjectId(`${visibleProjects[0].id}`);
     }
   }, [fixedProjectId, selectedProjectId, visibleProjects]);
+
+  useEffect(() => {
+    loadProjects();
+  }, [teamId, connection?.id]);
+
+  useEffect(() => {
+    loadBoards(selectedProjectKeys[0] || "");
+  }, [selectedProjectKeysSignature, teamId, connection?.id]);
+
+  useEffect(() => {
+    if (!needsSprintId) {
+      setJiraBoardId("");
+      setJiraSprintId("");
+      setJiraSprints([]);
+      return;
+    }
+
+    loadSprints(jiraBoardId);
+  }, [needsSprintId, jiraBoardId, teamId, connection?.id]);
 
   useEffect(() => {
     let isMounted = true;
@@ -629,34 +752,6 @@ function JiraTemplateSetup(props) {
               <Separator />
 
               <div className="flex flex-col gap-3">
-                {(needsProjectKeys || needsSprintId) && (
-                  <div className="flex flex-col gap-3 rounded-lg border border-divider bg-surface-secondary p-3">
-                    <p className="text-sm font-semibold">Jira filters</p>
-                    {needsProjectKeys && (
-                      <TextField fullWidth name="jira-template-project-keys">
-                        <Label>Project key(s)</Label>
-                        <Input
-                          placeholder="CHART or CHART, OPS"
-                          value={jiraProjectKeys}
-                          onChange={(event) => setJiraProjectKeys(event.target.value)}
-                          variant="secondary"
-                        />
-                      </TextField>
-                    )}
-                    {needsSprintId && (
-                      <TextField fullWidth name="jira-template-sprint-id">
-                        <Label>Sprint ID</Label>
-                        <Input
-                          placeholder="123"
-                          value={jiraSprintId}
-                          onChange={(event) => setJiraSprintId(event.target.value)}
-                          variant="secondary"
-                        />
-                      </TextField>
-                    )}
-                  </div>
-                )}
-
                 <p className="text-sm font-semibold">Add selected to</p>
                 {fixedProjectId ? (
                   <Chip variant="secondary" className="max-w-fit">
@@ -735,6 +830,60 @@ function JiraTemplateSetup(props) {
                 </Alert>
               )}
             </div>
+          </Surface>
+
+          <Surface className="rounded-3xl border border-divider p-5" variant="default">
+            {(needsProjectKeys || needsSprintId) && (
+              <div className="flex flex-col gap-3">
+                <p className="text-sm font-semibold">Required Jira filters</p>
+                {needsProjectKeys && (
+                  <JiraBuilderAutocompleteField
+                    label="Project key(s)"
+                    name="jira-template-project-keys"
+                    placeholder={metadataLoading ? "Loading projects..." : "Select projects"}
+                    items={projectItems}
+                    value={selectedProjectKeys}
+                    selectionMode="multiple"
+                    onChange={(projectKeys) => {
+                      setJiraProjectKeys((projectKeys || []).join(", "));
+                      setJiraBoardId("");
+                      setJiraSprintId("");
+                    }}
+                    isDisabled={metadataLoading && projectItems.length === 0}
+                    emptyLabel="No Jira projects found"
+                  />
+                )}
+                {needsSprintId && (
+                  <>
+                    <JiraBuilderAutocompleteField
+                      label="Board"
+                      name="jira-template-board"
+                      placeholder={metadataLoading ? "Loading boards..." : "Select board"}
+                      items={boardItems}
+                      value={jiraBoardId}
+                      selectionMode="single"
+                      onChange={(boardId) => {
+                        setJiraBoardId(boardId ? `${boardId}` : "");
+                        setJiraSprintId("");
+                      }}
+                      isDisabled={metadataLoading && boardItems.length === 0}
+                      emptyLabel="No Jira boards found"
+                    />
+                    <JiraBuilderAutocompleteField
+                      label="Sprint"
+                      name="jira-template-sprint-id"
+                      placeholder={jiraBoardId ? "Select sprint" : "Select a board first"}
+                      items={sprintItems}
+                      value={jiraSprintId}
+                      selectionMode="single"
+                      onChange={(sprintId) => setJiraSprintId(sprintId ? `${sprintId}` : "")}
+                      isDisabled={!jiraBoardId || (metadataLoading && sprintItems.length === 0)}
+                      emptyLabel="No Jira sprints found"
+                    />
+                  </>
+                )}
+              </div>
+            )}
           </Surface>
 
           {!createResult && (

--- a/client/src/sources/jira/jira.source.js
+++ b/client/src/sources/jira/jira.source.js
@@ -1,0 +1,72 @@
+import jiraLogo from "./assets/jira.svg";
+import jiraLogoDark from "./assets/jira-dark.svg";
+
+const DEFAULT_CONFIGURATION = {
+  source: "jira",
+  resource: "issues",
+  mode: "visual",
+  jql: "created >= {{start_date}} AND created <= {{end_date}} ORDER BY updated DESC",
+  fields: ["key", "summary", "status", "assignee", "priority", "issuetype", "created", "updated", "resolutiondate", "project"],
+  transform: {
+    type: "raw",
+  },
+  includeDoneAt: false,
+  visual: {
+    dateField: "created",
+    startDate: "last_30_days",
+    endDate: "now",
+  },
+  pagination: {
+    startAt: 0,
+    maxResults: 100,
+    maxRecords: 5000,
+  },
+};
+
+const jiraSource = {
+  id: "jira",
+  type: "jira",
+  subType: "jira",
+  name: "Jira",
+  category: "productivity",
+  showNewBadge: true,
+  capabilities: {
+    ai: {
+      canGenerateQueries: false,
+      hasSourceInstructions: true,
+      hasTools: true,
+      canGenerateDatasets: true,
+    },
+    templates: {
+      charts: true,
+      datasets: true,
+    },
+    nextSteps: {
+      chartTemplates: true,
+      datasetTemplates: true,
+    },
+  },
+  assets: {
+    lightLogo: jiraLogo,
+    darkLogo: jiraLogoDark,
+  },
+  defaults: {
+    dataRequest: {
+      method: "GET",
+      pagination: true,
+      items: "issues",
+      itemsLimit: 5000,
+      offset: "startAt",
+      paginationField: null,
+      template: "jira",
+      useGlobalHeaders: true,
+      configuration: DEFAULT_CONFIGURATION,
+    },
+  },
+  templates: {
+    chartTemplates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+  },
+};
+
+export { DEFAULT_CONFIGURATION };
+export default jiraSource;

--- a/docs/specs/FS-20260514-jira-source-implementation-plan.md
+++ b/docs/specs/FS-20260514-jira-source-implementation-plan.md
@@ -1,0 +1,1572 @@
+# Jira Source Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Jira Cloud as a custom Chartbrew source with connection setup, Jira builder, normalized runtime, templates, and source-owned AI planning.
+
+**Architecture:** Jira is a custom source with `id`, `type`, and `subType` all set to `"jira"`. Backend runtime lives in `server/sources/plugins/jira/`; frontend UI lives in `client/src/sources/jira/`; templates are JSON files loaded through the existing source template system. Jira uses source actions for metadata and source-owned AI tools for planning, while dashboard creation from templates is handled by a generic orchestrator tool.
+
+**Tech Stack:** Node.js, Express, Sequelize, request-promise, React, Redux Toolkit, HeroUI, Vite, existing Chartbrew source plugin registry.
+
+---
+
+## File Structure
+
+Create:
+
+- `server/sources/plugins/jira/jira.plugin.js` - Jira source metadata, capabilities, template registration, backend hooks.
+- `server/sources/plugins/jira/jira.connection.js` - Jira Cloud auth, URL normalization, safe request helpers, metadata actions.
+- `server/sources/plugins/jira/jira.resources.js` - Supported resources, fields, transforms, template constants, field mapping helpers.
+- `server/sources/plugins/jira/jira.protocol.js` - DataRequest defaults, variable application, validation, runtime execution, normalization, caching/audit.
+- `server/sources/plugins/jira/ai/jira.ai.js` - Source-owned planner, schema, preview, template recommendation.
+- `server/sources/plugins/jira/templates/project-overview.json` - Project overview starter bundle.
+- `server/sources/plugins/jira/templates/sprint-health.json` - Sprint health starter bundle.
+- `server/sources/plugins/jira/templates/bug-tracking.json` - Bug tracking starter bundle.
+- `server/sources/plugins/jira/templates/team-workload.json` - Team workload starter bundle.
+- `server/tests/unit/jiraProtocol.test.js` - Protocol validation, JQL building, normalization, pagination, and variable tests.
+- `server/tests/unit/jiraTemplates.test.js` - Template validation and variable binding coverage.
+- `client/src/sources/jira/jira.source.js` - Frontend source metadata and defaults.
+- `client/src/sources/jira/jira-connection-form.jsx` - Jira connection form.
+- `client/src/sources/jira/jira-builder.jsx` - Jira dataset builder container following Stripe Official layout.
+- `client/src/sources/jira/jira-template-setup.jsx` - Jira template bundle setup.
+- `client/src/sources/jira/jira-builder.constants.jsx` - UI resource and option constants.
+- `client/src/sources/jira/jira-builder.utils.js` - Builder config normalization and preview utilities.
+- `client/src/sources/jira/assets/jira.svg` - Jira logo asset.
+- `client/src/sources/jira/components/jira-builder-context.jsx` - Builder state provider.
+- `client/src/sources/jira/components/jira-resource-step.jsx` - Resource/category selection.
+- `client/src/sources/jira/components/jira-config-step.jsx` - Visual/JQL/advanced configuration.
+- `client/src/sources/jira/components/jira-preview-step.jsx` - Preview and normalized output table.
+- `client/src/sources/jira/components/jira-summary-sidebar.jsx` - Summary, warnings, variables, suggested charts.
+- `server/modules/ai/orchestrator/tools/createDashboardFromTemplate.js` - Generic AI tool for registered chart templates.
+
+Modify:
+
+- `server/sources/index.js` - Register Jira plugin.
+- `client/src/sources/definitions.js` - Register Jira source metadata.
+- `client/src/sources/index.js` - Register Jira connection form, builder, and template setup.
+- `server/modules/ai/orchestrator/tools/index.js` - Export generic dashboard-template tool.
+- `server/modules/ai/orchestrator/orchestrator.js` - Add generic dashboard-template tool schema and dispatch.
+- `server/tests/unit/sourceRegistry.test.js` - Assert Jira resolution.
+- `server/tests/unit/sourcePluginStructure.test.js` - Assert Jira plugin shape.
+- `server/tests/integration/connectionRoute.security.test.js` - Assert Jira source-action security.
+- `server/tests/unit/sourceAiHarness.test.js` - Add Jira source-owned AI coverage and dashboard-template tool coverage.
+
+---
+
+## Task 1: Backend Plugin Skeleton And Registry
+
+**Files:**
+- Create: `server/sources/plugins/jira/jira.plugin.js`
+- Create: `server/sources/plugins/jira/jira.protocol.js`
+- Create: `server/sources/plugins/jira/jira.connection.js`
+- Create: `server/sources/plugins/jira/jira.resources.js`
+- Modify: `server/sources/index.js`
+- Modify: `server/tests/unit/sourceRegistry.test.js`
+- Modify: `server/tests/unit/sourcePluginStructure.test.js`
+
+- [ ] **Step 1: Write failing registry tests**
+
+Add assertions to `server/tests/unit/sourceRegistry.test.js` that load the source registry and verify:
+
+```js
+const jira = getSourceById("jira");
+expect(jira.id).toBe("jira");
+expect(jira.type).toBe("jira");
+expect(jira.subType).toBe("jira");
+expect(getSourceForConnection({ type: "jira", subType: "jira" }).id).toBe("jira");
+```
+
+Add assertions to `server/tests/unit/sourcePluginStructure.test.js` that Jira exposes:
+
+```js
+expect(jira.capabilities.connection.supportsTest).toBe(true);
+expect(jira.capabilities.connection.authModes).toContain("api_token");
+expect(jira.capabilities.data.supportsVariables).toBe(true);
+expect(jira.capabilities.templates.charts).toBe(true);
+expect(jira.capabilities.ai.hasTools).toBe(true);
+expect(jira.backend.runDataRequest).toEqual(expect.any(Function));
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceRegistry.test.js tests/unit/sourcePluginStructure.test.js
+```
+
+Expected: FAIL because `./plugins/jira/jira.plugin` is not registered.
+
+- [ ] **Step 3: Add minimal Jira resources**
+
+Create `server/sources/plugins/jira/jira.resources.js`:
+
+```js
+const DEFAULT_FIELDS = [
+  "key",
+  "summary",
+  "status",
+  "assignee",
+  "reporter",
+  "priority",
+  "issuetype",
+  "created",
+  "updated",
+  "resolutiondate",
+  "project",
+  "parent",
+  "fixVersions",
+  "labels",
+];
+
+const JIRA_RESOURCES = {
+  issues: { label: "Issues", endpoint: "/rest/api/3/search", fields: DEFAULT_FIELDS },
+  boards: { label: "Boards", endpoint: "/rest/agile/1.0/board" },
+  sprints: { label: "Sprints", endpoint: "/rest/agile/1.0/board/{boardId}/sprint" },
+  sprint_issues: { label: "Sprint issues", endpoint: "/rest/agile/1.0/sprint/{sprintId}/issue", fields: DEFAULT_FIELDS },
+  versions: { label: "Versions", endpoint: "/rest/api/3/project/{projectIdOrKey}/versions" },
+  fields: { label: "Fields", endpoint: "/rest/api/3/field" },
+  users: { label: "Users", endpoint: "/rest/api/3/user/search" },
+};
+
+const FIELD_MAPPING_NAMES = {
+  storyPoints: ["story points", "story point estimate", "estimate"],
+  severity: ["severity"],
+  team: ["team"],
+};
+
+module.exports = {
+  DEFAULT_FIELDS,
+  FIELD_MAPPING_NAMES,
+  JIRA_RESOURCES,
+};
+```
+
+- [ ] **Step 4: Add minimal protocol**
+
+Create `server/sources/plugins/jira/jira.protocol.js`:
+
+```js
+const { JIRA_RESOURCES, DEFAULT_FIELDS } = require("./jira.resources");
+
+const DEFAULT_CONFIGURATION = {
+  source: "jira",
+  resource: "issues",
+  mode: "visual",
+  jql: "created >= {{start_date}} AND created <= {{end_date}} ORDER BY updated DESC",
+  fields: DEFAULT_FIELDS,
+  transform: { type: "raw" },
+  pagination: { startAt: 0, maxResults: 100, maxRecords: 5000 },
+};
+
+function getDefaultDataRequest() {
+  return {
+    method: "GET",
+    route: null,
+    headers: {},
+    body: null,
+    conditions: null,
+    configuration: { ...DEFAULT_CONFIGURATION },
+    query: null,
+    pagination: true,
+    items: "issues",
+    itemsLimit: 5000,
+    offset: "startAt",
+    paginationField: null,
+    template: "jira",
+    useGlobalHeaders: true,
+  };
+}
+
+function validateConfiguration(configuration = {}) {
+  const config = {
+    ...DEFAULT_CONFIGURATION,
+    ...configuration,
+    pagination: {
+      ...DEFAULT_CONFIGURATION.pagination,
+      ...(configuration.pagination || {}),
+    },
+  };
+  const errors = [];
+
+  if (config.source !== "jira") errors.push("configuration.source must be jira");
+  if (!JIRA_RESOURCES[config.resource]) errors.push(`Unsupported Jira resource: ${config.resource || "missing"}`);
+  if (!["visual", "jql", "advanced"].includes(config.mode)) errors.push("mode must be visual, jql, or advanced");
+  if (config.resource === "issues" && !String(config.jql || "").trim()) errors.push("jql is required for issue searches");
+  if (Number(config.pagination.maxResults) > 100) errors.push("pagination.maxResults cannot exceed 100");
+  if (Number(config.pagination.maxRecords) > 10000) errors.push("pagination.maxRecords cannot exceed 10000");
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings: [],
+    configuration: config,
+  };
+}
+
+function assertValidConfiguration(configuration) {
+  const validation = validateConfiguration(configuration);
+  if (!validation.valid) throw new Error(validation.errors.join(" "));
+  return validation.configuration;
+}
+
+function getBuilderMetadata() {
+  return Promise.resolve({
+    source: "jira",
+    resources: JIRA_RESOURCES,
+    defaults: DEFAULT_CONFIGURATION,
+  });
+}
+
+async function testConnection({ connection }) {
+  const jiraConnection = require("./jira.connection"); // eslint-disable-line global-require
+  const myself = await jiraConnection.getMyself(connection);
+  return { success: true, metadata: myself };
+}
+
+function testUnsavedConnection({ connection }) {
+  return testConnection({ connection });
+}
+
+async function runDataRequest() {
+  throw new Error("Jira runtime is not implemented yet");
+}
+
+module.exports = {
+  assertValidConfiguration,
+  getBuilderMetadata,
+  getDefaultDataRequest,
+  runDataRequest,
+  testConnection,
+  testUnsavedConnection,
+  validateConfiguration,
+};
+```
+
+- [ ] **Step 5: Add minimal connection helper**
+
+Create `server/sources/plugins/jira/jira.connection.js`:
+
+```js
+const request = require("request-promise");
+
+function normalizeSiteUrl(siteUrl = "") {
+  const trimmed = String(siteUrl).trim().replace(/\/+$/, "");
+  if (!/^https:\/\/[^/]+\.atlassian\.net$/i.test(trimmed)) {
+    throw new Error("Enter a Jira Cloud site URL like https://example.atlassian.net");
+  }
+  return trimmed;
+}
+
+function toPlainObject(value) {
+  if (!value) return {};
+  if (typeof value.toJSON === "function") return value.toJSON();
+  return { ...value };
+}
+
+function getCredentials(connection) {
+  const plain = toPlainObject(connection);
+  const siteUrl = normalizeSiteUrl(plain.host || plain.options?.jira?.siteUrl || plain.authentication?.siteUrl);
+  const email = plain.authentication?.email || plain.authentication?.user || plain.username || "";
+  const apiToken = plain.authentication?.apiToken || plain.authentication?.token || plain.password || "";
+  if (!email) throw new Error("Enter your Jira account email");
+  if (!apiToken) throw new Error("Enter your Jira API token");
+  return { siteUrl, email, apiToken };
+}
+
+function jiraRequest(connection, route, options = {}) {
+  const { siteUrl, email, apiToken } = getCredentials(connection);
+  return request({
+    method: options.method || "GET",
+    uri: `${siteUrl}${route}`,
+    auth: { user: email, pass: apiToken },
+    qs: options.qs || undefined,
+    body: options.body || undefined,
+    json: true,
+    resolveWithFullResponse: false,
+  });
+}
+
+function getMyself(connection) {
+  return jiraRequest(connection, "/rest/api/3/myself");
+}
+
+module.exports = {
+  getCredentials,
+  getMyself,
+  jiraRequest,
+  normalizeSiteUrl,
+};
+```
+
+- [ ] **Step 6: Add plugin and registry entry**
+
+Create `server/sources/plugins/jira/jira.plugin.js`:
+
+```js
+const path = require("path");
+const jiraProtocol = require("./jira.protocol");
+
+module.exports = {
+  id: "jira",
+  type: "jira",
+  subType: "jira",
+  name: "Jira",
+  category: "productivity",
+  description: "Connect to Jira Cloud projects, issues, boards, and sprints.",
+  capabilities: {
+    connection: {
+      supportsTest: true,
+      supportsOAuth: false,
+      supportsFiles: false,
+      authModes: ["api_token"],
+    },
+    data: {
+      supportsQuery: false,
+      supportsSchema: true,
+      supportsResourcePicker: true,
+      supportsPagination: true,
+      supportsVariables: true,
+      supportsJoins: true,
+    },
+    templates: {
+      datasets: true,
+      charts: true,
+      dashboards: false,
+    },
+    ai: {
+      canGenerateDatasets: true,
+      canGenerateQueries: false,
+      hasSourceInstructions: true,
+      hasTools: true,
+    },
+  },
+  backend: jiraProtocol,
+  templates: {
+    directory: path.join(__dirname, "templates"),
+    chartTemplates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+    defaults: {
+      dataRequest: jiraProtocol.getDefaultDataRequest(),
+    },
+  },
+};
+```
+
+Modify `server/sources/index.js`:
+
+```js
+const jira = require("./plugins/jira/jira.plugin");
+```
+
+Add `jira` to the `sources` array near the other custom sources.
+
+- [ ] **Step 7: Run registry tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceRegistry.test.js tests/unit/sourcePluginStructure.test.js
+```
+
+Expected: PASS for Jira registry and structure assertions.
+
+- [ ] **Step 8: Commit backend skeleton**
+
+```bash
+git add server/sources/index.js server/sources/plugins/jira server/tests/unit/sourceRegistry.test.js server/tests/unit/sourcePluginStructure.test.js
+git commit -m "feat: add jira source plugin skeleton"
+```
+
+---
+
+## Task 2: Jira Connection Actions And Metadata
+
+**Files:**
+- Modify: `server/sources/plugins/jira/jira.connection.js`
+- Modify: `server/sources/plugins/jira/jira.protocol.js`
+- Test: `server/tests/unit/jiraProtocol.test.js`
+- Modify: `server/tests/integration/connectionRoute.security.test.js`
+
+- [ ] **Step 1: Write action tests**
+
+Create `server/tests/unit/jiraProtocol.test.js` with tests that stub `jira.connection.jiraRequest` and verify:
+
+```js
+expect(await actions.listProjects({ connection })).toEqual([{ id: "10000", key: "CHART", name: "Chartbrew" }]);
+expect(await actions.listBoards({ connection, params: { projectKeyOrId: "CHART" } })).toEqual([{ id: 12, name: "CHART board", type: "scrum" }]);
+expect(await actions.detectFieldMappings({ connection })).toEqual({
+  fieldMappings: { storyPoints: "customfield_10016" },
+  candidates: expect.any(Object),
+});
+```
+
+Add integration assertions that an unknown Jira action returns `400` and allowed actions require a team-scoped connection, matching existing source action security patterns.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraProtocol.test.js tests/integration/connectionRoute.security.test.js
+```
+
+Expected: FAIL because Jira actions are not implemented.
+
+- [ ] **Step 3: Add metadata helpers**
+
+Add to `jira.connection.js`:
+
+```js
+function listProjects(connection) {
+  return jiraRequest(connection, "/rest/api/3/project/search", { qs: { maxResults: 50 } })
+    .then((response) => (response.values || []).map((project) => ({
+      id: project.id,
+      key: project.key,
+      name: project.name,
+      projectTypeKey: project.projectTypeKey,
+    })));
+}
+
+function listBoards(connection, params = {}) {
+  return jiraRequest(connection, "/rest/agile/1.0/board", {
+    qs: {
+      maxResults: 50,
+      projectKeyOrId: params.projectKeyOrId || undefined,
+      type: params.type || undefined,
+    },
+  }).then((response) => (response.values || []).map((board) => ({
+    id: board.id,
+    name: board.name,
+    type: board.type,
+  })));
+}
+
+function listFields(connection) {
+  return jiraRequest(connection, "/rest/api/3/field")
+    .then((fields) => (fields || []).map((field) => ({
+      id: field.id,
+      key: field.key,
+      name: field.name,
+      custom: field.custom,
+      schema: field.schema || {},
+    })));
+}
+```
+
+- [ ] **Step 4: Add field mapping detection**
+
+Add to `jira.connection.js`:
+
+```js
+const { FIELD_MAPPING_NAMES } = require("./jira.resources");
+
+function normalizeFieldName(name = "") {
+  return String(name).trim().toLowerCase();
+}
+
+function detectFieldMappingsFromFields(fields = []) {
+  const candidates = {};
+  const fieldMappings = {};
+
+  Object.entries(FIELD_MAPPING_NAMES).forEach(([semanticName, names]) => {
+    const matches = fields.filter((field) => {
+      const fieldName = normalizeFieldName(field.name);
+      return names.some((name) => fieldName.includes(name));
+    });
+    candidates[semanticName] = matches.map((field) => ({
+      id: field.id,
+      name: field.name,
+      schema: field.schema,
+    }));
+    if (matches[0]) fieldMappings[semanticName] = matches[0].id;
+  });
+
+  return { fieldMappings, candidates };
+}
+
+async function detectFieldMappings(connection) {
+  const fields = await listFields(connection);
+  return detectFieldMappingsFromFields(fields);
+}
+```
+
+Export the new helpers.
+
+- [ ] **Step 5: Add source actions**
+
+Add to `jira.protocol.js`:
+
+```js
+const jiraConnection = require("./jira.connection");
+
+const actions = {
+  listProjects({ connection }) {
+    return jiraConnection.listProjects(connection);
+  },
+  listBoards({ connection, params }) {
+    return jiraConnection.listBoards(connection, params);
+  },
+  listFields({ connection }) {
+    return jiraConnection.listFields(connection);
+  },
+  detectFieldMappings({ connection }) {
+    return jiraConnection.detectFieldMappings(connection);
+  },
+};
+
+module.exports = {
+  actions,
+  assertValidConfiguration,
+  getBuilderMetadata,
+  getDefaultDataRequest,
+  runDataRequest,
+  testConnection,
+  testUnsavedConnection,
+  validateConfiguration,
+};
+```
+
+- [ ] **Step 6: Add remaining actions**
+
+Implement `listIssueTypes`, `listStatuses`, `listUsers`, `listSprints`, `listVersions`, `validateJql`, and `previewJql` using these Jira Cloud routes:
+
+```txt
+GET /rest/api/3/issuetype
+GET /rest/api/3/status
+GET /rest/api/3/user/search?query=
+GET /rest/agile/1.0/board/{boardId}/sprint
+GET /rest/api/3/project/{projectIdOrKey}/versions
+POST /rest/api/3/jql/parse?validation=strict
+GET /rest/api/3/search
+```
+
+Normalize every action response to compact arrays of identifiers and labels.
+
+- [ ] **Step 7: Run action tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraProtocol.test.js tests/integration/connectionRoute.security.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit connection actions**
+
+```bash
+git add server/sources/plugins/jira server/tests/unit/jiraProtocol.test.js server/tests/integration/connectionRoute.security.test.js
+git commit -m "feat: add jira source actions"
+```
+
+---
+
+## Task 3: Jira Runtime, Variables, Normalization, And Caching
+
+**Files:**
+- Modify: `server/sources/plugins/jira/jira.protocol.js`
+- Modify: `server/sources/plugins/jira/jira.resources.js`
+- Test: `server/tests/unit/jiraProtocol.test.js`
+
+- [ ] **Step 1: Add failing runtime tests**
+
+Add tests for:
+
+```js
+validateConfiguration({ source: "jira", resource: "unknown" }).valid === false
+applyVariables replaces {{projects}}, {{start_date}}, and {{end_date}} in configuration.jql
+normalizeIssue maps fields.status.statusCategory.name to statusCategory
+aggregateRows groups by status and sums storyPoints
+runDataRequest caches responseData.data
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraProtocol.test.js
+```
+
+Expected: FAIL on missing runtime helpers.
+
+- [ ] **Step 3: Implement variable application**
+
+Use `processVariablesInString` from `server/sources/shared/variables/stringVariables.js` and recursively process Jira configuration values:
+
+```js
+function processConfigValue(value, dataRequest, variables) {
+  if (typeof value === "string") {
+    return processVariablesInString({ value, dataRequest, variables });
+  }
+  if (Array.isArray(value)) return value.map((item) => processConfigValue(item, dataRequest, variables));
+  if (value && typeof value === "object") {
+    return Object.keys(value).reduce((next, key) => ({
+      ...next,
+      [key]: processConfigValue(value[key], dataRequest, variables),
+    }), {});
+  }
+  return value;
+}
+
+function applyVariables({ dataRequest, variables }) {
+  const processedConfiguration = processConfigValue(dataRequest.configuration || {}, dataRequest, variables);
+  return {
+    dataRequest,
+    processedDataRequest: {
+      ...dataRequest,
+      configuration: processedConfiguration,
+      Connection: dataRequest.Connection,
+      VariableBindings: dataRequest.VariableBindings,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Implement normalization**
+
+Add:
+
+```js
+function normalizeIssue(issue, fieldMappings = {}) {
+  const fields = issue.fields || {};
+  return {
+    key: issue.key,
+    summary: fields.summary || "",
+    projectKey: fields.project?.key || null,
+    issueType: fields.issuetype?.name || null,
+    status: fields.status?.name || null,
+    statusCategory: fields.status?.statusCategory?.name || null,
+    assignee: fields.assignee?.displayName || null,
+    reporter: fields.reporter?.displayName || null,
+    priority: fields.priority?.name || null,
+    createdAt: fields.created || null,
+    updatedAt: fields.updated || null,
+    resolvedAt: fields.resolutiondate || null,
+    storyPoints: Number(fields[fieldMappings.storyPoints] || 0),
+    severity: fieldMappings.severity ? fields[fieldMappings.severity]?.value || fields[fieldMappings.severity] || null : null,
+    team: fieldMappings.team ? fields[fieldMappings.team]?.value || fields[fieldMappings.team] || null : null,
+    labels: fields.labels || [],
+    fixVersions: (fields.fixVersions || []).map((version) => version.name),
+    epicKey: fields.parent?.key || fields.customfield_epic || null,
+  };
+}
+```
+
+- [ ] **Step 5: Implement transforms**
+
+Support transform types:
+
+```txt
+raw
+grouped
+created_resolved_trend
+sprint_summary
+stale_table
+```
+
+The grouped transform should return:
+
+```js
+{ [groupBy]: label, issueCount, storyPoints }
+```
+
+The trend transform should return:
+
+```js
+{ period, created, resolved, open }
+```
+
+- [ ] **Step 6: Implement Jira fetch and pagination**
+
+For issue searches, call:
+
+```txt
+GET /rest/api/3/search
+```
+
+with `jql`, `fields`, `startAt`, and `maxResults`.
+
+For sprint issues, call:
+
+```txt
+GET /rest/agile/1.0/sprint/{sprintId}/issue
+```
+
+with the same pagination pattern. Stop when Jira returns fewer rows than `maxResults`, when `isLast` is true, or when `maxRecords` is reached.
+
+- [ ] **Step 7: Implement runDataRequest**
+
+Follow the Stripe Official runtime pattern:
+
+```js
+if (getCache) {
+  const drCache = await checkAndGetCache(connection.id, dataRequest);
+  if (drCache) return drCache;
+}
+const rows = await fetchJiraRows(savedConnection, config);
+const transformedRows = transformRows(rows, config, savedConnection.options?.jira?.fieldMappings || {});
+const dataToCache = { dataRequest, responseData: { data: transformedRows }, connection_id: savedConnection.id };
+await drCacheController.create(dataRequest.id, dataToCache);
+return dataToCache;
+```
+
+Include connector audit success/failure with `serializeResponsePreview`.
+
+- [ ] **Step 8: Run runtime tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraProtocol.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit runtime**
+
+```bash
+git add server/sources/plugins/jira server/tests/unit/jiraProtocol.test.js
+git commit -m "feat: add jira runtime"
+```
+
+---
+
+## Task 4: Jira Templates
+
+**Files:**
+- Create: `server/sources/plugins/jira/templates/project-overview.json`
+- Create: `server/sources/plugins/jira/templates/sprint-health.json`
+- Create: `server/sources/plugins/jira/templates/bug-tracking.json`
+- Create: `server/sources/plugins/jira/templates/team-workload.json`
+- Create: `server/tests/unit/jiraTemplates.test.js`
+
+- [ ] **Step 1: Write template validation tests**
+
+Use `loadTemplate("jira", slug)` and assert each Jira template loads, includes datasets, includes charts, and every chart references existing datasets.
+
+Add a focused test that a template dataset can include:
+
+```js
+variableBindings: [{
+  name: "start_date",
+  type: "date",
+  default_value: "last_30_days",
+  required: false,
+}]
+```
+
+and that `ChartTemplateController.createFromTemplate(...)` passes this through to `DatasetController.createWithDataRequests(...)`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraTemplates.test.js
+```
+
+Expected: FAIL because template files do not exist.
+
+- [ ] **Step 3: Add project overview template**
+
+Create `project-overview.json` with:
+
+```json
+{
+  "id": "jira-project-overview",
+  "slug": "project-overview",
+  "version": 1,
+  "source": "jira",
+  "name": "Jira Project Overview",
+  "description": "Project-level Jira KPIs, issue trends, status breakdowns, and recent completed work.",
+  "requiredConnection": { "type": "jira", "subType": "jira" },
+  "datasets": [
+    {
+      "id": "issues_created_resolved",
+      "name": "Jira issues created vs resolved",
+      "fieldsSchema": {
+        "root[].period": "date",
+        "root[].created": "number",
+        "root[].resolved": "number",
+        "root[].open": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND created >= {{start_date}} AND created <= {{end_date}} ORDER BY created ASC",
+          "transform": { "type": "created_resolved_trend", "interval": "day" },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true },
+          { "name": "start_date", "type": "date", "default_value": "last_30_days", "required": false },
+          { "name": "end_date", "type": "date", "default_value": "today", "required": false }
+        ]
+      }
+    }
+  ],
+  "charts": [
+    {
+      "id": "created-vs-resolved",
+      "name": "Issues created vs resolved",
+      "type": "line",
+      "requiredDatasetIds": ["issues_created_resolved"],
+      "layoutIntent": { "kind": "trend", "priority": 10 },
+      "cdcs": [
+        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].created", "legend": "Created" },
+        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].resolved", "legend": "Resolved" }
+      ]
+    }
+  ]
+}
+```
+
+Then expand the file with the remaining project overview datasets/charts from the spec.
+
+- [ ] **Step 4: Add remaining templates**
+
+Create the other three templates using the same structure:
+
+- `sprint-health.json`: sprint completion KPI, story points completed KPI, carryover issues table, work by assignee, sprint status breakdown.
+- `bug-tracking.json`: open bugs KPI, bugs by priority, oldest open bugs table, bug trend.
+- `team-workload.json`: open issues by assignee, WIP by assignee, stale issues table.
+
+- [ ] **Step 5: Run template tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraTemplates.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit templates**
+
+```bash
+git add server/sources/plugins/jira/templates server/tests/unit/jiraTemplates.test.js
+git commit -m "feat: add jira chart templates"
+```
+
+---
+
+## Task 5: Frontend Source Registration And Connection Form
+
+**Files:**
+- Create: `client/src/sources/jira/jira.source.js`
+- Create: `client/src/sources/jira/jira-connection-form.jsx`
+- Create: `client/src/sources/jira/assets/jira.svg`
+- Modify: `client/src/sources/definitions.js`
+- Modify: `client/src/sources/index.js`
+
+- [ ] **Step 1: Add frontend source metadata**
+
+Create `jira.source.js`:
+
+```js
+import jiraLogo from "./assets/jira.svg";
+
+const DEFAULT_CONFIGURATION = {
+  source: "jira",
+  resource: "issues",
+  mode: "visual",
+  jql: "created >= {{start_date}} AND created <= {{end_date}} ORDER BY updated DESC",
+  fields: ["key", "summary", "status", "assignee", "priority", "issuetype", "created", "updated", "resolutiondate", "project"],
+  transform: { type: "raw" },
+  pagination: { startAt: 0, maxResults: 100, maxRecords: 5000 },
+};
+
+const jiraSource = {
+  id: "jira",
+  type: "jira",
+  subType: "jira",
+  name: "Jira",
+  category: "productivity",
+  capabilities: {
+    ai: { canGenerateQueries: false, hasSourceInstructions: true, hasTools: true, canGenerateDatasets: true },
+    templates: { charts: true, datasets: true },
+    nextSteps: { chartTemplates: true, datasetTemplates: true },
+  },
+  assets: {
+    lightLogo: jiraLogo,
+    darkLogo: jiraLogo,
+  },
+  defaults: {
+    dataRequest: {
+      method: "GET",
+      pagination: true,
+      items: "issues",
+      itemsLimit: 5000,
+      offset: "startAt",
+      paginationField: null,
+      template: "jira",
+      useGlobalHeaders: true,
+      configuration: DEFAULT_CONFIGURATION,
+    },
+  },
+  templates: {
+    chartTemplates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+  },
+};
+
+export { DEFAULT_CONFIGURATION };
+export default jiraSource;
+```
+
+- [ ] **Step 2: Register source**
+
+Modify `client/src/sources/definitions.js` to import `jiraSource` and include it in `SOURCE_DEFINITIONS`.
+
+Modify `client/src/sources/index.js` to import Jira frontend components and register:
+
+```js
+jira: {
+  ConnectionForm: JiraConnectionForm,
+  DataRequestBuilder: JiraBuilder,
+  ChartTemplateSetup: JiraTemplateSetup,
+}
+```
+
+- [ ] **Step 3: Implement connection form**
+
+Create `jira-connection-form.jsx` using existing source form patterns. It should collect:
+
+```txt
+name
+host
+authentication.email
+authentication.apiToken
+```
+
+The submitted connection data should include:
+
+```js
+{
+  type: "jira",
+  subType: "jira",
+  host,
+  authentication: {
+    type: "api_token",
+    email,
+    apiToken,
+  },
+}
+```
+
+- [ ] **Step 4: Run frontend build check**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit frontend registration**
+
+```bash
+git add client/src/sources/definitions.js client/src/sources/index.js client/src/sources/jira
+git commit -m "feat: add jira frontend source"
+```
+
+---
+
+## Task 6: Jira Builder UI
+
+**Files:**
+- Create: `client/src/sources/jira/jira-builder.jsx`
+- Create: `client/src/sources/jira/jira-builder.constants.jsx`
+- Create: `client/src/sources/jira/jira-builder.utils.js`
+- Create: `client/src/sources/jira/components/jira-builder-context.jsx`
+- Create: `client/src/sources/jira/components/jira-resource-step.jsx`
+- Create: `client/src/sources/jira/components/jira-config-step.jsx`
+- Create: `client/src/sources/jira/components/jira-preview-step.jsx`
+- Create: `client/src/sources/jira/components/jira-summary-sidebar.jsx`
+
+- [ ] **Step 1: Mirror Stripe Official builder structure**
+
+Use `client/src/sources/stripeOfficial/stripeOfficial-builder.jsx` as the layout reference. Jira builder should have:
+
+```txt
+resource/category step
+configuration step
+preview step
+summary sidebar
+advanced/config preview toggle
+variable drawer where supported
+DataTransform support
+```
+
+- [ ] **Step 2: Add constants**
+
+Create resource options:
+
+```js
+export const RESOURCE_OPTIONS = [
+  { id: "issues", label: "Issues" },
+  { id: "sprint_issues", label: "Sprint issues" },
+  { id: "boards", label: "Boards" },
+  { id: "sprints", label: "Sprints" },
+  { id: "versions", label: "Versions" },
+];
+
+export const GROUP_BY_OPTIONS = [
+  { value: "status", label: "Status" },
+  { value: "statusCategory", label: "Status category" },
+  { value: "assignee", label: "Assignee" },
+  { value: "priority", label: "Priority" },
+  { value: "issueType", label: "Issue type" },
+  { value: "projectKey", label: "Project" },
+];
+
+export const METRIC_OPTIONS = [
+  { value: "count", label: "Count issues" },
+  { value: "storyPoints", label: "Sum story points" },
+  { value: "averageAge", label: "Average age" },
+  { value: "leadTime", label: "Lead time" },
+];
+```
+
+- [ ] **Step 3: Add config utilities**
+
+Implement:
+
+```js
+import { DEFAULT_CONFIGURATION } from "./jira.source";
+
+export function mergeConfiguration(dataRequest) {
+  return {
+    ...DEFAULT_CONFIGURATION,
+    ...(dataRequest?.configuration || {}),
+    transform: {
+      ...DEFAULT_CONFIGURATION.transform,
+      ...(dataRequest?.configuration?.transform || {}),
+    },
+    pagination: {
+      ...DEFAULT_CONFIGURATION.pagination,
+      ...(dataRequest?.configuration?.pagination || {}),
+    },
+  };
+}
+
+function quoteJqlValue(value) {
+  if (value === undefined || value === null || value === "") return null;
+  return `"${String(value).replace(/"/g, "\\\"")}"`;
+}
+
+export function buildJqlFromVisualConfig(configuration) {
+  const clauses = [];
+  if (configuration.projects) clauses.push(`project IN (${configuration.projects})`);
+  if (configuration.issueType) clauses.push(`issuetype = ${quoteJqlValue(configuration.issueType)}`);
+  if (configuration.statusCategory) clauses.push(`statusCategory = ${quoteJqlValue(configuration.statusCategory)}`);
+  if (configuration.assignee) clauses.push(`assignee = ${quoteJqlValue(configuration.assignee)}`);
+  if (configuration.priority) clauses.push(`priority = ${quoteJqlValue(configuration.priority)}`);
+  if (configuration.fixVersion) clauses.push(`fixVersion = ${quoteJqlValue(configuration.fixVersion)}`);
+  if (configuration.dateRange?.start) clauses.push(`${configuration.dateRange.field || "created"} >= ${configuration.dateRange.start}`);
+  if (configuration.dateRange?.end) clauses.push(`${configuration.dateRange.field || "created"} <= ${configuration.dateRange.end}`);
+  return `${clauses.filter(Boolean).join(" AND ") || "ORDER BY updated DESC"}`;
+}
+
+export function getPreviewRows(payload) {
+  if (Array.isArray(payload?.data)) return payload.data;
+  if (Array.isArray(payload?.response?.data)) return payload.response.data;
+  if (Array.isArray(payload?.response?.dataRequest?.responseData?.data)) return payload.response.dataRequest.responseData.data;
+  return [];
+}
+
+export function getPreviewColumns(payload) {
+  const firstRow = getPreviewRows(payload)[0];
+  return firstRow ? Object.keys(firstRow) : [];
+}
+
+export function getSuggestedCharts(configuration) {
+  if (configuration.transform?.type === "grouped") {
+    return ["bar", "doughnut", "table"];
+  }
+  if (configuration.transform?.type === "created_resolved_trend") {
+    return ["line", "bar"];
+  }
+  if (configuration.transform?.type === "sprint_summary") {
+    return ["kpi", "bar", "table"];
+  }
+  return ["table"];
+}
+```
+
+- [ ] **Step 4: Implement source actions in UI**
+
+Use `runSourceAction` for:
+
+```txt
+listProjects
+listBoards
+listSprints
+listFields
+detectFieldMappings
+validateJql
+previewJql
+```
+
+Cache action results inside builder state to avoid repeated metadata calls.
+
+- [ ] **Step 5: Implement preview and save flow**
+
+Follow the Stripe Official pattern:
+
+```txt
+on configuration change -> update DataRequest with template: "jira"
+Preview -> save request if needed -> dispatch runDataRequest
+Save -> onSave(jiraRequest)
+Delete -> onDelete
+Transform -> DataTransform save
+```
+
+- [ ] **Step 6: Run client build**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit builder**
+
+```bash
+git add client/src/sources/jira
+git commit -m "feat: add jira dataset builder"
+```
+
+---
+
+## Task 7: Jira Template Setup UI
+
+**Files:**
+- Create: `client/src/sources/jira/jira-template-setup.jsx`
+- Modify: `client/src/sources/jira/jira-builder.utils.js`
+
+- [ ] **Step 1: Implement bundle picker**
+
+Use Stripe Official template setup as the reference. Jira setup should let users choose:
+
+```txt
+Project overview
+Sprint health
+Bug tracking
+Team workload
+```
+
+It should require a connection and target dashboard options.
+
+- [ ] **Step 2: Add Jira setup fields**
+
+Before creating templates, collect or infer:
+
+```txt
+project keys
+board id, when sprint-health is selected
+sprint id or active sprint, when sprint-health is selected
+story points field mapping, when story-point charts are selected
+```
+
+Use source actions to load projects, boards, sprints, and field mappings.
+
+- [ ] **Step 3: Call chart template APIs**
+
+Use the existing built-in chart-template client flow used by Stripe Official. Send:
+
+```js
+{
+  connection_id,
+  dataset_template_ids,
+  chart_template_ids,
+  dashboard: { type: "existing", project_id }
+}
+```
+
+or:
+
+```js
+{
+  connection_id,
+  dashboard: { type: "new", name: "Jira Project Overview" }
+}
+```
+
+- [ ] **Step 4: Run client build**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit template setup**
+
+```bash
+git add client/src/sources/jira/jira-template-setup.jsx client/src/sources/jira/jira-builder.utils.js
+git commit -m "feat: add jira template setup"
+```
+
+---
+
+## Task 8: Jira Source-Owned AI Planner
+
+**Files:**
+- Create: `server/sources/plugins/jira/ai/jira.ai.js`
+- Modify: `server/sources/plugins/jira/jira.plugin.js`
+- Modify: `server/tests/unit/sourceAiHarness.test.js`
+
+- [ ] **Step 1: Add failing harness tests**
+
+Add Jira cases for:
+
+```txt
+open bugs by priority -> ok, issues grouped by priority, bar chart
+stale issues -> ok, issues table
+completed story points for active sprint -> needs_more_context when board/sprint missing
+sprint health dashboard -> recommends sprint-health template
+invalid field -> unsupported or error without raw Jira docs
+```
+
+Assert Jira does not expose `generateQuery`.
+
+- [ ] **Step 2: Run harness to verify failure**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js
+```
+
+Expected: FAIL because Jira AI is not implemented.
+
+- [ ] **Step 3: Implement capabilities and resources**
+
+Create `jira.ai.js`:
+
+```js
+const jiraProtocol = require("../jira.protocol");
+const { JIRA_RESOURCES } = require("../jira.resources");
+
+const SOURCE_ID = "jira";
+
+const SOURCE_INSTRUCTIONS = [
+  "Jira is configuration-based. Return DataRequest.configuration objects; do not invent Jira REST routes.",
+  "Use issues for issue search and sprint_issues for sprint issue analytics.",
+  "Ask for project, board, sprint, or field mapping context when required and missing.",
+  "Do not create burndown or transition-history charts in v1.",
+].join("\n");
+
+function getCapabilities() {
+  return {
+    source: SOURCE_ID,
+    instructions: SOURCE_INSTRUCTIONS,
+    supports: {
+      modes: ["visual", "jql", "advanced"],
+      resources: Object.keys(JIRA_RESOURCES),
+      variables: true,
+      templates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+    },
+  };
+}
+
+function listResources() {
+  return {
+    source: SOURCE_ID,
+    resources: Object.entries(JIRA_RESOURCES).map(([id, resource]) => ({
+      id,
+      label: resource.label,
+    })),
+  };
+}
+```
+
+- [ ] **Step 4: Implement planner**
+
+Add deterministic planning rules for the v1 supported questions:
+
+```js
+function planDataset({ question = "", overrides = {} }) {
+  const normalized = question.toLowerCase();
+  if (/sprint health/.test(normalized)) {
+    return recommendTemplates({ question });
+  }
+  if (/bug/.test(normalized) && /priority/.test(normalized)) {
+    return {
+      status: "ok",
+      dataRequest: {
+        template: "jira",
+        configuration: {
+          source: "jira",
+          resource: "issues",
+          mode: "visual",
+          jql: "project IN ({{projects}}) AND issuetype = Bug AND created >= {{start_date}} AND created <= {{end_date}}",
+          transform: { type: "grouped", metric: "count", groupBy: "priority" },
+          pagination: { startAt: 0, maxResults: 100, maxRecords: 5000 },
+        },
+      },
+      chartSpec: { type: "bar", xAxis: "root[].priority", yAxis: "root[].issueCount" },
+    };
+  }
+  return {
+    status: "needs_more_context",
+    message: "Choose a Jira project or template goal first.",
+    requiredContext: ["projects"],
+  };
+}
+```
+
+Expand rules for stale issues, sprint story points, and template recommendations.
+
+- [ ] **Step 5: Implement validation and preview wrappers**
+
+Use:
+
+```js
+function validateConfiguration(configuration) {
+  return jiraProtocol.validateConfiguration(configuration);
+}
+
+function previewConfiguration({ connection, configuration, rowLimit = 10 }) {
+  return jiraProtocol.previewDataRequest({
+    connection,
+    dataRequest: {
+      ...jiraProtocol.getDefaultDataRequest(),
+      configuration: {
+        ...configuration,
+        pagination: {
+          ...(configuration.pagination || {}),
+          maxRecords: rowLimit,
+        },
+      },
+    },
+    itemsLimit: rowLimit,
+  });
+}
+```
+
+- [ ] **Step 6: Wire AI module**
+
+Modify `jira.plugin.js`:
+
+```js
+const jiraAi = require("./ai/jira.ai");
+
+backend: {
+  ...jiraProtocol,
+  ai: jiraAi,
+},
+```
+
+- [ ] **Step 7: Run harness**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Jira AI**
+
+```bash
+git add server/sources/plugins/jira/ai server/sources/plugins/jira/jira.plugin.js server/tests/unit/sourceAiHarness.test.js
+git commit -m "feat: add jira source ai planner"
+```
+
+---
+
+## Task 9: Generic AI Dashboard Template Tool
+
+**Files:**
+- Create: `server/modules/ai/orchestrator/tools/createDashboardFromTemplate.js`
+- Modify: `server/modules/ai/orchestrator/tools/index.js`
+- Modify: `server/modules/ai/orchestrator/orchestrator.js`
+- Modify: `server/tests/unit/sourceAiHarness.test.js`
+
+- [ ] **Step 1: Add failing tool tests**
+
+Add tests that the tool:
+
+```txt
+accepts source, template_slug, connection_id, and dashboard options
+rejects unsupported source/template combinations
+calls ChartTemplateController.createFromTemplate
+is generic and not Jira-specific
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js
+```
+
+Expected: FAIL because the tool is missing.
+
+- [ ] **Step 3: Implement tool**
+
+Create `createDashboardFromTemplate.js`:
+
+```js
+const ChartTemplateController = require("../../../controllers/ChartTemplateController");
+
+async function createDashboardFromTemplate(payload) {
+  const {
+    team_id: teamId,
+    source,
+    template_slug: templateSlug,
+    connection_id: connectionId,
+    dashboard,
+    dataset_template_ids: datasetTemplateIds,
+    chart_template_ids: chartTemplateIds,
+    user,
+  } = payload;
+
+  if (!teamId) throw new Error("team_id is required");
+  if (!source) throw new Error("source is required");
+  if (!templateSlug) throw new Error("template_slug is required");
+  if (!connectionId) throw new Error("connection_id is required");
+
+  const controller = new ChartTemplateController();
+  return controller.createFromTemplate(teamId, source, templateSlug, {
+    connection_id: connectionId,
+    dashboard,
+    dataset_template_ids: datasetTemplateIds,
+    chart_template_ids: chartTemplateIds,
+  }, user);
+}
+
+module.exports = createDashboardFromTemplate;
+```
+
+- [ ] **Step 4: Register tool**
+
+Export it from `tools/index.js`, add a tool schema to `orchestrator.js`, and dispatch it in the tool switch. The schema should be source-agnostic:
+
+```js
+{
+  name: "create_dashboard_from_template",
+  displayName: "Create dashboard from template",
+  description: "Create a dashboard/project from a registered source chart template.",
+  parameters: {
+    type: "object",
+    properties: {
+      source: { type: "string" },
+      template_slug: { type: "string" },
+      connection_id: { type: "string" },
+      dashboard: { type: "object" },
+      dataset_template_ids: { type: "array", items: { type: "string" } },
+      chart_template_ids: { type: "array", items: { type: "string" } },
+    },
+    required: ["source", "template_slug", "connection_id", "dashboard"],
+  },
+}
+```
+
+- [ ] **Step 5: Run harness**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit generic dashboard-template tool**
+
+```bash
+git add server/modules/ai/orchestrator server/tests/unit/sourceAiHarness.test.js
+git commit -m "feat: add ai dashboard template tool"
+```
+
+---
+
+## Task 10: Full Verification
+
+**Files:**
+- All files from prior tasks.
+
+- [ ] **Step 1: Run focused backend tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceRegistry.test.js tests/unit/sourcePluginStructure.test.js tests/unit/jiraProtocol.test.js tests/unit/jiraTemplates.test.js tests/unit/sourceAiHarness.test.js tests/integration/connectionRoute.security.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run server build/test command available for this repo**
+
+Run:
+
+```bash
+npm run test:run -- --passWithNoTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run client build**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke check**
+
+Start the app with the repo's normal dev command and verify:
+
+```txt
+Jira appears in the connection picker.
+Jira connection form saves custom type/subType.
+Jira builder opens for Jira datasets.
+Visual/JQL/Advanced modes update DataRequest.configuration.
+Template setup lists four Jira bundles.
+AI source list includes Jira as source-owned configuration source.
+```
+
+- [ ] **Step 5: Commit verification fixes**
+
+If verification required fixes:
+
+```bash
+git add server/sources/plugins/jira client/src/sources/jira server/tests/unit/jiraProtocol.test.js server/tests/unit/jiraTemplates.test.js server/tests/unit/sourceAiHarness.test.js
+git commit -m "fix: verify jira source integration"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Jira custom identity is covered in Task 1 and Task 5.
+- Jira Cloud API-token auth is covered in Task 2 and Task 5.
+- Custom runtime, normalization, pagination, variables, and caching are covered in Task 3.
+- Separate templates are covered in Task 4.
+- Stripe Official-style frontend builder and setup UI are covered in Tasks 6 and 7.
+- Source-owned AI parity is covered in Task 8.
+- Generic dashboard-template AI side quest is covered in Task 9.
+- Verification is covered in Task 10.
+
+Known implementation risk:
+
+- The template variable binding test in Task 4 may reveal that `ChartTemplateController.createFromTemplate(...)` does not preserve `dataRequest.variableBindings`. If so, implement the smallest controller pass-through fix in Task 4 before creating Jira templates that depend on variables.

--- a/docs/specs/FS-20260514-jira-source.md
+++ b/docs/specs/FS-20260514-jira-source.md
@@ -1,0 +1,526 @@
+# Jira Source Plugin
+
+Status: draft
+
+## Goal
+
+Add Jira Cloud as a first-class Chartbrew source with custom connection setup, custom dataset builder, plugin-owned templates, normalized runtime output, and source-owned AI planning.
+
+Jira must be treated as a custom source family, not as a branded generic API source. Users should configure Jira concepts such as projects, boards, sprints, JQL, issue fields, and template bundles. They should not need to build raw REST requests unless they intentionally use an advanced Jira mode.
+
+## Source Identity
+
+Jira uses a custom source identity:
+
+```js
+{
+  id: "jira",
+  type: "jira",
+  subType: "jira",
+}
+```
+
+This follows the same custom-source pattern as Stripe Official. Jira may call HTTP APIs internally, but it must not use the generic `api` protocol or generic API builder.
+
+## Scope
+
+Included in v1:
+
+- Jira Cloud only.
+- Email, API token, and Jira site URL authentication.
+- Custom backend plugin, protocol, connection helper, resources module, templates, and AI module.
+- Custom frontend source definition, connection form, builder, and template setup UI.
+- Issues and JQL support.
+- Jira Agile API support for boards, sprints, and sprint issues.
+- Sprint summary analytics, including completion, story points completed, carryover, assignee workload, and sprint status.
+- Field mapping for story points, severity, and team fields.
+- Separate built-in template bundles for project overview, sprint health, bug tracking, and team workload.
+- Source-owned AI planner covering the same resources and configuration surface as the manual builder.
+
+Out of scope for v1:
+
+- OAuth.
+- Jira Data Center or Jira Server.
+- True sprint burndown from changelog/status transition history.
+- Deep cycle-time analytics based on transition history.
+- Writing data back to Jira.
+- Arbitrary Jira REST request building.
+- A Jira-specific dashboard creation AI tool.
+
+Side quest:
+
+- Add a generic AI orchestration tool for creating dashboards/projects from registered source chart templates. The tool should not be Jira-specific. Jira should use it when available, and existing source AI layers such as Stripe Official should be able to adopt it later.
+
+## Backend Layout
+
+Add Jira under the source plugin tree:
+
+```txt
+server/sources/plugins/jira/
+  jira.plugin.js
+  jira.protocol.js
+  jira.connection.js
+  jira.resources.js
+  ai/jira.ai.js
+  templates/
+    project-overview.json
+    sprint-health.json
+    bug-tracking.json
+    team-workload.json
+```
+
+Register the plugin in `server/sources/index.js` and follow `source-plugin-guide.md`.
+
+The plugin should expose capabilities similar to:
+
+```js
+{
+  connection: {
+    supportsTest: true,
+    supportsOAuth: false,
+    supportsFiles: false,
+    authModes: ["api_token"],
+  },
+  data: {
+    supportsQuery: false,
+    supportsSchema: true,
+    supportsResourcePicker: true,
+    supportsPagination: true,
+    supportsVariables: true,
+    supportsJoins: true,
+  },
+  templates: {
+    datasets: true,
+    charts: true,
+    dashboards: false,
+  },
+  ai: {
+    canGenerateDatasets: true,
+    canGenerateQueries: false,
+    hasSourceInstructions: true,
+    hasTools: true,
+  },
+}
+```
+
+Jira must not add helper routes. Source-specific metadata and preview operations should go through the existing source action route:
+
+```txt
+POST /team/:team_id/connections/:connection_id/source-action
+```
+
+Initial source actions:
+
+- `listProjects`
+- `listIssueTypes`
+- `listStatuses`
+- `listUsers`
+- `listBoards`
+- `listSprints`
+- `listVersions`
+- `listFields`
+- `validateJql`
+- `previewJql`
+- `detectFieldMappings`
+
+## Connection Setup
+
+Jira Cloud v1 uses these fields:
+
+```txt
+Site URL: https://example.atlassian.net
+Email
+API token
+```
+
+Connection testing should call:
+
+```txt
+GET /rest/api/3/myself
+```
+
+On save, `jira.connection.js` should normalize the site URL and best-effort load lightweight metadata. The connection should persist enough source-owned setup state to make future builder sessions fast:
+
+```js
+{
+  type: "jira",
+  subType: "jira",
+  host: "https://example.atlassian.net",
+  schema: {
+    jira: {
+      accountId: "abc123",
+      displayName: "Raz",
+      emailAddress: "raz@example.com",
+      siteUrl: "https://example.atlassian.net",
+    },
+    resources: ["issues", "boards", "sprints", "versions", "users", "fields"],
+  },
+  options: {
+    jira: {
+      siteUrl: "https://example.atlassian.net",
+      fieldMappings: {
+        storyPoints: "customfield_10016",
+        severity: "customfield_10123",
+        team: "customfield_10200",
+      },
+      defaults: {
+        projectKeys: ["CHART"],
+        boardId: 12,
+      },
+    },
+  },
+}
+```
+
+Field mapping should be part of connection setup or template setup. `detectFieldMappings` should scan `/rest/api/3/field`, choose likely matches by field name and schema, and let the user override. Story points is required for story-point charts, but not for count-based sprint charts.
+
+## DataRequest Configuration
+
+Every Jira DataRequest should store a Jira-owned `configuration` object. The protocol validates the configuration, applies variables, calls Jira Cloud, paginates, and returns normalized rows.
+
+Example issues configuration:
+
+```js
+{
+  source: "jira",
+  resource: "issues",
+  mode: "visual",
+  jql: "project IN ({{projects}}) AND created >= {{start_date}} AND created <= {{end_date}}",
+  fields: [
+    "key",
+    "summary",
+    "status",
+    "assignee",
+    "priority",
+    "issuetype",
+    "created",
+    "updated",
+    "resolutiondate",
+    "project",
+  ],
+  transform: {
+    type: "grouped",
+    metric: "count",
+    groupBy: "status",
+  },
+  pagination: {
+    startAt: 0,
+    maxResults: 100,
+    maxRecords: 5000,
+  },
+}
+```
+
+Supported v1 resources:
+
+- `issues`
+- `boards`
+- `sprints`
+- `sprint_issues`
+- `versions`
+- `fields`
+- `users`
+
+Supported v1 modes:
+
+- `visual`
+- `jql`
+- `advanced`
+
+## Runtime Behavior
+
+Jira runtime output should be normalized by default. Raw Jira payloads are too nested and instance-specific for charting.
+
+Normalized issue rows should look like:
+
+```js
+{
+  key: "CHART-123",
+  summary: "Add Jira dashboard template",
+  projectKey: "CHART",
+  issueType: "Story",
+  status: "In Progress",
+  statusCategory: "In Progress",
+  assignee: "Raz",
+  reporter: "Jane",
+  priority: "High",
+  createdAt: "2026-05-01T10:00:00.000Z",
+  updatedAt: "2026-05-03T12:00:00.000Z",
+  resolvedAt: null,
+  storyPoints: 5,
+  labels: ["dashboard", "jira"],
+  fixVersions: ["v5.2.0"],
+  epicKey: "CHART-100",
+}
+```
+
+Aggregated outputs should already be chart-friendly:
+
+```js
+{ period: "2026-05-01", created: 8, resolved: 5, open: 42 }
+{ status: "In Progress", issueCount: 14, storyPoints: 38 }
+{ assignee: "Raz", issueCount: 7, storyPoints: 21 }
+```
+
+The protocol should support:
+
+- `testConnection({ connection })`
+- `testUnsavedConnection({ connection })`
+- `prepareConnectionData({ connection })`
+- `runDataRequest({ connection, dataRequest, getCache, filters, timezone, variables, auditContext })`
+- `previewDataRequest({ connection, dataRequest, itemsLimit, items, offset, pagination, paginationField })`
+- `getBuilderMetadata({ connection, dataRequest, options })`
+- `getSchema({ connection, dataRequest })`
+- `applyVariables({ dataRequest, variables })`
+- `validateConfiguration(configuration, options)`
+- source `actions`
+
+Runtime should enforce caps for pagination and preview. Default limits should be conservative, such as 100 results per Jira page and 5000 max records per full request.
+
+## Variables And Filters
+
+Jira should support variables inside JQL and visual configuration:
+
+- `{{projects}}`
+- `{{assignees}}`
+- `{{issue_types}}`
+- `{{statuses}}`
+- `{{start_date}}`
+- `{{end_date}}`
+- `{{board_id}}`
+- `{{sprint_id}}`
+- `{{fix_version}}`
+
+Dashboard/date filters should merge into Jira config where possible, especially date range, project, assignee, issue type, sprint, and fix version. Unsupported filters should remain client-side instead of producing invalid JQL.
+
+Important caveat:
+
+Variable support at runtime and automatic variable creation are separate concerns. Variables are stored as `VariableBinding` rows and are usually created when a dataset or data request is created. `DatasetController.createWithDataRequests()` already accepts `variableBindings` for datasets and data requests, but implementation must verify that the built-in chart-template creation path preserves those bindings cleanly. If this path is not reliable enough, Jira template setup should create variable bindings after dataset creation.
+
+## Frontend Layout
+
+Add Jira under the source UI tree:
+
+```txt
+client/src/sources/jira/
+  jira.source.js
+  jira-connection-form.jsx
+  jira-builder.jsx
+  jira-template-setup.jsx
+  components/
+  assets/
+```
+
+Register frontend components in `client/src/sources/index.js` and source metadata in `client/src/sources/definitions.js`.
+
+The source metadata should use:
+
+```js
+{
+  id: "jira",
+  type: "jira",
+  subType: "jira",
+  name: "Jira",
+  category: "productivity",
+}
+```
+
+The builder should have three modes:
+
+- Visual
+- JQL
+- Advanced
+
+The builder UI should follow the current Stripe Official builder layout and interaction model rather than introducing a new page pattern. Jira should use the same broad structure:
+
+- A source-specific builder provider/context for shared builder state.
+- A category or resource selection step similar to Stripe Official's category step.
+- A configuration step for the selected Jira resource.
+- An output/preview step for running the request and inspecting normalized rows.
+- A summary sidebar for selected resource, filters, output shape, warnings, variables, and suggested charts.
+- A collapsible advanced/config preview area for users who need to inspect the generated Jira configuration.
+
+Jira-specific components should live under `client/src/sources/jira/components/` and mirror the Stripe Official component split where it helps keep files focused. The goal is visual and workflow consistency with Stripe Official while still using Jira language and controls.
+
+Visual mode should cover non-technical Jira reporting:
+
+- Resource: Issues, sprint issues, boards, sprints, versions
+- Project
+- Board
+- Sprint
+- Issue type
+- Status and status category
+- Assignee
+- Priority
+- Fix version
+- Date field and date range
+- Group by
+- Metric: count, story points, average age, lead time
+
+JQL mode should expose JQL, selected fields, and preview. It still stores a Jira configuration object, not a generic API request.
+
+Advanced mode should expose resource and route-like choices only for supported Jira resources. It exists for debugging and edge cases, not as an arbitrary REST builder.
+
+The right side of the builder should connect dataset configuration to chart creation by showing output shape, variables, warnings, and suggested chart types.
+
+## Template Bundles
+
+Ship separate plugin-owned JSON templates, similar to Stripe Official:
+
+```txt
+project-overview.json
+sprint-health.json
+bug-tracking.json
+team-workload.json
+```
+
+Project overview:
+
+- Open issues KPI
+- Completed this period KPI
+- Created vs resolved trend
+- Issues by status
+- Issues by assignee
+- Recent completed work table
+
+Sprint health:
+
+- Sprint completion KPI
+- Story points completed KPI
+- Carryover issues table
+- Work by assignee
+- Sprint issue status breakdown
+
+Bug tracking:
+
+- Open bugs KPI
+- Bugs by priority
+- Oldest open bugs table
+- Bug trend
+
+Team workload:
+
+- Open issues by assignee
+- Work in progress by assignee
+- Stale issues table
+
+Template charts should use `layoutIntent` rather than fixed grid coordinates. Dataset outputs should be shaped so chart configs can bind directly to fields such as `root[].period`, `root[].issueCount`, `root[].storyPoints`, `root[].status`, and `root[].assignee`.
+
+## AI Planner
+
+Jira should use source-owned configuration mode. It must not expose `generateQuery`.
+
+Implement:
+
+- `getCapabilities({ connection })`
+- `listResources({ connection })`
+- `getSchema({ connection })`
+- `getSampleData({ connection, resource, rowLimit })`
+- `planDataset({ connection, question, overrides })`
+- `validateConfiguration(configuration, { connection })`
+- `previewConfiguration({ connection, configuration, rowLimit })`
+- `listTemplates({ connection })`
+- `recommendTemplates({ connection, question })`
+
+The planner should support the same v1 resources as the builder:
+
+- `issues`
+- `boards`
+- `sprints`
+- `sprint_issues`
+- `versions`
+- `fields`
+- `users`
+
+Planner examples:
+
+```txt
+"Show open bugs by priority"
+-> issues config, groupBy priority, metric count, bar chart
+
+"Create a sprint health dashboard"
+-> recommend sprint-health template, require board/sprint context if missing
+
+"Which issues are stale?"
+-> issues config with statusCategory != Done and updated before threshold, table chart
+
+"Show completed story points for the active sprint"
+-> sprint_issues config with active sprint and storyPoints metric, KPI chart
+```
+
+If a prompt needs a board, sprint, project, or field mapping that cannot be inferred, the planner should return `needs_more_context` or `needs_disambiguation`. It should not guess. Tool outputs must be compact and secret-free.
+
+Dashboard creation caveat:
+
+The current orchestrator has tools for creating datasets, charts, temporary charts, and moving charts to dashboards. It does not yet have a first-class generic tool for creating dashboards from registered source chart templates. Jira AI can expose `listTemplates` and `recommendTemplates`, but a prompt such as "create a sprint health dashboard" should either hand off to the template setup UI or use the future generic template/dashboard tool once it exists.
+
+## Generic AI Dashboard Template Tool
+
+Add a non-Jira-specific orchestration tool that creates dashboards/projects from registered source chart templates.
+
+The tool should call the existing built-in chart-template creation path through `ChartTemplateController.createFromTemplate(...)`, with:
+
+- source id
+- template slug
+- connection id
+- selected dataset template ids
+- selected chart template ids
+- target dashboard options, either existing project id or new dashboard name
+
+This tool should be available to any source with registered chart templates. Jira should be one consumer, not the owner. Stripe Official and future source AI layers should be able to adopt it later.
+
+## Error Handling
+
+Connection errors should distinguish:
+
+- Invalid site URL.
+- Invalid email or API token.
+- Jira Cloud API permission problems.
+- Agile API unavailable or board access denied.
+- Missing field mappings for story-point charts.
+- Invalid JQL.
+- Unsupported resource or transform.
+- Pagination cap reached.
+
+Runtime errors should avoid leaking credentials and should include enough source context to debug the failed operation.
+
+## Testing
+
+Backend tests:
+
+- `server/tests/unit/sourceRegistry.test.js` resolves Jira by `id`, `type`, and persisted connection shape.
+- `server/tests/unit/sourcePluginStructure.test.js` validates Jira plugin metadata and capabilities.
+- `server/tests/integration/connectionRoute.security.test.js` verifies source action authorization and rejects unlisted actions.
+- Jira protocol unit tests cover configuration validation, JQL building, variable application, pagination, normalization, field mappings, and transform output.
+- Jira template tests validate each template JSON file and chart/dataset dependency shape.
+- Template creation tests cover variable binding behavior if Jira templates rely on `dataRequest.variableBindings`.
+- `server/tests/unit/sourceAiHarness.test.js` covers Jira planner statuses, DataRequest shapes, chart specs, compact output, invalid fields, and template recommendations.
+
+Frontend tests, where current setup supports them:
+
+- Connection form validation.
+- Builder mode switching.
+- Visual config to DataRequest shape.
+- JQL preview wiring.
+- Field mapping override UI.
+- Template setup requirements for project, board, sprint, and story points.
+
+Manual verification:
+
+- Create Jira Cloud connection.
+- Test metadata actions.
+- Detect and override story points field mapping.
+- Preview issue and sprint issue datasets.
+- Create each template bundle.
+- Run source AI planning for issues and sprint summary requests.
+- Verify chart rendering for KPI, trend, bar, doughnut, and table charts.
+
+## Implementation Notes
+
+- Follow `source-plugin-guide.md` for all source runtime, frontend source UI, template, and AI changes.
+- Keep Jira-specific behavior inside `server/sources/plugins/jira/` and `client/src/sources/jira/`.
+- Prefer registry and capability checks over `connection.type` branches.
+- Do not add source-specific controller branches or helper routes.
+- Keep Jira resource definitions compact and bounded. Do not embed large Jira API documentation in orchestrator prompts.
+- Use mocked Jira responses in tests. Do not depend on live Jira Cloud.
+- Keep all code JavaScript with double quotes.

--- a/docs/superpowers/plans/2026-05-16-jira-ai-capabilities.md
+++ b/docs/superpowers/plans/2026-05-16-jira-ai-capabilities.md
@@ -1,0 +1,1701 @@
+# Jira AI Capabilities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Jira AI source-owned planning resolve vague Jira context automatically, expose richer Jira capabilities to the orchestrator, and produce useful previews/fallbacks without requiring board IDs or sprint IDs from users.
+
+**Architecture:** Add a focused Jira AI resolver module used by `jira.ai.js` and explicit source tools. Expand Jira resource metadata to mirror the Stripe Official semantic capability style, then update planner output to include `resolution`, `actions`, and `fallback` states. Keep all runtime execution source-owned through Jira `DataRequest.configuration`; `generate_query` and `run_query` remain out of the Jira path.
+
+**Tech Stack:** Node.js, Express source plugin registry, Vitest, Jira Cloud REST/Agile API wrappers, Chartbrew source-owned AI orchestrator tools.
+
+---
+
+## File Map
+
+- Create `server/sources/plugins/jira/ai/jira.resolver.js`: parse Jira hints, run Jira discovery calls, score candidates, and return a compact resolution object.
+- Modify `server/sources/plugins/jira/ai/jira.ai.js`: use resolver output in `planDataset`, expose richer capabilities/resources, add semantic intents, actions, fallback planning, and source-owned context resolution exports.
+- Modify `server/sources/plugins/jira/jira.resources.js`: add Jira semantic metadata for metrics, dimensions, filters, date fields, transforms, and auto-resolve requirements.
+- Modify `server/modules/ai/orchestrator/tools/sourceTools.js`: pass `mode` into source planning and add a generic `source_resolve_context` tool that routes to source AI modules that export `resolveContext`.
+- Modify `server/modules/ai/orchestrator/orchestrator.js`: advertise `source_resolve_context`, route it through `callTool`, inject team/original question context, and document Jira source-owned behavior.
+- Modify `server/tests/unit/jiraAi.test.js`: cover resolver behavior, planner output, fallbacks, and follow-up context reuse.
+- Modify `server/tests/unit/sourceAiHarness.test.js`: cover generic source context resolution, fallback plan contract, compact output, and no secret leakage.
+- Modify `server/tests/unit/orchestratorResponsesApi.test.js`: cover the new tool definition and continued Jira/run_query guard.
+
+Git note: Raz handles git manually. Do not run `git add`, `git commit`, or branch commands during execution.
+
+---
+
+### Task 1: Expand Jira Semantic Resource Metadata
+
+**Files:**
+- Modify: `server/sources/plugins/jira/jira.resources.js`
+- Modify: `server/sources/plugins/jira/ai/jira.ai.js`
+- Test: `server/tests/unit/jiraAi.test.js`
+
+- [ ] **Step 1: Add failing metadata assertions**
+
+Add this test to `server/tests/unit/jiraAi.test.js` inside `describe("Jira AI planner", () => { ... })`:
+
+```js
+it("exposes Jira semantic capabilities and resource planning metadata", () => {
+  const capabilities = jiraAi.getCapabilities();
+  const resources = jiraAi.listResources();
+  const sprintIssues = resources.resources.find((resource) => resource.id === "sprint_issues");
+  const issues = resources.resources.find((resource) => resource.id === "issues");
+
+  expect(capabilities.supports.discovery).toEqual(expect.arrayContaining([
+    "projects",
+    "boards",
+    "sprints",
+    "versions",
+    "users",
+    "fields",
+  ]));
+  expect(capabilities.supports.semanticIntents).toEqual(expect.arrayContaining([
+    "sprint_status",
+    "sprint_summary",
+    "bug_breakdown",
+    "release_progress",
+  ]));
+  expect(capabilities.supports.riskPolicy).toMatchObject({
+    preview: "best_match",
+    persist: "disambiguate_meaningful_uncertainty",
+  });
+  expect(sprintIssues).toMatchObject({
+    id: "sprint_issues",
+    requires: ["sprint"],
+    canAutoResolve: ["project", "board", "activeSprint"],
+    metrics: expect.arrayContaining(["count", "storyPoints", "completionRate"]),
+    dimensions: expect.arrayContaining(["status", "statusCategory", "assignee", "priority", "issueType"]),
+    transforms: expect.arrayContaining(["raw", "grouped", "sprint_summary", "stale_table"]),
+    dateFields: expect.arrayContaining(["createdAt", "updatedAt", "resolvedAt", "doneAt"]),
+  });
+  expect(issues.filters).toEqual(expect.arrayContaining([
+    expect.objectContaining({ field: "statusCategory" }),
+    expect.objectContaining({ field: "assignee" }),
+    expect.objectContaining({ field: "fixVersion" }),
+  ]));
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: failure because `discovery`, `semanticIntents`, `riskPolicy`, `metrics`, `dimensions`, `filters`, `requires`, and `canAutoResolve` are not fully present.
+
+- [ ] **Step 3: Add semantic metadata to Jira resources**
+
+Update `server/sources/plugins/jira/jira.resources.js` by adding constants below `FIELD_MAPPING_NAMES`:
+
+```js
+const ISSUE_METRICS = ["count", "storyPoints", "averageLeadTime", "averageCycleTime"];
+const SPRINT_METRICS = ["count", "storyPoints", "completionRate", "completedStoryPoints"];
+const ISSUE_DIMENSIONS = [
+  "date",
+  "status",
+  "statusCategory",
+  "assignee",
+  "priority",
+  "issueType",
+  "project",
+  "fixVersion",
+  "epic",
+  "label",
+];
+const SPRINT_DIMENSIONS = [
+  "status",
+  "statusCategory",
+  "assignee",
+  "priority",
+  "issueType",
+];
+const ISSUE_DATE_FIELDS = ["createdAt", "updatedAt", "resolvedAt", "doneAt"];
+const ISSUE_FILTERS = [
+  { field: "project", operators: ["in", "is"] },
+  { field: "issueType", operators: ["in", "is"] },
+  { field: "status", operators: ["in", "is", "isNot"] },
+  { field: "statusCategory", operators: ["is", "isNot"] },
+  { field: "assignee", operators: ["in", "is", "isEmpty"] },
+  { field: "priority", operators: ["in", "is"] },
+  { field: "fixVersion", operators: ["in", "is", "isEmpty"] },
+  { field: "createdAt", operators: ["between", "greaterOrEqual", "lessOrEqual"] },
+  { field: "updatedAt", operators: ["between", "greaterOrEqual", "lessOrEqual"] },
+  { field: "resolvedAt", operators: ["between", "greaterOrEqual", "lessOrEqual"] },
+  { field: "doneAt", operators: ["between", "greaterOrEqual", "lessOrEqual"] },
+];
+```
+
+Then enrich `JIRA_RESOURCES` entries:
+
+```js
+issues: {
+  label: "Issues",
+  endpoint: "/rest/api/3/search/jql",
+  fields: DEFAULT_FIELDS,
+  metrics: ISSUE_METRICS,
+  dimensions: ISSUE_DIMENSIONS,
+  filters: ISSUE_FILTERS,
+  transforms: ["raw", "grouped", "created_resolved_trend", "stale_table"],
+  dateFields: ISSUE_DATE_FIELDS,
+  requires: [],
+  canAutoResolve: ["project", "user", "version"],
+},
+sprint_issues: {
+  label: "Sprint issues",
+  endpoint: "/rest/agile/1.0/sprint/{sprintId}/issue",
+  fields: DEFAULT_FIELDS,
+  metrics: SPRINT_METRICS,
+  dimensions: SPRINT_DIMENSIONS,
+  filters: ISSUE_FILTERS,
+  transforms: ["raw", "grouped", "sprint_summary", "stale_table"],
+  dateFields: ISSUE_DATE_FIELDS,
+  requires: ["sprint"],
+  canAutoResolve: ["project", "board", "activeSprint"],
+},
+```
+
+Add explicit metadata for `boards`, `sprints`, `versions`, `fields`, and `users`:
+
+```js
+boards: {
+  label: "Boards",
+  endpoint: "/rest/agile/1.0/board",
+  metrics: ["count"],
+  dimensions: ["type", "project"],
+  filters: [{ field: "project", operators: ["is"] }, { field: "type", operators: ["is"] }],
+  transforms: ["raw"],
+  dateFields: [],
+  requires: [],
+  canAutoResolve: ["project"],
+},
+sprints: {
+  label: "Sprints",
+  endpoint: "/rest/agile/1.0/board/{boardId}/sprint",
+  metrics: ["count"],
+  dimensions: ["state", "board"],
+  filters: [{ field: "board", operators: ["is"] }, { field: "state", operators: ["is"] }],
+  transforms: ["raw"],
+  dateFields: ["startDate", "endDate", "completeDate"],
+  requires: ["board"],
+  canAutoResolve: ["project", "board"],
+},
+versions: {
+  label: "Versions",
+  endpoint: "/rest/api/3/project/{projectIdOrKey}/versions",
+  metrics: ["count"],
+  dimensions: ["released", "archived", "project"],
+  filters: [{ field: "project", operators: ["is"] }, { field: "released", operators: ["is"] }],
+  transforms: ["raw"],
+  dateFields: ["releaseDate"],
+  requires: ["project"],
+  canAutoResolve: ["project"],
+},
+fields: {
+  label: "Fields",
+  endpoint: "/rest/api/3/field",
+  metrics: ["count"],
+  dimensions: ["custom", "schema"],
+  filters: [{ field: "name", operators: ["contains", "is"] }, { field: "custom", operators: ["is"] }],
+  transforms: ["raw"],
+  dateFields: [],
+  requires: [],
+  canAutoResolve: [],
+},
+users: {
+  label: "Users",
+  endpoint: "/rest/api/3/user/search",
+  metrics: ["count"],
+  dimensions: ["active"],
+  filters: [{ field: "query", operators: ["contains", "is"] }, { field: "active", operators: ["is"] }],
+  transforms: ["raw"],
+  dateFields: [],
+  requires: [],
+  canAutoResolve: [],
+},
+```
+
+- [ ] **Step 4: Return expanded metadata from Jira AI**
+
+In `server/sources/plugins/jira/ai/jira.ai.js`, define constants near `SOURCE_INSTRUCTIONS`:
+
+```js
+const SEMANTIC_INTENTS = [
+  "project_overview",
+  "sprint_status",
+  "sprint_summary",
+  "sprint_workload",
+  "bug_tracking",
+  "bug_breakdown",
+  "team_workload",
+  "stale_issues",
+  "completed_work",
+  "release_progress",
+  "status_breakdown",
+  "priority_breakdown",
+  "issue_type_breakdown",
+];
+
+const DISCOVERY_TARGETS = [
+  "projects",
+  "boards",
+  "sprints",
+  "versions",
+  "users",
+  "issueTypes",
+  "statuses",
+  "priorities",
+  "fields",
+];
+```
+
+Update `getCapabilities()`:
+
+```js
+supports: {
+  modes: ["visual", "jql", "advanced"],
+  resources: Object.keys(JIRA_RESOURCES),
+  agile: true,
+  variables: true,
+  pagination: true,
+  templates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+  chartPlacement: true,
+  discovery: DISCOVERY_TARGETS,
+  semanticIntents: SEMANTIC_INTENTS,
+  metrics: Array.from(new Set(Object.values(JIRA_RESOURCES).flatMap((resource) => resource.metrics || []))),
+  dimensions: Array.from(new Set(Object.values(JIRA_RESOURCES).flatMap((resource) => resource.dimensions || []))),
+  dateFields: ["createdAt", "updatedAt", "resolvedAt", "doneAt"],
+  riskPolicy: {
+    preview: "best_match",
+    persist: "disambiguate_meaningful_uncertainty",
+  },
+},
+```
+
+Update `listResources()` mapping to include:
+
+```js
+metrics: resource.metrics || [],
+dimensions: resource.dimensions || [],
+filters: resource.filters || [],
+dateFields: resource.dateFields || [],
+requires: resource.requires || [],
+canAutoResolve: resource.canAutoResolve || [],
+transforms: resource.transforms || getTransformsForResource(id),
+```
+
+- [ ] **Step 5: Run the test and verify it passes**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: all Jira AI tests pass.
+
+- [ ] **Step 6: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.
+
+---
+
+### Task 2: Add Shared Jira Context Resolver
+
+**Files:**
+- Create: `server/sources/plugins/jira/ai/jira.resolver.js`
+- Modify: `server/sources/plugins/jira/ai/jira.ai.js`
+- Test: `server/tests/unit/jiraAi.test.js`
+
+- [ ] **Step 1: Add failing resolver tests**
+
+Update imports in `server/tests/unit/jiraAi.test.js`:
+
+```js
+const jiraResolver = require("../../sources/plugins/jira/ai/jira.resolver");
+```
+
+Add tests:
+
+```js
+it("resolves exact project, single scrum board, and active sprint", async () => {
+  vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+    id: "10001",
+    key: "D2371",
+    name: "D2371 Project",
+  }]);
+  vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+    id: 77,
+    name: "D2371 Scrum Board",
+    type: "scrum",
+  }]);
+  vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+    id: 123,
+    name: "Sprint 14",
+    state: "active",
+  }]);
+
+  const resolution = await jiraResolver.resolveContext({
+    connection: { id: 42 },
+    question: "show active sprint status for D2371",
+    intent: { id: "sprint_status", resource: "sprint_issues" },
+    mode: "preview",
+  });
+
+  expect(resolution).toMatchObject({
+    needsDisambiguation: false,
+    project: { key: "D2371", confidence: 0.98 },
+    board: { id: "77", confidence: 0.9 },
+    sprint: { id: "123", state: "active", confidence: 0.95 },
+  });
+});
+
+it("returns sprint alternatives when multiple active sprints are plausible", async () => {
+  vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+    id: 77,
+    name: "D2371 Scrum Board",
+    type: "scrum",
+  }]);
+  vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([
+    { id: 123, name: "Sprint 14", state: "active" },
+    { id: 124, name: "Sprint 15", state: "active" },
+  ]);
+
+  const resolution = await jiraResolver.resolveContext({
+    connection: { id: 42 },
+    question: "show active sprint status for D2371",
+    intent: { id: "sprint_status", resource: "sprint_issues" },
+    mode: "persist",
+  });
+
+  expect(resolution.needsDisambiguation).toBe(true);
+  expect(resolution.options).toEqual(expect.arrayContaining([
+    expect.objectContaining({ value: "sprint:123" }),
+    expect.objectContaining({ value: "sprint:124" }),
+  ]));
+});
+
+it("resolves versions and users only when requested", async () => {
+  const listUsersSpy = vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
+    accountId: "abc",
+    displayName: "Jane Product",
+    active: true,
+  }]);
+  const listVersionsSpy = vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([{
+    id: "20001",
+    name: "v5.2.0",
+    released: false,
+  }]);
+
+  const resolution = await jiraResolver.resolveContext({
+    connection: { id: 42 },
+    question: "show release readiness for D2371 v5.2.0 assigned to Jane",
+    intent: { id: "release_progress", resource: "issues", needsVersion: true, needsUser: true },
+    mode: "preview",
+  });
+
+  expect(listUsersSpy).toHaveBeenCalledWith(expect.any(Object), {
+    query: "Jane",
+    maxResults: 20,
+  });
+  expect(listVersionsSpy).toHaveBeenCalledWith(expect.any(Object), {
+    projectIdOrKey: "D2371",
+  });
+  expect(resolution.user).toMatchObject({ accountId: "abc", confidence: 0.8 });
+  expect(resolution.version).toMatchObject({ id: "20001", name: "v5.2.0", confidence: 0.9 });
+});
+```
+
+- [ ] **Step 2: Run tests and verify resolver module is missing**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: failure because `jira.resolver.js` does not exist.
+
+- [ ] **Step 3: Create resolver module**
+
+Create `server/sources/plugins/jira/ai/jira.resolver.js`:
+
+```js
+const jiraConnection = require("../jira.connection");
+
+const PROJECT_TOKEN_IGNORE = new Set(["JIRA", "SCRUM", "SPRINT", "STATUS", "DONE", "OPEN"]);
+
+function normalizeText(value = "") {
+  return String(value || "").trim().toLowerCase();
+}
+
+function extractProjectKey(question = "", overrides = {}) {
+  const explicitProject = overrides.project || overrides.projects || overrides.projectIdOrKey;
+  if (explicitProject) {
+    return Array.isArray(explicitProject) ? String(explicitProject[0]).trim() : String(explicitProject).split(",")[0].trim();
+  }
+
+  const matches = String(question || "").match(/\b[A-Z][A-Z0-9_]{1,12}\b/g) || [];
+  return matches.find((match) => !PROJECT_TOKEN_IGNORE.has(match)) || null;
+}
+
+function extractAssigneeQuery(question = "", overrides = {}) {
+  if (overrides.assigneeName) return String(overrides.assigneeName).trim();
+  if (overrides.assignee) return String(overrides.assignee).trim();
+
+  const match = String(question || "").match(/\b(?:assigned to|assignee|by)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/);
+  return match ? match[1].trim() : "";
+}
+
+function extractVersionName(question = "", overrides = {}) {
+  if (overrides.fixVersion) return String(overrides.fixVersion).trim();
+  if (overrides.version) return String(overrides.version).trim();
+
+  const match = String(question || "").match(/\b(?:version|release|fix version)?\s*(v?\d+(?:\.\d+){1,3}[A-Za-z0-9._-]*)\b/i);
+  return match ? match[1].trim() : "";
+}
+
+function shouldResolveSprints(intent = {}, question = "") {
+  return intent.resource === "sprint_issues" || intent.needsSprint || /\bsprint\b/i.test(question);
+}
+
+function shouldResolveUser(intent = {}, question = "") {
+  return Boolean(intent.needsUser) || /\b(assignee|assigned to|workload for|by)\b/i.test(question);
+}
+
+function shouldResolveVersion(intent = {}, question = "") {
+  return Boolean(intent.needsVersion) || /\b(release|version|fix version)\b/i.test(question);
+}
+
+function option(label, value, meta = {}) {
+  return { label, value, ...meta };
+}
+
+function pickBestBoard(boards = []) {
+  const scrumBoards = boards.filter((board) => !board.type || board.type === "scrum");
+  return scrumBoards[0] || boards[0] || null;
+}
+
+function buildEntity(candidate, confidence, extra = {}) {
+  if (!candidate) return null;
+  return {
+    ...extra,
+    ...candidate,
+    id: candidate.id !== undefined && candidate.id !== null ? String(candidate.id) : candidate.id,
+    confidence,
+  };
+}
+
+async function resolveProject({ connection, projectKey }) {
+  if (!projectKey) return { project: null, warnings: [] };
+
+  try {
+    const projects = await jiraConnection.listProjects(connection);
+    const exact = projects.find((project) => normalizeText(project.key) === normalizeText(projectKey));
+    if (exact) {
+      return { project: buildEntity(exact, 0.98), warnings: [] };
+    }
+    const fuzzy = projects.find((project) => normalizeText(project.name).includes(normalizeText(projectKey)));
+    if (fuzzy) {
+      return { project: buildEntity(fuzzy, 0.75), warnings: [`Using project ${fuzzy.key} as the closest match for ${projectKey}.`] };
+    }
+  } catch (error) {
+    return {
+      project: { key: projectKey, name: projectKey, confidence: 0.9 },
+      warnings: ["Could not list projects; using the project key from the question."],
+    };
+  }
+
+  return {
+    project: { key: projectKey, name: projectKey, confidence: 0.9 },
+    warnings: ["Project was inferred from the question."],
+  };
+}
+
+async function resolveBoardAndSprint({
+  connection, projectKey, overrides = {}, mode = "preview",
+}) {
+  const warnings = [];
+  const options = [];
+  let boards = [];
+
+  if (overrides.boardId) {
+    boards = [{ id: overrides.boardId, name: `Board ${overrides.boardId}`, type: "scrum" }];
+  } else if (projectKey) {
+    boards = await jiraConnection.listBoards(connection, {
+      projectKeyOrId: projectKey,
+      maxResults: 50,
+    });
+  }
+
+  const board = pickBestBoard(boards);
+  const boardAlternatives = boards
+    .filter((candidate) => !board || String(candidate.id) !== String(board.id))
+    .slice(0, 5)
+    .map((candidate) => buildEntity(candidate, 0.65));
+  const resolvedBoard = buildEntity(board, boards.length === 1 ? 0.95 : 0.86, { alternatives: boardAlternatives });
+
+  if (!board) {
+    return { board: null, sprint: null, warnings: ["No Jira board could be resolved."], options };
+  }
+
+  const sprints = await jiraConnection.listSprints(connection, {
+    boardId: board.id,
+    maxResults: 50,
+    state: overrides.sprintState || "active",
+  });
+  const activeSprints = sprints.filter((sprint) => sprint.state === (overrides.sprintState || "active"));
+
+  if (overrides.sprintId) {
+    const exact = sprints.find((sprint) => String(sprint.id) === String(overrides.sprintId)) || { id: overrides.sprintId, name: `Sprint ${overrides.sprintId}`, state: overrides.sprintState || "active" };
+    return { board: resolvedBoard, sprint: buildEntity(exact, 0.99), warnings, options };
+  }
+
+  if (activeSprints.length === 1) {
+    return { board: resolvedBoard, sprint: buildEntity(activeSprints[0], 0.95), warnings, options };
+  }
+
+  if (activeSprints.length > 1) {
+    const sprintOptions = activeSprints.slice(0, 5).map((sprint) => option(
+      `Use ${sprint.name}`,
+      `sprint:${sprint.id}`,
+      { sprintId: String(sprint.id), boardId: String(board.id) }
+    ));
+    const firstSprint = buildEntity(activeSprints[0], mode === "preview" ? 0.7 : 0.55, {
+      alternatives: activeSprints.slice(1, 5).map((sprint) => buildEntity(sprint, 0.65)),
+    });
+    return {
+      board: resolvedBoard,
+      sprint: mode === "preview" ? firstSprint : null,
+      warnings: mode === "preview" ? ["Multiple active sprints were found; using the first active sprint for preview."] : warnings,
+      options: sprintOptions,
+      needsDisambiguation: mode !== "preview",
+    };
+  }
+
+  return {
+    board: resolvedBoard,
+    sprint: null,
+    warnings: ["No active sprint was found for the resolved board."],
+    options: [
+      option("Show project status instead", "status_breakdown"),
+      option("Help me pick a board or sprint", "pick_board"),
+    ],
+  };
+}
+
+async function resolveUser({ connection, question, overrides, intent }) {
+  if (!shouldResolveUser(intent, question)) return null;
+  const query = extractAssigneeQuery(question, overrides);
+  if (!query) return null;
+
+  const users = await jiraConnection.listUsers(connection, { query, maxResults: 20 });
+  const exact = users.find((user) => normalizeText(user.displayName) === normalizeText(query));
+  const selected = exact || users[0] || null;
+  return buildEntity(selected, exact ? 0.95 : 0.8);
+}
+
+async function resolveVersion({ connection, question, overrides, intent, projectKey }) {
+  if (!shouldResolveVersion(intent, question) || !projectKey) return null;
+  const versionName = extractVersionName(question, overrides);
+  if (!versionName) return null;
+
+  const versions = await jiraConnection.listVersions(connection, { projectIdOrKey: projectKey });
+  const exact = versions.find((version) => normalizeText(version.name) === normalizeText(versionName));
+  const selected = exact || versions.find((version) => normalizeText(version.name).includes(normalizeText(versionName))) || null;
+  return buildEntity(selected, exact ? 0.95 : 0.8);
+}
+
+async function resolveContext({
+  connection,
+  question = "",
+  overrides = {},
+  intent = {},
+  mode = "preview",
+} = {}) {
+  const warnings = [];
+  const options = [];
+  const projectKey = extractProjectKey(question, overrides);
+  const projectResolution = await resolveProject({ connection, projectKey });
+  warnings.push(...projectResolution.warnings);
+
+  let boardSprintResolution = {};
+  if (shouldResolveSprints(intent, question)) {
+    boardSprintResolution = await resolveBoardAndSprint({
+      connection,
+      projectKey: projectResolution.project?.key || projectKey,
+      overrides,
+      mode,
+    });
+    warnings.push(...(boardSprintResolution.warnings || []));
+    options.push(...(boardSprintResolution.options || []));
+  }
+
+  const user = await resolveUser({ connection, question, overrides, intent });
+  const version = await resolveVersion({
+    connection,
+    question,
+    overrides,
+    intent,
+    projectKey: projectResolution.project?.key || projectKey,
+  });
+
+  return {
+    project: projectResolution.project,
+    board: boardSprintResolution.board || null,
+    sprint: boardSprintResolution.sprint || null,
+    user,
+    version,
+    warnings,
+    options,
+    needsDisambiguation: Boolean(boardSprintResolution.needsDisambiguation),
+  };
+}
+
+module.exports = {
+  extractProjectKey,
+  resolveContext,
+};
+```
+
+- [ ] **Step 4: Remove duplicated active sprint resolver from `jira.ai.js`**
+
+In `server/sources/plugins/jira/ai/jira.ai.js`, add:
+
+```js
+const jiraResolver = require("./jira.resolver");
+```
+
+Keep the old `extractProjectKey` wrapper temporarily if `buildJql` still uses it:
+
+```js
+function extractProjectKey(question = "", overrides = {}) {
+  return jiraResolver.extractProjectKey(question, overrides);
+}
+```
+
+Delete the old `resolveActiveSprint` function from `jira.ai.js`. `planDataset` will be updated in Task 3 to use `jiraResolver.resolveContext`.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: resolver tests pass or fail only where `planDataset` still expects the old `resolveActiveSprint`; Task 3 will complete integration.
+
+- [ ] **Step 6: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.
+
+---
+
+### Task 3: Rework Jira Intent Planning And Planner Contract
+
+**Files:**
+- Modify: `server/sources/plugins/jira/ai/jira.ai.js`
+- Test: `server/tests/unit/jiraAi.test.js`
+
+- [ ] **Step 1: Add failing planner contract tests**
+
+Add tests to `server/tests/unit/jiraAi.test.js`:
+
+```js
+it("returns resolution and correction actions for active sprint status", async () => {
+  vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+    id: "10001",
+    key: "D2371",
+    name: "D2371 Project",
+  }]);
+  vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+    id: 77,
+    name: "D2371 Scrum Board",
+    type: "scrum",
+  }]);
+  vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+    id: 123,
+    name: "Sprint 14",
+    state: "active",
+  }]);
+
+  const plan = await jiraAi.planDataset({
+    connection: { id: 42 },
+    question: "show me the active sprint status for D2371",
+    mode: "preview",
+  });
+
+  expect(plan.status).toBe("ok");
+  expect(plan.rationale.intent).toBe("sprint_status");
+  expect(plan.resolution).toMatchObject({
+    project: { key: "D2371" },
+    board: { id: "77" },
+    sprint: { id: "123" },
+  });
+  expect(plan.actions).toEqual(expect.arrayContaining([
+    expect.objectContaining({ value: "change_sprint" }),
+    expect.objectContaining({ value: "group_by_assignee" }),
+  ]));
+});
+
+it("plans a sprint summary from follow-up overrides", async () => {
+  const plan = await jiraAi.planDataset({
+    connection: { id: 42 },
+    question: "show me a simple sprint summary",
+    overrides: {
+      project: "D2371",
+      boardId: "77",
+      sprintId: "123",
+    },
+    mode: "preview",
+  });
+
+  expect(plan.status).toBe("ok");
+  expect(plan.rationale.intent).toBe("sprint_summary");
+  expect(plan.configuration).toMatchObject({
+    resource: "sprint_issues",
+    sprintId: "123",
+    boardId: "77",
+    transform: { type: "sprint_summary" },
+  });
+  expect(plan.chartSpec.type).toBe("gauge");
+});
+
+it("falls back to project status breakdown when active sprint cannot be resolved", async () => {
+  vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+    id: "10001",
+    key: "D2371",
+    name: "D2371 Project",
+  }]);
+  vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+    id: 77,
+    name: "D2371 Scrum Board",
+    type: "scrum",
+  }]);
+  vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
+
+  const plan = await jiraAi.planDataset({
+    connection: { id: 42 },
+    question: "show me the active sprint status for D2371",
+    mode: "preview",
+  });
+
+  expect(plan.status).toBe("fallback");
+  expect(plan.message).toContain("project status breakdown");
+  expect(plan.configuration).toMatchObject({
+    resource: "issues",
+    transform: {
+      type: "grouped",
+      groupBy: "status",
+      metric: "count",
+    },
+  });
+  expect(plan.configuration.jql).toContain("project IN (\"D2371\")");
+});
+
+it("plans Jira release progress from a version name", async () => {
+  vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+    id: "10001",
+    key: "D2371",
+    name: "D2371 Project",
+  }]);
+  vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([{
+    id: "20001",
+    name: "v5.2.0",
+    released: false,
+  }]);
+
+  const plan = await jiraAi.planDataset({
+    connection: { id: 42 },
+    question: "show release readiness for D2371 v5.2.0",
+    mode: "preview",
+  });
+
+  expect(plan.status).toBe("ok");
+  expect(plan.rationale.intent).toBe("release_progress");
+  expect(plan.configuration.jql).toContain("fixVersion IN (\"v5.2.0\")");
+  expect(plan.resolution.version).toMatchObject({ name: "v5.2.0" });
+});
+```
+
+- [ ] **Step 2: Run tests and verify planner contract fails**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: failures because planner does not return `resolution`, `actions`, `fallback`, or release progress intent.
+
+- [ ] **Step 3: Add semantic intent resolver in `jira.ai.js`**
+
+Replace `resolveIntent` with:
+
+```js
+function resolveIntent(question = "", overrides = {}) {
+  const normalizedQuestion = question.toLowerCase();
+  const groupBy = overrides.groupBy || inferGroupBy(normalizedQuestion);
+
+  if (overrides.intent) {
+    return {
+      id: overrides.intent,
+      resource: overrides.resource || "issues",
+      transform: overrides.transform || { type: "raw" },
+      chartType: overrides.chartType || "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("release") || normalizedQuestion.includes("version") || normalizedQuestion.includes("fix version")) {
+    return {
+      id: "release_progress",
+      resource: "issues",
+      needsVersion: true,
+      transform: { type: "grouped", groupBy: "statusCategory", metric: "count" },
+      chartType: "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("sprint")) {
+    const asksForSummary = normalizedQuestion.includes("summary")
+      || normalizedQuestion.includes("completion")
+      || normalizedQuestion.includes("health");
+    const sprintMetric = ["status", "statusCategory"].includes(groupBy) ? "count" : "storyPoints";
+    return {
+      id: asksForSummary ? "sprint_summary" : "sprint_status",
+      resource: "sprint_issues",
+      needsSprint: true,
+      transform: asksForSummary
+        ? { type: "sprint_summary" }
+        : { type: "grouped", groupBy: groupBy || "status", metric: overrides.metric || sprintMetric },
+      chartType: asksForSummary ? "gauge" : "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("bug") || normalizedQuestion.includes("defect")) {
+    return {
+      id: "bug_breakdown",
+      resource: "issues",
+      issueType: "Bug",
+      transform: { type: "grouped", groupBy: groupBy || "priority", metric: "count" },
+      chartType: "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("stale") || normalizedQuestion.includes("stuck") || normalizedQuestion.includes("oldest")) {
+    return {
+      id: "stale_issues",
+      resource: "issues",
+      transform: { type: "stale_table" },
+      chartType: "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("completed") || normalizedQuestion.includes("done") || normalizedQuestion.includes("recent")) {
+    return {
+      id: "completed_work",
+      resource: "issues",
+      transform: normalizedQuestion.includes("trend")
+        ? { type: "created_resolved_trend", interval: overrides.interval || inferInterval(normalizedQuestion) }
+        : { type: "raw" },
+      chartType: normalizedQuestion.includes("trend") ? "line" : "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("workload") || normalizedQuestion.includes("assignee") || normalizedQuestion.includes("team load")) {
+    return {
+      id: "team_workload",
+      resource: "issues",
+      transform: { type: "grouped", groupBy: "assignee", metric: "count" },
+      chartType: "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("created vs resolved") || normalizedQuestion.includes("created and resolved") || normalizedQuestion.includes("trend") || normalizedQuestion.includes("over time")) {
+    return {
+      id: "created_done_trend",
+      resource: "issues",
+      transform: {
+        type: "created_resolved_trend",
+        interval: overrides.interval || inferInterval(normalizedQuestion),
+      },
+      chartType: "line",
+    };
+  }
+
+  if (groupBy) {
+    return {
+      id: "issue_breakdown",
+      resource: "issues",
+      transform: { type: "grouped", groupBy, metric: overrides.metric || "count" },
+      chartType: normalizedQuestion.includes("doughnut") || normalizedQuestion.includes("donut") ? "doughnut" : "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("table") || normalizedQuestion.includes("latest")) {
+    return {
+      id: "issue_table",
+      resource: "issues",
+      transform: { type: "raw" },
+      chartType: "table",
+    };
+  }
+
+  return {
+    id: "project_overview",
+    resource: "issues",
+    transform: { type: "raw" },
+    chartType: "kpi",
+  };
+}
+```
+
+- [ ] **Step 4: Add action and fallback helpers**
+
+Add these helpers in `jira.ai.js` above `planDataset`:
+
+```js
+function buildActions(intent, resolution = {}) {
+  const actions = [];
+
+  if (intent.resource === "sprint_issues") {
+    actions.push({ label: "Use a different sprint", value: "change_sprint" });
+    actions.push({ label: "Break down by assignee", value: "group_by_assignee" });
+  }
+
+  if (resolution.project?.key) {
+    actions.push({
+      label: `Show ${resolution.project.key} project status instead`,
+      value: "status_breakdown",
+    });
+  }
+
+  if (intent.id !== "issue_table") {
+    actions.push({ label: "Show issue table", value: "show_table" });
+  }
+
+  return actions;
+}
+
+function buildProjectStatusFallback({ question, overrides, resolution, reason }) {
+  const projectKey = resolution.project?.key || extractProjectKey(question, overrides) || "{{projects}}";
+  const configuration = {
+    source: SOURCE_ID,
+    resource: "issues",
+    mode: "visual",
+    jql: buildJql({
+      question,
+      overrides: {
+        ...overrides,
+        projects: projectKey,
+      },
+      intent: { resource: "issues" },
+    }),
+    fields: DEFAULT_FIELDS,
+    transform: { type: "grouped", groupBy: "status", metric: "count" },
+    pagination: {
+      ...DEFAULT_PAGINATION,
+      ...(overrides.pagination || {}),
+    },
+  };
+  const validation = validateConfiguration(configuration);
+  const chartSpec = getChartSpec(validation.configuration, question, "bar");
+
+  return {
+    status: "fallback",
+    source: SOURCE_ID,
+    message: reason || `I could not resolve the active sprint, so I used the ${projectKey} project status breakdown instead.`,
+    datasetName: chartSpec.title,
+    configuration: validation.configuration,
+    chartSpec,
+    outputFields: getOutputFields(validation.configuration),
+    resolution,
+    actions: buildActions({ id: "issue_breakdown", resource: "issues" }, resolution),
+    warnings: validation.warnings,
+    errors: validation.errors,
+    rationale: {
+      intent: "status_breakdown_fallback",
+      resource: "issues",
+      mode: validation.configuration.mode,
+      transform: validation.configuration.transform,
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Update `planDataset` to use resolver**
+
+Replace the sprint-resolution block in `planDataset` with:
+
+```js
+const intent = resolveIntent(question, overrides);
+const normalizedQuestion = question.toLowerCase();
+const issueType = overrides.issueType || intent.issueType || (normalizedQuestion.includes("bug") || normalizedQuestion.includes("defect") ? "Bug" : undefined);
+const resolution = await jiraResolver.resolveContext({
+  connection,
+  question,
+  overrides,
+  intent,
+  mode: overrides.modeContext || "preview",
+});
+
+if (resolution.needsDisambiguation) {
+  return {
+    status: "needs_disambiguation",
+    source: SOURCE_ID,
+    message: resolution.message || "I found multiple Jira matches. Which one should I use?",
+    options: resolution.options || [],
+    resolution,
+  };
+}
+
+if (intent.resource === "sprint_issues" && !resolution.sprint?.id) {
+  return buildProjectStatusFallback({
+    question,
+    overrides,
+    resolution,
+    reason: resolution.project?.key
+      ? `I could not resolve the active sprint, so I used the ${resolution.project.key} project status breakdown instead.`
+      : "I could not resolve the active sprint, so I used a project status breakdown instead.",
+  });
+}
+
+const sprintId = resolution.sprint?.id || overrides.sprintId || "{{sprint_id}}";
+const boardId = resolution.board?.id || overrides.boardId || "{{board_id}}";
+const projectKey = resolution.project?.key || overrides.projects || overrides.project || "{{projects}}";
+const fixVersion = resolution.version?.name || overrides.fixVersion;
+```
+
+Then in the config object:
+
+```js
+jql: buildJql({
+  question,
+  overrides: {
+    ...overrides,
+    projects: projectKey,
+    fixVersion,
+  },
+  intent: {
+    resource: intent.resource,
+    issueType,
+    priority: normalizedQuestion.includes("blocker") ? "Blocker" : undefined,
+  },
+}),
+sprintId,
+boardId,
+projectIdOrKey: projectKey,
+transform: overrides.transform || intent.transform,
+includeDoneAt: ["completed_work", "created_done_trend", "sprint_summary"].includes(intent.id) || overrides.includeDoneAt,
+```
+
+Return the expanded contract:
+
+```js
+rationale: {
+  intent: intent.id,
+  resource: validation.configuration.resource,
+  mode: validation.configuration.mode,
+  transform: validation.configuration.transform,
+  issueType,
+},
+resolution,
+actions: buildActions(intent, resolution),
+warnings: [
+  ...validation.warnings,
+  ...(resolution.warnings || []),
+],
+```
+
+- [ ] **Step 6: Run planner tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: all Jira AI planner tests pass.
+
+- [ ] **Step 7: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.
+
+---
+
+### Task 4: Add Generic Source Context Resolution Tool
+
+**Files:**
+- Modify: `server/modules/ai/orchestrator/tools/sourceTools.js`
+- Modify: `server/modules/ai/orchestrator/tools/index.js`
+- Modify: `server/modules/ai/orchestrator/orchestrator.js`
+- Modify: `server/sources/plugins/jira/ai/jira.ai.js`
+- Test: `server/tests/unit/sourceAiHarness.test.js`
+- Test: `server/tests/unit/orchestratorResponsesApi.test.js`
+
+- [ ] **Step 1: Add failing source tool test**
+
+In `server/tests/unit/sourceAiHarness.test.js`, import the new tool:
+
+```js
+const {
+  sourceGetCapabilities,
+  sourceGetSampleData,
+  sourceListResources,
+  sourceListTemplates,
+  sourcePlanDataset,
+  sourcePreviewConfiguration,
+  sourceRecommendTemplates,
+  sourceResolveContext,
+  sourceValidateConfiguration,
+} = require("../../modules/ai/orchestrator/tools/sourceTools");
+```
+
+Add:
+
+```js
+it("routes generic source context resolution to Jira AI", async () => {
+  vi.spyOn(db.Connection, "findOne").mockResolvedValue(toolHarnessConnections.jira);
+  vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+    id: "10001",
+    key: "D2371",
+    name: "D2371 Project",
+  }]);
+  vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+    id: 77,
+    name: "D2371 Scrum Board",
+    type: "scrum",
+  }]);
+  vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+    id: 123,
+    name: "Sprint 14",
+    state: "active",
+  }]);
+
+  const result = await sourceResolveContext({
+    team_id: TOOL_TEAM_ID,
+    connection_id: toolHarnessConnections.jira.id,
+    source_id: "jira",
+    question: "show active sprint status for D2371",
+    intent: { id: "sprint_status", resource: "sprint_issues" },
+    mode: "preview",
+  });
+
+  expect(result).toMatchObject({
+    source: "jira",
+    resolution: {
+      project: { key: "D2371" },
+      board: { id: "77" },
+      sprint: { id: "123" },
+    },
+  });
+  expectToolOutputContract(result);
+});
+```
+
+- [ ] **Step 2: Add failing orchestrator tool definition test**
+
+In `server/tests/unit/orchestratorResponsesApi.test.js`, add:
+
+```js
+it("advertises generic source context resolution", async () => {
+  const tools = await availableTools();
+  const tool = tools.find((candidate) => candidate.name === "source_resolve_context");
+
+  expect(tool).toMatchObject({
+    name: "source_resolve_context",
+    displayName: "Resolve source context",
+  });
+  expect(tool.parameters.required).toEqual(expect.arrayContaining(["connection_id", "question"]));
+});
+```
+
+Import `availableTools` at the top if it is not already imported:
+
+```js
+const {
+  availableTools,
+  buildResponseInputFromMessages,
+  buildAssistantMessageFromResponse,
+  buildDisambiguationAssistantMessage,
+  buildFallbackAssistantMessage,
+  sanitizeToolError,
+  buildUsageRecordFromResponse,
+} = require("../../modules/ai/orchestrator/orchestrator");
+```
+
+- [ ] **Step 3: Run tests and verify failures**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js tests/unit/orchestratorResponsesApi.test.js
+```
+
+Expected: failures because `sourceResolveContext` and `source_resolve_context` do not exist.
+
+- [ ] **Step 4: Export `resolveContext` from Jira AI**
+
+In `server/sources/plugins/jira/ai/jira.ai.js`, add:
+
+```js
+async function resolveContext({
+  connection,
+  question = "",
+  overrides = {},
+  intent = {},
+  mode = "preview",
+} = {}) {
+  const resolution = await jiraResolver.resolveContext({
+    connection,
+    question,
+    overrides,
+    intent,
+    mode,
+  });
+
+  return {
+    source: SOURCE_ID,
+    resolution,
+  };
+}
+```
+
+Export it:
+
+```js
+resolveContext,
+```
+
+- [ ] **Step 5: Add source tool plumbing**
+
+In `server/modules/ai/orchestrator/tools/sourceTools.js`, add:
+
+```js
+async function sourceResolveContext(payload) {
+  const { connection, source } = await getScopedSource(payload);
+  const tool = requireAiTool(source, "resolveContext");
+
+  return tool({
+    connection,
+    question: mergeQuestionContext(payload.question, payload.original_question),
+    overrides: payload.overrides || {},
+    intent: payload.intent || {},
+    mode: payload.mode || "preview",
+  });
+}
+```
+
+Export it:
+
+```js
+sourceResolveContext,
+```
+
+In `server/modules/ai/orchestrator/tools/index.js`, import/export `sourceResolveContext` with the other source tools.
+
+- [ ] **Step 6: Add orchestrator tool definition and routing**
+
+In `server/modules/ai/orchestrator/orchestrator.js`, import `sourceResolveContext` from `./tools`.
+
+Add `"source_resolve_context"` to `TEAM_SCOPED_TOOLS` and `ORIGINAL_QUESTION_TOOLS`.
+
+Add this available tool near the other source tools:
+
+```js
+{
+  name: "source_resolve_context",
+  displayName: "Resolve source context",
+  description: "Resolve source-owned business context such as Jira projects, boards, sprints, versions, and users without asking for raw IDs. Use this for corrections, follow-ups, or explicit context inspection.",
+  parameters: {
+    type: "object",
+    properties: {
+      source_id: { type: "string", enum: supportedSourceIds },
+      connection_id: { type: "string" },
+      question: { type: "string" },
+      intent: { type: "object" },
+      overrides: { type: "object" },
+      mode: { type: "string", enum: ["preview", "persist"], default: "preview" }
+    },
+    required: ["connection_id", "question"]
+  }
+}
+```
+
+Add routing in `callTool`:
+
+```js
+case "source_resolve_context":
+  return sourceResolveContext(payload);
+```
+
+Update source-owned prompt guidance:
+
+```txt
+* Use source_resolve_context when a Jira follow-up needs to inspect or correct project, board, sprint, version, or user context.
+```
+
+- [ ] **Step 7: Run source/orchestrator tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js tests/unit/orchestratorResponsesApi.test.js
+```
+
+Expected: both test files pass.
+
+- [ ] **Step 8: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.
+
+---
+
+### Task 5: Make Fallback Plans Preview-Safe In Source Tools
+
+**Files:**
+- Modify: `server/modules/ai/orchestrator/tools/sourceTools.js`
+- Modify: `server/sources/plugins/jira/ai/jira.ai.js`
+- Test: `server/tests/unit/sourceAiHarness.test.js`
+- Test: `server/tests/unit/jiraAi.test.js`
+
+- [ ] **Step 1: Add failing fallback contract test**
+
+Add to `server/tests/unit/sourceAiHarness.test.js`:
+
+```js
+it("keeps Jira fallback plans usable for preview", async () => {
+  vi.spyOn(db.Connection, "findOne").mockResolvedValue(toolHarnessConnections.jira);
+  vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+    id: "10001",
+    key: "D2371",
+    name: "D2371 Project",
+  }]);
+  vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+    id: 77,
+    name: "D2371 Scrum Board",
+    type: "scrum",
+  }]);
+  vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
+
+  const plan = await sourcePlanDataset({
+    team_id: TOOL_TEAM_ID,
+    connection_id: toolHarnessConnections.jira.id,
+    source_id: "jira",
+    question: "show active sprint status for D2371",
+    mode: "preview",
+  });
+
+  expect(plan.status).toBe("fallback");
+  expect(plan.configuration).toMatchObject({
+    source: "jira",
+    resource: "issues",
+  });
+  expect(plan.chartSpec).toMatchObject({
+    type: "bar",
+    xAxis: "root[].status",
+    yAxis: "root[].issueCount",
+  });
+  expect(plan.needs_user_input).toBeUndefined();
+  expectToolOutputContract(plan);
+});
+```
+
+- [ ] **Step 2: Run test and verify current behavior fails**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js
+```
+
+Expected: failure if `sourcePlanDataset` does not pass `mode`, or fallback does not produce a usable plan.
+
+- [ ] **Step 3: Pass risk mode into planner**
+
+In `server/modules/ai/orchestrator/tools/sourceTools.js`, update `sourcePlanDataset` tool call:
+
+```js
+const result = await tool({
+  connection,
+  question: mergeQuestionContext(payload.question, payload.original_question),
+  overrides: payload.overrides || {},
+  mode: payload.mode || "preview",
+});
+```
+
+In `jira.ai.js`, update `planDataset` signature:
+
+```js
+async function planDataset({
+  connection = null,
+  question = "",
+  overrides = {},
+  mode = "preview",
+} = {}) {
+```
+
+Then pass mode to resolver:
+
+```js
+mode: overrides.modeContext || mode,
+```
+
+- [ ] **Step 4: Ensure fallback plans are not treated as disambiguation**
+
+Keep this sourceTools behavior unchanged except for `needs_disambiguation`:
+
+```js
+if (result?.status === "needs_disambiguation") {
+  return {
+    ...result,
+    needs_user_input: true,
+    prompt: result.message || "Choose an option before I continue.",
+    options: Array.isArray(result.options) ? result.options : [],
+  };
+}
+```
+
+Confirm no branch maps `fallback` to `needs_user_input`.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceAiHarness.test.js tests/unit/jiraAi.test.js
+```
+
+Expected: fallback plans are valid and source-owned harness tests pass.
+
+- [ ] **Step 6: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.
+
+---
+
+### Task 6: Add Preview Failure Fallback For Sprint Issue Previews
+
+**Files:**
+- Modify: `server/sources/plugins/jira/ai/jira.ai.js`
+- Test: `server/tests/unit/jiraAi.test.js`
+
+- [ ] **Step 1: Add failing preview fallback test**
+
+Add to `server/tests/unit/jiraAi.test.js`:
+
+```js
+it("falls back to project status when sprint issue preview fails", async () => {
+  const fetchSpy = vi.spyOn(require("../../sources/plugins/jira/jira.protocol"), "fetchJiraRows");
+  fetchSpy
+    .mockRejectedValueOnce(new Error("400 - The sprint field is invalid"))
+    .mockResolvedValueOnce([{
+      key: "D2371-1",
+      fields: {
+        summary: "Fallback issue",
+        project: { key: "D2371" },
+        issuetype: { name: "Story" },
+        status: { name: "Done", statusCategory: { name: "Done", key: "done" } },
+        created: "2026-05-01T00:00:00.000Z",
+        updated: "2026-05-02T00:00:00.000Z",
+      },
+    }]);
+
+  const preview = await jiraAi.previewConfiguration({
+    connection: { id: 42 },
+    rowLimit: 5,
+    configuration: {
+      source: "jira",
+      resource: "sprint_issues",
+      mode: "visual",
+      jql: "project IN (\"D2371\") ORDER BY updated DESC",
+      fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
+      sprintId: "123",
+      boardId: "77",
+      projectIdOrKey: "D2371",
+      transform: { type: "grouped", groupBy: "status", metric: "count" },
+      pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
+    },
+  });
+
+  expect(preview.status).toBe("fallback");
+  expect(preview.message).toContain("project status breakdown");
+  expect(preview.rows).toEqual([{ status: "Done", issueCount: 1, storyPoints: 0 }]);
+  expect(fetchSpy).toHaveBeenCalledTimes(2);
+});
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: failure because `previewConfiguration` currently throws the first sprint preview error.
+
+- [ ] **Step 3: Add preview fallback helper**
+
+In `jira.ai.js`, add:
+
+```js
+function getProjectStatusFallbackConfiguration(configuration = {}) {
+  const projectKey = configuration.projectIdOrKey && !String(configuration.projectIdOrKey).includes("{{")
+    ? configuration.projectIdOrKey
+    : "{{projects}}";
+
+  return {
+    ...configuration,
+    resource: "issues",
+    sprintId: undefined,
+    boardId: undefined,
+    projectIdOrKey: projectKey,
+    jql: buildJql({
+      question: "project status breakdown",
+      overrides: { projects: projectKey },
+      intent: { resource: "issues" },
+    }),
+    transform: { type: "grouped", groupBy: "status", metric: "count" },
+  };
+}
+```
+
+- [ ] **Step 4: Catch sprint preview errors and fallback**
+
+In `previewConfiguration`, wrap the `jiraProtocol.fetchJiraRows` call:
+
+```js
+let jiraRows;
+let fallbackMessage = null;
+let previewConfigToUse = previewConfig;
+
+try {
+  jiraRows = await jiraProtocol.fetchJiraRows(connection, previewConfigToUse);
+} catch (error) {
+  if (previewConfig.resource !== "sprint_issues") {
+    throw error;
+  }
+
+  previewConfigToUse = getProjectStatusFallbackConfiguration(previewConfig);
+  jiraRows = await jiraProtocol.fetchJiraRows(connection, previewConfigToUse);
+  fallbackMessage = "I could not preview sprint issues, so I used the project status breakdown instead.";
+}
+```
+
+Then use `previewConfigToUse` for normalization, transformation, columns, and chart spec:
+
+```js
+const normalizedRows = ["issues", "sprint_issues"].includes(previewConfigToUse.resource)
+  ? jiraRows.map((issue) => jiraProtocol.normalizeIssue(issue, connection?.options?.jira?.fieldMappings || {}))
+  : jiraRows;
+const rows = jiraProtocol.transformRows(normalizedRows, previewConfigToUse);
+```
+
+Return:
+
+```js
+return {
+  status: fallbackMessage ? "fallback" : "ok",
+  message: fallbackMessage || undefined,
+  rows: rows.slice(0, rowLimit),
+  columns: buildColumns(rows, previewConfigToUse),
+  rowCount: rows.length,
+  warnings: validation.warnings,
+  chartSpec: getChartSpec(previewConfigToUse, ""),
+};
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js
+```
+
+Expected: all Jira AI tests pass.
+
+- [ ] **Step 6: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.
+
+---
+
+### Task 7: Full Verification
+
+**Files:**
+- Verify all modified Jira AI/orchestrator test files.
+
+- [ ] **Step 1: Run focused unit test suite**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/jiraAi.test.js tests/unit/jiraProtocol.test.js tests/unit/jiraTemplates.test.js tests/unit/sourceAiHarness.test.js tests/unit/orchestratorResponsesApi.test.js tests/unit/updateAudit.test.js
+```
+
+Expected: all listed tests pass.
+
+- [ ] **Step 2: Run source registry and plugin structure tests**
+
+Run:
+
+```bash
+npm run test:run -- tests/unit/sourceRegistry.test.js tests/unit/sourcePluginStructure.test.js
+```
+
+Expected: all listed tests pass.
+
+- [ ] **Step 3: Review source guide consistency**
+
+Read:
+
+```bash
+sed -n '1,220p' source-plugin-guide.md
+```
+
+Expected: Jira AI remains source-owned, templates stay source-owned, and no generic API route or builder behavior is introduced.
+
+- [ ] **Step 4: Search for accidental Jira generic query usage**
+
+Run:
+
+```bash
+rg -n "run_query|generate_query|source_resolve_context|resolveContext" server/modules/ai/orchestrator server/sources/plugins/jira server/tests/unit
+```
+
+Expected:
+
+- Jira source-owned paths mention `source_resolve_context`, `source_plan_dataset`, `source_preview_configuration`, and `resolveContext`.
+- Jira docs/tests may mention `run_query` only as a forbidden guard.
+- No Jira planner code calls `generate_query` or `run_query`.
+
+- [ ] **Step 5: Manual behavior smoke check through unit-level planner calls**
+
+Run:
+
+```bash
+node -e "const jiraAi=require('./sources/plugins/jira/ai/jira.ai'); jiraAi.planDataset({question:'show bugs by priority for D2371', overrides:{project:'D2371'}}).then((p)=>console.log(JSON.stringify({status:p.status,resource:p.configuration.resource,jql:p.configuration.jql,chart:p.chartSpec.type}, null, 2)))"
+```
+
+Expected output contains:
+
+```json
+{
+  "status": "ok",
+  "resource": "issues",
+  "chart": "bar"
+}
+```
+
+The exact JQL should include `project IN ("D2371")` and `issuetype = "Bug"`.
+
+- [ ] **Step 6: Git checkpoint**
+
+Do not run git commands. Raz handles git manually.

--- a/docs/superpowers/plans/2026-05-16-jira-ai-capabilities.md
+++ b/docs/superpowers/plans/2026-05-16-jira-ai-capabilities.md
@@ -325,12 +325,12 @@ Add tests:
 it("resolves exact project, single scrum board, and active sprint", async () => {
   vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
     id: "10001",
-    key: "D2371",
-    name: "D2371 Project",
+    key: "A4321",
+    name: "A4321 Project",
   }]);
   vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
     id: 77,
-    name: "D2371 Scrum Board",
+    name: "A4321 Scrum Board",
     type: "scrum",
   }]);
   vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -341,14 +341,14 @@ it("resolves exact project, single scrum board, and active sprint", async () => 
 
   const resolution = await jiraResolver.resolveContext({
     connection: { id: 42 },
-    question: "show active sprint status for D2371",
+    question: "show active sprint status for A4321",
     intent: { id: "sprint_status", resource: "sprint_issues" },
     mode: "preview",
   });
 
   expect(resolution).toMatchObject({
     needsDisambiguation: false,
-    project: { key: "D2371", confidence: 0.98 },
+    project: { key: "A4321", confidence: 0.98 },
     board: { id: "77", confidence: 0.9 },
     sprint: { id: "123", state: "active", confidence: 0.95 },
   });
@@ -357,7 +357,7 @@ it("resolves exact project, single scrum board, and active sprint", async () => 
 it("returns sprint alternatives when multiple active sprints are plausible", async () => {
   vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
     id: 77,
-    name: "D2371 Scrum Board",
+    name: "A4321 Scrum Board",
     type: "scrum",
   }]);
   vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([
@@ -367,7 +367,7 @@ it("returns sprint alternatives when multiple active sprints are plausible", asy
 
   const resolution = await jiraResolver.resolveContext({
     connection: { id: 42 },
-    question: "show active sprint status for D2371",
+    question: "show active sprint status for A4321",
     intent: { id: "sprint_status", resource: "sprint_issues" },
     mode: "persist",
   });
@@ -393,7 +393,7 @@ it("resolves versions and users only when requested", async () => {
 
   const resolution = await jiraResolver.resolveContext({
     connection: { id: 42 },
-    question: "show release readiness for D2371 v5.2.0 assigned to Jane",
+    question: "show release readiness for A4321 v5.2.0 assigned to Jane",
     intent: { id: "release_progress", resource: "issues", needsVersion: true, needsUser: true },
     mode: "preview",
   });
@@ -403,7 +403,7 @@ it("resolves versions and users only when requested", async () => {
     maxResults: 20,
   });
   expect(listVersionsSpy).toHaveBeenCalledWith(expect.any(Object), {
-    projectIdOrKey: "D2371",
+    projectIdOrKey: "A4321",
   });
   expect(resolution.user).toMatchObject({ accountId: "abc", confidence: 0.8 });
   expect(resolution.version).toMatchObject({ id: "20001", name: "v5.2.0", confidence: 0.9 });
@@ -710,12 +710,12 @@ Add tests to `server/tests/unit/jiraAi.test.js`:
 it("returns resolution and correction actions for active sprint status", async () => {
   vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
     id: "10001",
-    key: "D2371",
-    name: "D2371 Project",
+    key: "A4321",
+    name: "A4321 Project",
   }]);
   vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
     id: 77,
-    name: "D2371 Scrum Board",
+    name: "A4321 Scrum Board",
     type: "scrum",
   }]);
   vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -726,14 +726,14 @@ it("returns resolution and correction actions for active sprint status", async (
 
   const plan = await jiraAi.planDataset({
     connection: { id: 42 },
-    question: "show me the active sprint status for D2371",
+    question: "show me the active sprint status for A4321",
     mode: "preview",
   });
 
   expect(plan.status).toBe("ok");
   expect(plan.rationale.intent).toBe("sprint_status");
   expect(plan.resolution).toMatchObject({
-    project: { key: "D2371" },
+    project: { key: "A4321" },
     board: { id: "77" },
     sprint: { id: "123" },
   });
@@ -748,7 +748,7 @@ it("plans a sprint summary from follow-up overrides", async () => {
     connection: { id: 42 },
     question: "show me a simple sprint summary",
     overrides: {
-      project: "D2371",
+      project: "A4321",
       boardId: "77",
       sprintId: "123",
     },
@@ -769,19 +769,19 @@ it("plans a sprint summary from follow-up overrides", async () => {
 it("falls back to project status breakdown when active sprint cannot be resolved", async () => {
   vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
     id: "10001",
-    key: "D2371",
-    name: "D2371 Project",
+    key: "A4321",
+    name: "A4321 Project",
   }]);
   vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
     id: 77,
-    name: "D2371 Scrum Board",
+    name: "A4321 Scrum Board",
     type: "scrum",
   }]);
   vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
 
   const plan = await jiraAi.planDataset({
     connection: { id: 42 },
-    question: "show me the active sprint status for D2371",
+    question: "show me the active sprint status for A4321",
     mode: "preview",
   });
 
@@ -795,14 +795,14 @@ it("falls back to project status breakdown when active sprint cannot be resolved
       metric: "count",
     },
   });
-  expect(plan.configuration.jql).toContain("project IN (\"D2371\")");
+  expect(plan.configuration.jql).toContain("project IN (\"A4321\")");
 });
 
 it("plans Jira release progress from a version name", async () => {
   vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
     id: "10001",
-    key: "D2371",
-    name: "D2371 Project",
+    key: "A4321",
+    name: "A4321 Project",
   }]);
   vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([{
     id: "20001",
@@ -812,7 +812,7 @@ it("plans Jira release progress from a version name", async () => {
 
   const plan = await jiraAi.planDataset({
     connection: { id: 42 },
-    question: "show release readiness for D2371 v5.2.0",
+    question: "show release readiness for A4321 v5.2.0",
     mode: "preview",
   });
 
@@ -1163,12 +1163,12 @@ it("routes generic source context resolution to Jira AI", async () => {
   vi.spyOn(db.Connection, "findOne").mockResolvedValue(toolHarnessConnections.jira);
   vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
     id: "10001",
-    key: "D2371",
-    name: "D2371 Project",
+    key: "A4321",
+    name: "A4321 Project",
   }]);
   vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
     id: 77,
-    name: "D2371 Scrum Board",
+    name: "A4321 Scrum Board",
     type: "scrum",
   }]);
   vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -1181,7 +1181,7 @@ it("routes generic source context resolution to Jira AI", async () => {
     team_id: TOOL_TEAM_ID,
     connection_id: toolHarnessConnections.jira.id,
     source_id: "jira",
-    question: "show active sprint status for D2371",
+    question: "show active sprint status for A4321",
     intent: { id: "sprint_status", resource: "sprint_issues" },
     mode: "preview",
   });
@@ -1189,7 +1189,7 @@ it("routes generic source context resolution to Jira AI", async () => {
   expect(result).toMatchObject({
     source: "jira",
     resolution: {
-      project: { key: "D2371" },
+      project: { key: "A4321" },
       board: { id: "77" },
       sprint: { id: "123" },
     },
@@ -1373,12 +1373,12 @@ it("keeps Jira fallback plans usable for preview", async () => {
   vi.spyOn(db.Connection, "findOne").mockResolvedValue(toolHarnessConnections.jira);
   vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
     id: "10001",
-    key: "D2371",
-    name: "D2371 Project",
+    key: "A4321",
+    name: "A4321 Project",
   }]);
   vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
     id: 77,
-    name: "D2371 Scrum Board",
+    name: "A4321 Scrum Board",
     type: "scrum",
   }]);
   vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
@@ -1387,7 +1387,7 @@ it("keeps Jira fallback plans usable for preview", async () => {
     team_id: TOOL_TEAM_ID,
     connection_id: toolHarnessConnections.jira.id,
     source_id: "jira",
-    question: "show active sprint status for D2371",
+    question: "show active sprint status for A4321",
     mode: "preview",
   });
 
@@ -1495,10 +1495,10 @@ it("falls back to project status when sprint issue preview fails", async () => {
   fetchSpy
     .mockRejectedValueOnce(new Error("400 - The sprint field is invalid"))
     .mockResolvedValueOnce([{
-      key: "D2371-1",
+      key: "A4321-1",
       fields: {
         summary: "Fallback issue",
-        project: { key: "D2371" },
+        project: { key: "A4321" },
         issuetype: { name: "Story" },
         status: { name: "Done", statusCategory: { name: "Done", key: "done" } },
         created: "2026-05-01T00:00:00.000Z",
@@ -1513,11 +1513,11 @@ it("falls back to project status when sprint issue preview fails", async () => {
       source: "jira",
       resource: "sprint_issues",
       mode: "visual",
-      jql: "project IN (\"D2371\") ORDER BY updated DESC",
+      jql: "project IN (\"A4321\") ORDER BY updated DESC",
       fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
       sprintId: "123",
       boardId: "77",
-      projectIdOrKey: "D2371",
+      projectIdOrKey: "A4321",
       transform: { type: "grouped", groupBy: "status", metric: "count" },
       pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
     },
@@ -1681,7 +1681,7 @@ Expected:
 Run:
 
 ```bash
-node -e "const jiraAi=require('./sources/plugins/jira/ai/jira.ai'); jiraAi.planDataset({question:'show bugs by priority for D2371', overrides:{project:'D2371'}}).then((p)=>console.log(JSON.stringify({status:p.status,resource:p.configuration.resource,jql:p.configuration.jql,chart:p.chartSpec.type}, null, 2)))"
+node -e "const jiraAi=require('./sources/plugins/jira/ai/jira.ai'); jiraAi.planDataset({question:'show bugs by priority for A4321', overrides:{project:'A4321'}}).then((p)=>console.log(JSON.stringify({status:p.status,resource:p.configuration.resource,jql:p.configuration.jql,chart:p.chartSpec.type}, null, 2)))"
 ```
 
 Expected output contains:
@@ -1694,7 +1694,7 @@ Expected output contains:
 }
 ```
 
-The exact JQL should include `project IN ("D2371")` and `issuetype = "Bug"`.
+The exact JQL should include `project IN ("A4321")` and `issuetype = "Bug"`.
 
 - [ ] **Step 6: Git checkpoint**
 

--- a/docs/superpowers/specs/2026-05-16-jira-ai-capabilities-design.md
+++ b/docs/superpowers/specs/2026-05-16-jira-ai-capabilities-design.md
@@ -10,7 +10,7 @@ The Jira source should stay source-owned. The AI should plan Jira `DataRequest.c
 
 ## Current Gap
 
-Stripe Official exposes a semantic AI surface: source instructions, resources, metrics, dimensions, filters, compiled metrics, validation, repair, and compact preview behavior. Jira currently has a thinner planner with some hidden sprint resolution. That makes simple prompts like “show me the active sprint status for D2371” fragile because the orchestrator does not have enough structured capability information or reusable discovery behavior.
+Stripe Official exposes a semantic AI surface: source instructions, resources, metrics, dimensions, filters, compiled metrics, validation, repair, and compact preview behavior. Jira currently has a thinner planner with some hidden sprint resolution. That makes simple prompts like “show me the active sprint status for A4321” fragile because the orchestrator does not have enough structured capability information or reusable discovery behavior.
 
 ## Chosen Approach
 
@@ -101,7 +101,7 @@ Input:
 Resolution order:
 
 1. Parse hints from the question:
-   - project keys such as `D2371`
+   - project keys such as `A4321`
    - sprint state words such as active, current, latest, closed, future
    - Jira resource words such as sprint, bug, release, workload
    - assignee or reporter names
@@ -130,8 +130,8 @@ Resolver output:
 
 ```js
 {
-  project: { key: "D2371", name: "D2371", confidence: 0.98 },
-  board: { id: 77, name: "D2371 Scrum Board", confidence: 0.86, alternatives: [] },
+  project: { key: "A4321", name: "A4321", confidence: 0.98 },
+  board: { id: 77, name: "A4321 Scrum Board", confidence: 0.86, alternatives: [] },
   sprint: { id: 123, name: "Sprint 14", state: "active", confidence: 0.93 },
   warnings: [],
   needsDisambiguation: false
@@ -189,12 +189,12 @@ The `actions` array should power quick correction options:
 ]
 ```
 
-For “show me the active sprint status for D2371 in Jira”, the planner should resolve the project, board, and active sprint automatically and return:
+For “show me the active sprint status for A4321 in Jira”, the planner should resolve the project, board, and active sprint automatically and return:
 
 ```js
 {
   resource: "sprint_issues",
-  project: "D2371",
+  project: "A4321",
   boardId: "77",
   sprintId: "123",
   transform: { type: "grouped", groupBy: "status", metric: "count" },
@@ -234,7 +234,7 @@ Fallback response shape:
 ```js
 {
   status: "fallback",
-  message: "I could not resolve the active sprint, so I used the D2371 project status breakdown instead.",
+  message: "I could not resolve the active sprint, so I used the A4321 project status breakdown instead.",
   configuration,
   chartSpec,
   resolution,
@@ -253,7 +253,7 @@ Unit tests should cover:
 - No active sprint with project-level fallback.
 - User/version resolution only when requested.
 - No secret leakage in failed discovery.
-- Planning active sprint status from “active sprint status for D2371”.
+- Planning active sprint status from “active sprint status for A4321”.
 - Planning “simple sprint summary” using prior sprint/project overrides.
 - Planning bug breakdowns, workload, stale issues, recently completed work, and release progress.
 - Planner returns `resolution`, `actions`, `rationale`, and valid chart specs.
@@ -266,7 +266,7 @@ Unit tests should cover:
 
 ## Acceptance Criteria
 
-- A user can ask “show me the active sprint status for D2371 in Jira” and get a useful preview without knowing board or sprint IDs.
+- A user can ask “show me the active sprint status for A4321 in Jira” and get a useful preview without knowing board or sprint IDs.
 - A user can ask “show me a simple sprint summary” as a follow-up and Jira reuses prior resolved context.
 - A user can ask “show bugs by priority” and get a valid Jira configuration and chart with minimal extra input.
 - Release, workload, stale, and completed-work questions produce sensible default plans.

--- a/docs/superpowers/specs/2026-05-16-jira-ai-capabilities-design.md
+++ b/docs/superpowers/specs/2026-05-16-jira-ai-capabilities-design.md
@@ -1,0 +1,276 @@
+# Jira AI Capabilities Design
+
+Date: 2026-05-16
+
+## Goal
+
+Revise the Jira source AI layer so the orchestrator can answer vague Jira questions by taking initiative, resolving missing Jira context, and returning useful previews without expecting users to know Jira board IDs, sprint IDs, account IDs, or version IDs.
+
+The Jira source should stay source-owned. The AI should plan Jira `DataRequest.configuration` objects and chart specs, not generic API routes or generic queries.
+
+## Current Gap
+
+Stripe Official exposes a semantic AI surface: source instructions, resources, metrics, dimensions, filters, compiled metrics, validation, repair, and compact preview behavior. Jira currently has a thinner planner with some hidden sprint resolution. That makes simple prompts like “show me the active sprint status for D2371” fragile because the orchestrator does not have enough structured capability information or reusable discovery behavior.
+
+## Chosen Approach
+
+Use a hybrid capability layer.
+
+Jira should expose explicit discovery capabilities, but `source_plan_dataset` should also run the common discovery path automatically. The orchestrator gets flexibility when it needs it, while straightforward vague questions still work through a single planning call.
+
+Rejected alternatives:
+
+- Planner-only: simpler orchestration, but too much opaque behavior inside one large planner.
+- Tool-only: more transparent, but produces long fragile tool chains and expects the model to sequence Jira discovery perfectly.
+
+## Architecture
+
+Jira AI should have two layers.
+
+The high-level planner remains the default path:
+
+```txt
+source_plan_dataset -> source_preview_configuration -> create_temporary_chart
+```
+
+For Jira business questions, the orchestrator should call `source_plan_dataset` first. The planner should infer intent, resolve missing Jira context, generate a configuration, and return chart bindings.
+
+The explicit discovery/actions layer should be available for follow-ups, correction flows, and advanced orchestration:
+
+- `resolveJiraContext`
+- `listProjects`
+- `listBoards`
+- `listSprints`
+- `listVersions`
+- `listUsers`
+- `listIssueTypes`
+- `listStatuses`
+- `listFields`
+- `validateJql`
+- `previewJql`
+
+Both layers should share a Jira AI resolver module so context resolution is consistent and testable.
+
+## Capability Model
+
+`getCapabilities()` should describe what Jira AI can safely build, not just that Jira has resources.
+
+It should include:
+
+- `resources`: issues, sprint issues, boards, sprints, versions, users, fields.
+- `discovery`: projects, boards, active/future/closed sprints, versions, users, issue types, statuses, priorities, custom field mappings.
+- `semanticIntents`: project overview, sprint status, sprint summary, sprint workload, bug tracking, stale work, recently completed work, release progress, assignee workload, status breakdown, priority breakdown, issue type breakdown.
+- `metrics`: issue count, story points, completion rate, completed story points, average lead time, average cycle time when data is available.
+- `dimensions`: date, status, status category, assignee, priority, issue type, project, sprint, fix version, epic/parent, label.
+- `dateFields`: createdAt, updatedAt, resolvedAt, doneAt when done-date fetching is enabled.
+- `riskPolicy`: previews may proceed with a best match; saved charts and dashboards should disambiguate meaningful uncertainty.
+
+`listResources()` should follow the Stripe Official pattern and include metrics, dimensions, filters, transforms, date fields, discovery requirements, and whether IDs can be auto-resolved.
+
+Example:
+
+```js
+{
+  id: "sprint_issues",
+  label: "Sprint issues",
+  requires: ["sprint"],
+  canAutoResolve: ["project", "board", "activeSprint"],
+  metrics: ["count", "storyPoints", "completionRate"],
+  dimensions: ["status", "statusCategory", "assignee", "priority", "issueType"],
+  transforms: ["raw", "grouped", "sprint_summary", "stale_table"],
+  dateFields: ["createdAt", "updatedAt", "resolvedAt", "doneAt"]
+}
+```
+
+## Context Resolution
+
+Add a dedicated resolver used by both the planner and explicit discovery tools.
+
+Input:
+
+```js
+{
+  question,
+  overrides,
+  intent,
+  connection,
+  mode: "preview" | "persist"
+}
+```
+
+Resolution order:
+
+1. Parse hints from the question:
+   - project keys such as `D2371`
+   - sprint state words such as active, current, latest, closed, future
+   - Jira resource words such as sprint, bug, release, workload
+   - assignee or reporter names
+   - version/release names
+   - issue type, status, and priority terms
+2. Query Jira only for missing context:
+   - exact project key lookup first
+   - project search fallback by name/key
+   - boards for the selected project
+   - sprints for selected boards
+   - versions for selected project
+   - users only when user wording exists
+   - fields only when story points, severity, team, or custom field mapping is needed
+3. Score candidates:
+   - exact project key: very high confidence
+   - one board for a project: high confidence
+   - one active sprint on a scrum board: high confidence
+   - multiple active sprints: ambiguous
+   - fuzzy user/version matches: medium unless exact display/name match
+4. Decide:
+   - Preview/show requests can proceed with the best match when confidence is acceptable.
+   - Persist/save/dashboard requests should ask when ambiguity affects saved data.
+   - No useful match should return disambiguation options that move the task forward.
+
+Resolver output:
+
+```js
+{
+  project: { key: "D2371", name: "D2371", confidence: 0.98 },
+  board: { id: 77, name: "D2371 Scrum Board", confidence: 0.86, alternatives: [] },
+  sprint: { id: 123, name: "Sprint 14", state: "active", confidence: 0.93 },
+  warnings: [],
+  needsDisambiguation: false
+}
+```
+
+## Planning Behavior
+
+Planner stages:
+
+1. Detect semantic intent.
+2. Resolve Jira context.
+3. Generate `DataRequest.configuration`.
+4. Generate chart spec bindings.
+5. Return a compact result contract.
+
+Supported intents for v1:
+
+- `sprint_status`
+- `sprint_summary`
+- `sprint_workload`
+- `team_workload`
+- `stale_issues`
+- `bug_breakdown`
+- `release_progress`
+- `completed_work`
+- `created_done_trend`
+- `issue_breakdown`
+- `issue_table`
+
+Planner result contract:
+
+```js
+{
+  status: "ok" | "fallback" | "needs_disambiguation" | "invalid",
+  source: "jira",
+  datasetName,
+  configuration,
+  chartSpec,
+  outputFields,
+  resolution,
+  actions,
+  warnings,
+  errors,
+  rationale
+}
+```
+
+The `actions` array should power quick correction options:
+
+```js
+[
+  { label: "Use a different sprint", value: "change_sprint" },
+  { label: "Break down by assignee", value: "group_by_assignee" }
+]
+```
+
+For “show me the active sprint status for D2371 in Jira”, the planner should resolve the project, board, and active sprint automatically and return:
+
+```js
+{
+  resource: "sprint_issues",
+  project: "D2371",
+  boardId: "77",
+  sprintId: "123",
+  transform: { type: "grouped", groupBy: "status", metric: "count" },
+  chartType: "bar"
+}
+```
+
+## Orchestrator Behavior
+
+The orchestrator should treat Jira as a source-owned configuration source.
+
+Rules:
+
+- Use `source_plan_dataset` first for Jira business questions.
+- Use discovery tools when a follow-up needs to inspect or correct context.
+- Do not ask for board IDs, sprint IDs, version IDs, or account IDs unless Jira cannot resolve them.
+- For low-risk previews, proceed with the best match and explain what was used.
+- For saved charts and dashboards, disambiguate meaningful uncertainty.
+- Never use `generate_query` or `run_query` for Jira source-owned configurations.
+- Treat `fallback` planner results as usable for preview and temporary chart creation.
+
+## Fallbacks
+
+Jira AI should avoid dead ends.
+
+Fallback rules:
+
+- If active sprint cannot be resolved but project can, fallback to project status breakdown or open issues by assignee.
+- If board is ambiguous, preview may choose the best scrum board when confidence is acceptable, but persisted charts should ask.
+- If sprint issue preview fails and `sprintId` is known, retry with a safer sprint issue config without extra JQL.
+- If sprint issue preview still fails, fallback to project-level JQL status breakdown.
+- If done-date fetching is needed but unavailable or too expensive, fallback to `resolutiondate` or `statusCategoryChangedDate` where possible and warn.
+- If user/version/assignee matching is ambiguous, preview may use no filter or the strongest exact match; persisted charts should ask.
+
+Fallback response shape:
+
+```js
+{
+  status: "fallback",
+  message: "I could not resolve the active sprint, so I used the D2371 project status breakdown instead.",
+  configuration,
+  chartSpec,
+  resolution,
+  actions
+}
+```
+
+## Testing
+
+Unit tests should cover:
+
+- `resolveContext` exact project key resolution.
+- Single board resolution for a project.
+- Single active sprint resolution.
+- Multiple board/sprint alternatives.
+- No active sprint with project-level fallback.
+- User/version resolution only when requested.
+- No secret leakage in failed discovery.
+- Planning active sprint status from “active sprint status for D2371”.
+- Planning “simple sprint summary” using prior sprint/project overrides.
+- Planning bug breakdowns, workload, stale issues, recently completed work, and release progress.
+- Planner returns `resolution`, `actions`, `rationale`, and valid chart specs.
+- Fallback configurations are valid and preview-safe.
+- Source tools pass preview/persist risk context.
+- Orchestrator renders disambiguation options.
+- Orchestrator never uses `run_query` for Jira.
+- Orchestrator proceeds with preview for `fallback` plans.
+- Persisted/dashboard creation asks when ambiguity is meaningful.
+
+## Acceptance Criteria
+
+- A user can ask “show me the active sprint status for D2371 in Jira” and get a useful preview without knowing board or sprint IDs.
+- A user can ask “show me a simple sprint summary” as a follow-up and Jira reuses prior resolved context.
+- A user can ask “show bugs by priority” and get a valid Jira configuration and chart with minimal extra input.
+- Release, workload, stale, and completed-work questions produce sensible default plans.
+- Ambiguity produces quick correction options instead of silent failure.
+- Jira API failures never expose auth headers or raw request objects.
+- Jira AI behavior remains source-owned and consistent with the source plugin guide.
+

--- a/server/charts/AxisChart.js
+++ b/server/charts/AxisChart.js
@@ -1018,6 +1018,7 @@ class AxisChart {
 
   /* OPERATIONS */
   operate(data, xData, xType, yType, op, yAxis, averageByTotal) {
+    const explicitOperations = ["avg", "max", "min", "sum"];
     const yData = {};
     data.map((item, index) => {
       let key = item.x;
@@ -1079,8 +1080,12 @@ class AxisChart {
           finalItem = nestedResult;
         }
       } else {
+        const shouldSumDateBucket = xType === "date"
+          && yType === "number"
+          && !explicitOperations.includes(op);
+
         finalItem = finalItem[yData[key].length - 1];
-        if (op === "sum" && yType === "number") {
+        if ((op === "sum" || shouldSumDateBucket) && yType === "number") {
           finalItem = _.reduce(yData[key], (sum, n) => {
             const value = n instanceof Object ? 0 : Number(n);
             return sum + (Number.isNaN(value) ? 0 : value);

--- a/server/controllers/AiController.js
+++ b/server/controllers/AiController.js
@@ -69,7 +69,9 @@ async function getOrchestration(
   }
 
   try {
-    const orchestration = await orchestrate(teamId, question, fullHistory, conversation, context);
+    const orchestration = await orchestrate(teamId, question, fullHistory, conversation, context, {
+      userId,
+    });
 
     // Extract title from AI response for new conversations
     let finalMessage = orchestration.message;

--- a/server/controllers/ChartTemplateController.js
+++ b/server/controllers/ChartTemplateController.js
@@ -54,6 +54,33 @@ function getChartTemplateOptions(chartTemplate) {
   }, {});
 }
 
+function normalizeVariableName(name) {
+  if (typeof name !== "string") return name;
+  const match = name.match(/^\{\{([^}]+)\}\}$/);
+  return match ? match[1].trim() : name.trim();
+}
+
+function applyVariableDefaultsToDataRequest(dataRequest, variableDefaults = {}) {
+  if (!dataRequest?.variableBindings || Object.keys(variableDefaults).length === 0) {
+    return dataRequest;
+  }
+
+  return {
+    ...dataRequest,
+    variableBindings: dataRequest.variableBindings.map((binding) => {
+      const name = normalizeVariableName(binding.name || binding.variableName || "");
+      if (variableDefaults[name] === undefined || variableDefaults[name] === null) {
+        return binding;
+      }
+
+      return {
+        ...binding,
+        default_value: variableDefaults[name],
+      };
+    }),
+  };
+}
+
 class ChartTemplateController {
   constructor() {
     this.chartController = new ChartController();
@@ -159,6 +186,7 @@ class ChartTemplateController {
 
       const datasetMapping = {};
       const selectedDatasets = template.datasets.filter((dataset) => datasetTemplateIds.includes(dataset.id));
+      const variableDefaults = data.variable_defaults || data.variableDefaults || {};
 
       const createdDatasets = await Promise.all(selectedDatasets.map(async (datasetTemplate) => {
         const dataset = await this.datasetController.createWithDataRequests({
@@ -170,7 +198,7 @@ class ChartTemplateController {
           fieldsSchema: datasetTemplate.fieldsSchema || {},
           dataRequests: [{
             ...sourcePlugin.backend.getDefaultDataRequest(),
-            ...datasetTemplate.dataRequest,
+            ...applyVariableDefaultsToDataRequest(datasetTemplate.dataRequest, variableDefaults),
             connection_id: connection.id,
           }],
           main_dr_index: 0,

--- a/server/modules/ai/orchestrator/entityCreationRules.js
+++ b/server/modules/ai/orchestrator/entityCreationRules.js
@@ -99,7 +99,7 @@ Note: Sources that declare AI query generation or source-owned AI tools in the s
 2. Create Chart with ChartDatasetConfig using quick-create (project_id, dataset_id, name, type, draft=false, chartDatasetConfigs array including xAxis/yAxis/date bindings on the CDC)
 
 **Source-owned configuration sequence:**
-1. Use source_plan_dataset to create a DataRequest.configuration and chartSpec. Do not use generate_query for configuration-based sources.
+1. Use source_plan_dataset to create a DataRequest.configuration and chartSpec. Do not use generate_query or run_query for configuration-based sources.
 2. For generic API connections, use connection AI Context first. If a recognizable provider host returns modelFallbackAllowed=true or needs_model_planning, you may use provider/API knowledge as a fallback by passing explicit method, route, pagination/body/header assumptions, and chart bindings to the create tool.
 3. Optionally use source_validate_configuration and source_preview_configuration for compact rows/warnings.
 4. For default previews, use create_temporary_chart with connection_id, name, configuration or explicit route/method, and chartSpec bindings.

--- a/server/modules/ai/orchestrator/orchestrator.js
+++ b/server/modules/ai/orchestrator/orchestrator.js
@@ -22,6 +22,8 @@ const { isCapabilityQuestion, generateCapabilityResponse } = require("./capabili
 const {
   formatSupportedSourceBullets,
   formatSupportedSourceList,
+  getQueryGenerationDialectIds,
+  getQueryGenerationSourceIds,
   getSupportedDialectIds,
   getSupportedSourceIds,
   getSupportedSourceForConnection,
@@ -63,6 +65,9 @@ const {
   sourcePlanDataset,
   sourcePreviewConfiguration,
   sourceRecommendTemplates,
+  sourceResolveContext,
+  sourceRunAction,
+  sourceSearchRecords,
   sourceValidateConfiguration,
   stripeOfficialPlanDataset,
   stripeOfficialPreviewConfiguration,
@@ -92,6 +97,9 @@ const TEAM_SCOPED_TOOLS = new Set([
   "source_get_sample_data",
   "source_list_templates",
   "source_recommend_templates",
+  "source_resolve_context",
+  "source_run_action",
+  "source_search_records",
   "source_plan_dataset",
   "source_validate_configuration",
   "source_preview_configuration",
@@ -108,6 +116,8 @@ const ORIGINAL_QUESTION_TOOLS = new Set([
   "create_dataset",
   "create_chart",
   "create_temporary_chart",
+  "source_resolve_context",
+  "source_search_records",
   "source_plan_dataset",
   "stripe_official_plan_dataset",
 ]);
@@ -116,6 +126,8 @@ async function availableTools() {
   const supportedSourceList = formatSupportedSourceList();
   const supportedDialectIds = getSupportedDialectIds();
   const supportedSourceIds = getSupportedSourceIds();
+  const queryGenerationDialectIds = getQueryGenerationDialectIds();
+  const queryGenerationSourceIds = getQueryGenerationSourceIds();
 
   return [
     {
@@ -215,6 +227,23 @@ async function availableTools() {
       }
     },
     {
+      name: "source_resolve_context",
+      displayName: "Resolve source context",
+      description: "Resolve source-owned business context such as Jira projects, boards, sprints, versions, and users without asking for raw IDs. Use this for corrections, follow-ups, or explicit context inspection.",
+      parameters: {
+        type: "object",
+        properties: {
+          source_id: { type: "string", enum: supportedSourceIds },
+          connection_id: { type: "string" },
+          question: { type: "string" },
+          intent: { type: "object" },
+          overrides: { type: "object" },
+          mode: { type: "string", enum: ["preview", "persist"], default: "preview" }
+        },
+        required: ["connection_id", "question"]
+      }
+    },
+    {
       name: "source_plan_dataset",
       displayName: "Plan dataset",
       description: "Plan a source-owned DataRequest configuration and chart bindings from a natural-language request. Use this for configuration-based sources instead of generate_query.",
@@ -223,7 +252,44 @@ async function availableTools() {
         properties: {
           connection_id: { type: "string" },
           question: { type: "string" },
-          overrides: { type: "object", description: "Optional explicit source configuration overrides such as date range, filters, pagination, metric, dimension, mode, or resource." }
+          overrides: { type: "object", description: "Optional explicit source configuration overrides such as date range, filters, pagination, metric, dimension, or resource." },
+          mode: { type: "string", enum: ["preview", "persist"], default: "preview", description: "Use preview for temporary exploration. Use persist before creating saved datasets, charts, or dashboards so the source can request disambiguation instead of guessing IDs." }
+        },
+        required: ["connection_id", "question"]
+      }
+    },
+    {
+      name: "source_run_action",
+      displayName: "Run source action",
+      description: "Run a bounded source-owned metadata action such as Jira listUsers, listProjects, listBoards, listSprints, listVersions, validateJql, or previewJql. Use this to inspect source context without asking users for raw IDs.",
+      parameters: {
+        type: "object",
+        properties: {
+          source_id: { type: "string", enum: supportedSourceIds },
+          connection_id: { type: "string" },
+          action: { type: "string" },
+          params: { type: "object" },
+          row_limit: { type: "integer", default: 25 }
+        },
+        required: ["connection_id", "action"]
+      }
+    },
+    {
+      name: "source_search_records",
+      displayName: "Search source records",
+      description: "Search compact source-owned records for answer-first questions without creating a dataset. For Jira, use this for issue tables such as open issues by assignee, blockers, active sprint issues, and similar small result sets.",
+      parameters: {
+        type: "object",
+        properties: {
+          source_id: { type: "string", enum: supportedSourceIds },
+          connection_id: { type: "string" },
+          question: { type: "string" },
+          resource: { type: "string" },
+          filters: { type: "object" },
+          jql: { type: "string" },
+          fields: { type: "array", items: { type: "string" } },
+          overrides: { type: "object" },
+          row_limit: { type: "integer", default: 25 }
         },
         required: ["connection_id", "question"]
       }
@@ -305,9 +371,9 @@ async function availableTools() {
         properties: {
           question: { type: "string" },
           schema: { type: "object" }, // database schema from get_schema
-          source_id: { type: "string", enum: supportedSourceIds },
+          source_id: { type: "string", enum: queryGenerationSourceIds },
           hints: { type: "object" }, // optional project-level entity hints
-          preferred_dialect: { type: "string", enum: supportedDialectIds } // supported source ids/types/subtypes
+          preferred_dialect: { type: "string", enum: queryGenerationDialectIds } // supported source ids/types/subtypes
         },
         required: ["question"]
       }
@@ -733,8 +799,14 @@ async function callTool(name, payload) {
         return sourceListTemplates(payload);
       case "source_recommend_templates":
         return sourceRecommendTemplates(payload);
+      case "source_resolve_context":
+        return sourceResolveContext(payload);
       case "source_plan_dataset":
         return sourcePlanDataset(payload);
+      case "source_run_action":
+        return sourceRunAction(payload);
+      case "source_search_records":
+        return sourceSearchRecords(payload);
       case "source_validate_configuration":
         return sourceValidateConfiguration(payload);
       case "source_preview_configuration":
@@ -842,7 +914,10 @@ ${ENTITY_CREATION_RULES}
      * **DEFAULT: Always create a temporary preview chart to show the results visually**
    - For source-owned configuration connections:
      * Call source_get_capabilities or source_list_resources when you need source context
-     * Call source_plan_dataset with the user's business question. Do not invent API routes or configuration fields.
+     * Use source_resolve_context when a Jira follow-up needs to inspect or correct project, board, sprint, version, or user context.
+     * Use source_run_action for bounded Jira metadata lookups such as users, projects, boards, sprints, versions, or JQL validation.
+     * Use source_search_records for answer-first Jira issue lists before creating datasets. This is preferred for prompts like "what is Raz working on", "show open issues assigned to X", "show blockers", or "what is in the active sprint".
+     * Call source_plan_dataset with the user's business question. Use mode="preview" for exploration or temporary charts, and mode="persist" before saved datasets, saved charts, or dashboards so ambiguous source context can be clarified. Do not invent API routes or configuration fields.
      * For generic API connections: prefer source AI Context. If the source identifies a recognizable provider and returns status="needs_model_planning" or modelFallbackAllowed=true, you may use your provider/API knowledge as a fallback. In that case, call create_temporary_chart/create_dataset with explicit method, route, itemsLimit, pagination/body/header assumptions, and chart bindings. Do not use provider memory for unknown hosts.
      * Call source_validate_configuration or source_preview_configuration when you need validation, compact rows, or warnings before answering
      * For charts, pass the planned configuration to create_temporary_chart by default

--- a/server/modules/ai/orchestrator/orchestrator.js
+++ b/server/modules/ai/orchestrator/orchestrator.js
@@ -15,6 +15,7 @@
 const OpenAI = require("openai");
 const db = require("../../../models/models");
 const socketManager = require("../../socketManager");
+const { sanitizeSnippet } = require("../../updateAudit");
 const { emitProgressEvent, parseProgressEvents } = require("./responseParser");
 const { ENTITY_CREATION_RULES } = require("./entityCreationRules");
 const { isCapabilityQuestion, generateCapabilityResponse } = require("./capabilityHandler");
@@ -52,6 +53,7 @@ const {
   updateDataset,
   updateChart,
   createTemporaryChart,
+  createDashboardFromTemplate,
   moveChartToDashboard,
   disambiguate,
   sourceGetCapabilities,
@@ -83,6 +85,7 @@ const TEAM_SCOPED_TOOLS = new Set([
   "update_dataset",
   "update_chart",
   "create_temporary_chart",
+  "create_dashboard_from_template",
   "move_chart_to_dashboard",
   "source_get_capabilities",
   "source_list_resources",
@@ -95,6 +98,10 @@ const TEAM_SCOPED_TOOLS = new Set([
   "stripe_official_plan_dataset",
   "stripe_official_validate_configuration",
   "stripe_official_preview_configuration",
+]);
+
+const USER_SCOPED_TOOLS = new Set([
+  "create_dashboard_from_template",
 ]);
 
 const ORIGINAL_QUESTION_TOOLS = new Set([
@@ -329,14 +336,14 @@ async function availableTools() {
     {
       name: "run_query",
       displayName: "Run query",
-      description: `Execute read-only source queries on supported connections (${supportedSourceList}) with guardrails.`,
+      description: `Execute read-only source queries on query-generation connections (${supportedSourceList}) with guardrails. Do not use this for source-owned configuration sources; use source_preview_configuration instead.`,
       parameters: {
         type: "object",
         properties: {
           connection_id: { type: "string" },
           dialect: { type: "string", enum: supportedDialectIds },
           query: { type: "string", description: "Read-only query for query-based sources" },
-          configuration: { type: "object", description: "Configuration for source-owned non-query execution" },
+          configuration: { type: "object", description: "Legacy only. Do not pass source-owned configurations; use source_preview_configuration instead." },
           params: { type: "object" },
           row_limit: { type: "integer", default: 1000 },
           timeout_ms: { type: "integer", default: 8000 },
@@ -622,6 +629,34 @@ async function availableTools() {
       // }
     },
     {
+      name: "create_dashboard_from_template",
+      displayName: "Create dashboard from template",
+      description: "Create a full dashboard/project from a source-owned template bundle. This is generic across template-backed sources. Use only when the user asks to create a full dashboard, dashboard bundle, or starter dashboard; use create_temporary_chart for one-off charts.",
+      parameters: {
+        type: "object",
+        properties: {
+          source_id: { type: "string", enum: supportedSourceIds, description: "Source plugin id that owns the template, for example jira or stripeOfficial" },
+          template_slug: { type: "string", description: "Template slug from source_list_templates or source_recommend_templates" },
+          connection_id: { type: "string", description: `Connection ID to use for data fetching (must be one of: ${supportedSourceList})` },
+          dashboard: {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["new", "existing"] },
+              name: { type: "string", description: "Name for a new dashboard" },
+              project_id: { type: "string", description: "Existing dashboard/project ID" }
+            },
+            required: ["type"],
+            description: "Destination dashboard. Use type=new with a name when creating a new dashboard, or type=existing with project_id when the user names an existing dashboard."
+          },
+          dataset_template_ids: { type: "array", items: { type: "string" }, description: "Optional selected dataset template ids. Omit to create all datasets in the template." },
+          chart_template_ids: { type: "array", items: { type: "string" }, description: "Optional selected chart template ids. Omit to create all charts in the template." },
+          variable_defaults: { type: "object", description: "Default values for template variable bindings, for example { projects: 'CHART', sprint_id: '123' } for Jira templates." }
+        },
+        required: ["source_id", "template_slug", "connection_id", "dashboard"]
+      }
+      // returns: { project_id, dashboard_url, datasets, charts }
+    },
+    {
       name: "move_chart_to_dashboard",
       displayName: "Add chart to dashboard",
       description: "Move a temporary chart from the ghost project to a real dashboard/project. Use this after creating a temporary chart when the user confirms they want to add it to a specific dashboard. The chart's layout will be automatically recalculated for the new dashboard.",
@@ -682,6 +717,8 @@ async function callTool(name, payload) {
         return updateChart(payload);
       case "create_temporary_chart":
         return createTemporaryChart(payload);
+      case "create_dashboard_from_template":
+        return createDashboardFromTemplate(payload);
       case "move_chart_to_dashboard":
         return moveChartToDashboard(payload);
       case "disambiguate":
@@ -712,8 +749,12 @@ async function callTool(name, payload) {
         throw new Error(`Tool ${name} not found`);
     }
   } catch (error) {
-    throw new Error(`Tool ${name} execution failed: ${error.message}`);
+    throw new Error(`Tool ${name} execution failed: ${sanitizeToolError(error)}`);
   }
+}
+
+function sanitizeToolError(error) {
+  return sanitizeSnippet(error?.message || error || "Tool execution failed", 1000) || "Tool execution failed";
 }
 
 function buildSystemPrompt(semanticLayer, conversation = null) {
@@ -771,6 +812,7 @@ ${ENTITY_CREATION_RULES}
 - Execute source queries and summarize results
 - Suggest appropriate chart types for data
 - Create datasets and charts in projects
+- Create full dashboards from source-owned template bundles when the user asks for a starter dashboard or dashboard pack
 - Create temporary charts when no project is specified, then move them to dashboards upon user confirmation
 - Inform users when they request unsupported data sources that these will be available when the corresponding source plugin declares AI query support
 - Only suggest actions that correspond to these tools - no exports, sharing features, or other unimplemented functionality
@@ -804,10 +846,11 @@ ${ENTITY_CREATION_RULES}
      * For generic API connections: prefer source AI Context. If the source identifies a recognizable provider and returns status="needs_model_planning" or modelFallbackAllowed=true, you may use your provider/API knowledge as a fallback. In that case, call create_temporary_chart/create_dataset with explicit method, route, itemsLimit, pagination/body/header assumptions, and chart bindings. Do not use provider memory for unknown hosts.
      * Call source_validate_configuration or source_preview_configuration when you need validation, compact rows, or warnings before answering
      * For charts, pass the planned configuration to create_temporary_chart by default
+     * For full dashboard requests, call source_recommend_templates or source_list_templates, then create_dashboard_from_template with a source-owned template slug
      * If the user explicitly names a dashboard/project, create the dataset with create_dataset and then place the chart with create_chart using the planned chartSpec bindings
      * If a source tool returns status="needs_more_context" without modelFallbackAllowed, stop the creation flow and guide the user with the tool message. If editConnectionUrl is present, include it as a markdown link. If contextInstructions or exampleAiContext are present, summarize exactly what to paste.
      * If a chart creation tool returns chart_created=true and snapshot_status="unavailable", say the chart was created and mention only that the rendered preview is not available yet. Do not describe that as a failed or blocked chart.
-     * Never use generate_query for configuration-based sources
+     * Never use generate_query or run_query for configuration-based sources
 
 2. When creating charts - CRITICAL CHART PLACEMENT RULES:
    
@@ -1228,6 +1271,25 @@ function buildFallbackAssistantMessage({ toolResults = [], snapshots = [] } = {}
   return "I completed the requested action, but I could not generate a final text response. Please try again or rephrase the request.";
 }
 
+function buildDisambiguationAssistantMessage({ prompt, options = [] } = {}) {
+  const suggestions = options.map((option, index) => ({
+    id: String(option.value || option.id || `option_${index + 1}`),
+    label: option.label || option.value || `Option ${index + 1}`,
+    action: "reply",
+  }));
+
+  return [
+    prompt || "I need one more choice before I can continue.",
+    "",
+    "```cb-actions",
+    JSON.stringify({
+      version: 1,
+      suggestions,
+    }, null, 2),
+    "```",
+  ].join("\n");
+}
+
 function buildUsageRecordFromResponse(response, elapsedMs, model) {
   if (!response?.usage) {
     return null;
@@ -1348,7 +1410,7 @@ async function orchestrate(
   teamId, question, conversationHistory = [], conversation = null, context = null, options = {}
 ) {
   // Extract optional tool progress callback
-  const { toolProgressCallback } = options;
+  const { toolProgressCallback, userId } = options;
   if (!openaiClient) {
     throw new Error("OpenAI client is not initialized. Please check your environment variables.");
   }
@@ -1510,6 +1572,9 @@ async function orchestrate(
         if (TEAM_SCOPED_TOOLS.has(toolName)) {
           toolArgs.team_id = teamId;
         }
+        if (USER_SCOPED_TOOLS.has(toolName)) {
+          toolArgs.user_id = userId;
+        }
         if (ORIGINAL_QUESTION_TOOLS.has(toolName)) {
           toolArgs.original_question = question;
         }
@@ -1561,10 +1626,12 @@ async function orchestrate(
             content: JSON.stringify(result)
           };
         } catch (error) {
+          const safeError = sanitizeToolError(error);
+
           // Call progress callback on error
           if (toolProgressCallback) {
             try {
-              await toolProgressCallback(toolName, "error", { error: error.message });
+              await toolProgressCallback(toolName, "error", { error: safeError });
             } catch (callbackError) {
               // oxlint-disable-next-line no-console
               console.error("Tool progress callback error:", callbackError);
@@ -1576,8 +1643,7 @@ async function orchestrate(
             role: "tool",
             name: toolName,
             content: JSON.stringify({
-              error: error.message,
-              stack: error.stack
+              error: safeError
             })
           };
         }
@@ -1611,10 +1677,18 @@ async function orchestrate(
           }
         }).content
       );
+      const disambiguationMessage = buildDisambiguationAssistantMessage({
+        prompt: disambiguationRequest.prompt,
+        options: disambiguationRequest.options,
+      });
+      persistedMessages.push({
+        role: "assistant",
+        content: disambiguationMessage,
+      });
 
       return {
         needs_user_input: true,
-        message: disambiguationRequest.prompt || "I need one more choice before I can continue.",
+        message: disambiguationMessage,
         prompt: disambiguationRequest.prompt,
         options: disambiguationRequest.options,
         conversationHistory: persistedMessages,
@@ -1680,6 +1754,8 @@ module.exports = {
   buildSemanticLayer,
   buildResponseInputFromMessages,
   buildAssistantMessageFromResponse,
+  buildDisambiguationAssistantMessage,
   buildFallbackAssistantMessage,
+  sanitizeToolError,
   buildUsageRecordFromResponse,
 };

--- a/server/modules/ai/orchestrator/sourceSupport.js
+++ b/server/modules/ai/orchestrator/sourceSupport.js
@@ -5,23 +5,29 @@ const {
 } = require("../../../sources");
 const { isSourceServerEnabled } = require("../../../sources/sourceAvailability");
 
-function sourceSupportsOrchestrator(source) {
-  const supportsQueryGeneration = Boolean(
+function sourceSupportsQueryGeneration(source) {
+  return Boolean(
     source?.capabilities?.data?.supportsQuery
     && source?.capabilities?.ai?.canGenerateQueries
     && source?.backend?.runDataRequest
     && source?.backend?.ai?.generateQuery
   );
-  const supportsSourceTools = Boolean(
+}
+
+function sourceSupportsSourceTools(source) {
+  return Boolean(
     source?.capabilities?.ai?.hasTools
     && source?.backend?.runDataRequest
     && source?.backend?.ai
   );
 
+}
+
+function sourceSupportsOrchestrator(source) {
   return Boolean(
     source
     && isSourceServerEnabled(source)
-    && (supportsQueryGeneration || supportsSourceTools)
+    && (sourceSupportsQueryGeneration(source) || sourceSupportsSourceTools(source))
   );
 }
 
@@ -37,6 +43,12 @@ function getOrchestratorSources() {
   return getSources().filter(sourceSupportsOrchestrator);
 }
 
+function getQueryGenerationSources() {
+  return getSources().filter((source) => {
+    return source && isSourceServerEnabled(source) && sourceSupportsQueryGeneration(source);
+  });
+}
+
 function getSupportedConnectionTypes() {
   return [...new Set(getOrchestratorSources().map((source) => source.type))];
 }
@@ -45,8 +57,20 @@ function getSupportedSourceIds() {
   return getOrchestratorSources().map((source) => source.id);
 }
 
+function getQueryGenerationSourceIds() {
+  return getQueryGenerationSources().map((source) => source.id);
+}
+
 function getSupportedDialectIds() {
   return [...new Set(getOrchestratorSources().flatMap((source) => [
+    source.id,
+    source.type,
+    source.subType,
+  ].filter(Boolean)))];
+}
+
+function getQueryGenerationDialectIds() {
+  return [...new Set(getQueryGenerationSources().flatMap((source) => [
     source.id,
     source.type,
     source.subType,
@@ -108,6 +132,9 @@ module.exports = {
   formatSupportedSourceBullets,
   formatSupportedSourceList,
   getOrchestratorSources,
+  getQueryGenerationDialectIds,
+  getQueryGenerationSourceIds,
+  getQueryGenerationSources,
   getSourceByDialect,
   getSupportedConnectionTypes,
   getSupportedDialectIds,
@@ -116,6 +143,8 @@ module.exports = {
   isConnectionSupported,
   requireSourceById,
   requireSupportedSourceForConnection,
+  sourceSupportsQueryGeneration,
+  sourceSupportsSourceTools,
   sourceUsesSourceOwnedConfiguration,
   sourceSupportsOrchestrator,
 };

--- a/server/modules/ai/orchestrator/sourceSupport.js
+++ b/server/modules/ai/orchestrator/sourceSupport.js
@@ -25,6 +25,14 @@ function sourceSupportsOrchestrator(source) {
   );
 }
 
+function sourceUsesSourceOwnedConfiguration(source) {
+  return Boolean(
+    source?.capabilities?.ai?.hasTools
+    && source?.backend?.ai
+    && !source?.capabilities?.ai?.canGenerateQueries
+  );
+}
+
 function getOrchestratorSources() {
   return getSources().filter(sourceSupportsOrchestrator);
 }
@@ -108,5 +116,6 @@ module.exports = {
   isConnectionSupported,
   requireSourceById,
   requireSupportedSourceForConnection,
+  sourceUsesSourceOwnedConfiguration,
   sourceSupportsOrchestrator,
 };

--- a/server/modules/ai/orchestrator/tools/createDashboardFromTemplate.js
+++ b/server/modules/ai/orchestrator/tools/createDashboardFromTemplate.js
@@ -1,0 +1,62 @@
+const ChartTemplateController = require("../../../../controllers/ChartTemplateController");
+const { normalizeTeamId } = require("./teamScope");
+
+const chartTemplateController = new ChartTemplateController();
+const clientUrl = process.env.NODE_ENV === "production" ? process.env.VITE_APP_CLIENT_HOST : process.env.VITE_APP_CLIENT_HOST_DEV;
+
+async function createDashboardFromTemplate(payload) {
+  const {
+    team_id,
+    user_id,
+    source_id,
+    template_slug,
+    connection_id,
+    dashboard = {},
+    dataset_template_ids,
+    chart_template_ids,
+    variable_defaults,
+  } = payload;
+
+  if (!team_id) {
+    throw new Error("team_id is required to create a dashboard from a template");
+  }
+  if (!user_id) {
+    throw new Error("user_id is required to create a dashboard from a template");
+  }
+  if (!source_id) {
+    throw new Error("source_id is required to create a dashboard from a template");
+  }
+  if (!template_slug) {
+    throw new Error("template_slug is required to create a dashboard from a template");
+  }
+  if (!connection_id) {
+    throw new Error("connection_id is required to create a dashboard from a template");
+  }
+
+  const result = await chartTemplateController.createFromTemplate(
+    normalizeTeamId(team_id),
+    source_id,
+    template_slug,
+    {
+      connection_id,
+      dashboard,
+      dataset_template_ids,
+      chart_template_ids,
+      variable_defaults,
+    },
+    { id: Number(user_id) },
+  );
+
+  return {
+    status: "ok",
+    dashboard_created: true,
+    source: source_id,
+    template_slug,
+    project_id: result.project_id,
+    dashboard_url: `${clientUrl}/dashboard/${result.project_id}`,
+    datasets: result.datasets,
+    charts: result.charts,
+  };
+}
+
+module.exports = createDashboardFromTemplate;

--- a/server/modules/ai/orchestrator/tools/generateQuery.js
+++ b/server/modules/ai/orchestrator/tools/generateQuery.js
@@ -1,4 +1,9 @@
-const { getSourceByDialect, requireSourceById } = require("../sourceSupport");
+const {
+  getSourceByDialect,
+  requireSourceById,
+  sourceSupportsQueryGeneration,
+  sourceUsesSourceOwnedConfiguration,
+} = require("../sourceSupport");
 
 async function getSourceInstructions(source) {
   if (source.backend?.ai?.getCapabilities) {
@@ -46,7 +51,7 @@ async function generateQuery(payload) {
       ? requireSourceById(source_id)
       : getSourceByDialect(preferred_dialect || schema?.source_id);
 
-    if (!source?.backend?.ai?.generateQuery) {
+    if (sourceUsesSourceOwnedConfiguration(source) || !sourceSupportsQueryGeneration(source)) {
       throw new Error(`No AI query generator is available for '${preferred_dialect || source_id || "unknown"}'`);
     }
     const sourceInstructions = await getSourceInstructions(source);

--- a/server/modules/ai/orchestrator/tools/index.js
+++ b/server/modules/ai/orchestrator/tools/index.js
@@ -21,6 +21,9 @@ const {
   sourcePlanDataset,
   sourcePreviewConfiguration,
   sourceRecommendTemplates,
+  sourceResolveContext,
+  sourceRunAction,
+  sourceSearchRecords,
   sourceValidateConfiguration,
 } = require("./sourceTools");
 const {
@@ -53,6 +56,9 @@ module.exports = {
   sourcePlanDataset,
   sourcePreviewConfiguration,
   sourceRecommendTemplates,
+  sourceResolveContext,
+  sourceRunAction,
+  sourceSearchRecords,
   sourceValidateConfiguration,
   stripeOfficialPlanDataset,
   stripeOfficialPreviewConfiguration,

--- a/server/modules/ai/orchestrator/tools/index.js
+++ b/server/modules/ai/orchestrator/tools/index.js
@@ -10,6 +10,7 @@ const createChart = require("./createChart");
 const updateDataset = require("./updateDataset");
 const updateChart = require("./updateChart");
 const createTemporaryChart = require("./createTemporaryChart");
+const createDashboardFromTemplate = require("./createDashboardFromTemplate");
 const moveChartToDashboard = require("./moveChartToDashboard");
 const disambiguate = require("./disambiguate");
 const {
@@ -42,6 +43,7 @@ module.exports = {
   updateDataset,
   updateChart,
   createTemporaryChart,
+  createDashboardFromTemplate,
   moveChartToDashboard,
   disambiguate,
   sourceGetCapabilities,

--- a/server/modules/ai/orchestrator/tools/runQuery.js
+++ b/server/modules/ai/orchestrator/tools/runQuery.js
@@ -1,6 +1,9 @@
 const db = require("../../../../models/models");
 const drCacheController = require("../../../../controllers/DataRequestCacheController");
-const { requireSupportedSourceForConnection } = require("../sourceSupport");
+const {
+  requireSupportedSourceForConnection,
+  sourceUsesSourceOwnedConfiguration,
+} = require("../sourceSupport");
 const { normalizeTeamId, requireConnectionForTeam } = require("./teamScope");
 
 async function runQuery(payload) {
@@ -22,6 +25,10 @@ async function runQuery(payload) {
 
     if (!query && !isConfigurationRequest) {
       throw new Error("query or configuration is required");
+    }
+
+    if (sourceUsesSourceOwnedConfiguration(source)) {
+      throw new Error(`${source.name} uses source-owned configuration tools. Use source_preview_configuration for previews and create_temporary_chart for charts instead of run_query.`);
     }
 
     // Add LIMIT clause if not present to respect row_limit

--- a/server/modules/ai/orchestrator/tools/sourceTools.js
+++ b/server/modules/ai/orchestrator/tools/sourceTools.js
@@ -34,6 +34,20 @@ function requireAiTool(source, toolName) {
   return tool;
 }
 
+function requireSourceAction(source, actionName) {
+  const allowedActions = source.capabilities?.actions || [];
+  if (!allowedActions.includes(actionName)) {
+    throw new Error(`${source.name} does not expose source action '${actionName}'`);
+  }
+
+  const action = source.backend?.actions?.[actionName];
+  if (typeof action !== "function") {
+    throw new Error(`${source.name} action '${actionName}' is not available`);
+  }
+
+  return action;
+}
+
 function mergeQuestionContext(question, originalQuestion) {
   if (!originalQuestion || originalQuestion === question) {
     return question;
@@ -96,6 +110,7 @@ async function sourcePlanDataset(payload) {
     connection,
     question: mergeQuestionContext(payload.question, payload.original_question),
     overrides: payload.overrides || {},
+    mode: payload.mode || "preview",
   });
 
   if (result?.status === "needs_disambiguation") {
@@ -108,6 +123,72 @@ async function sourcePlanDataset(payload) {
   }
 
   return result;
+}
+
+async function sourceResolveContext(payload) {
+  const { connection, source } = await getScopedSource(payload);
+  const tool = requireAiTool(source, "resolveContext");
+
+  const result = await tool({
+    connection,
+    question: mergeQuestionContext(payload.question, payload.original_question),
+    overrides: payload.overrides || {},
+    intent: payload.intent || {},
+    mode: payload.mode || "preview",
+  });
+
+  if (result?.resolution?.needsDisambiguation === true) {
+    return {
+      ...result,
+      needs_user_input: true,
+      prompt: result.resolution.message || "Choose an option before I continue.",
+      options: Array.isArray(result.resolution.options) ? result.resolution.options : [],
+    };
+  }
+
+  return result;
+}
+
+async function sourceRunAction(payload) {
+  const { connection, source } = await getScopedSource(payload);
+  const action = requireSourceAction(source, payload.action);
+  const result = await action({
+    connection,
+    params: payload.params || {},
+  });
+  const rows = Array.isArray(result) ? result : (result?.values || result?.rows || result?.issues || []);
+
+  if (Array.isArray(rows)) {
+    const rowLimit = Math.min(Number(payload.row_limit || payload.params?.maxResults || 25), 50);
+    return {
+      source: source.id,
+      action: payload.action,
+      rows: rows.slice(0, rowLimit),
+      rowCount: rows.length,
+    };
+  }
+
+  return {
+    source: source.id,
+    action: payload.action,
+    result,
+  };
+}
+
+async function sourceSearchRecords(payload) {
+  const { connection, source } = await getScopedSource(payload);
+  const tool = requireAiTool(source, "searchRecords");
+
+  return tool({
+    connection,
+    question: mergeQuestionContext(payload.question, payload.original_question),
+    resource: payload.resource,
+    filters: payload.filters || {},
+    jql: payload.jql,
+    fields: payload.fields,
+    rowLimit: payload.row_limit,
+    overrides: payload.overrides || {},
+  });
 }
 
 async function sourceValidateConfiguration(payload) {
@@ -136,5 +217,8 @@ module.exports = {
   sourcePlanDataset,
   sourcePreviewConfiguration,
   sourceRecommendTemplates,
+  sourceResolveContext,
+  sourceRunAction,
+  sourceSearchRecords,
   sourceValidateConfiguration,
 };

--- a/server/modules/updateAudit.js
+++ b/server/modules/updateAudit.js
@@ -70,6 +70,7 @@ function redactScalar(value) {
 
   return value
     .replace(/Bearer\s+[A-Za-z0-9\-._~+/]+=*/gi, "Bearer [REDACTED]")
+    .replace(/Basic\s+[A-Za-z0-9\-._~+/]+=*/gi, "Basic [REDACTED]")
     .replace(/(token|password|secret|apikey|api_key)=([^&\s]+)/gi, "$1=[REDACTED]");
 }
 

--- a/server/sources/index.js
+++ b/server/sources/index.js
@@ -5,6 +5,7 @@ const clickhouse = require("./plugins/clickhouse/clickhouse.plugin");
 const customerio = require("./plugins/customerio/customerio.plugin");
 const firestore = require("./plugins/firestore/firestore.plugin");
 const googleAnalytics = require("./plugins/googleAnalytics/googleAnalytics.plugin");
+const jira = require("./plugins/jira/jira.plugin");
 const mongodb = require("./plugins/mongodb/mongodb.plugin");
 const mysql = require("./plugins/mysql/mysql.plugin");
 const postgres = require("./plugins/postgres/postgres.plugin");
@@ -23,6 +24,7 @@ const sources = [
   customerio,
   firestore,
   googleAnalytics,
+  jira,
   mongodb,
   mysql,
   postgres,

--- a/server/sources/plugins/jira/ai/jira.ai.js
+++ b/server/sources/plugins/jira/ai/jira.ai.js
@@ -1,7 +1,7 @@
 const moment = require("moment-timezone");
 
-const jiraConnection = require("../jira.connection");
 const jiraProtocol = require("../jira.protocol");
+const jiraResolver = require("./jira.resolver");
 const { DEFAULT_FIELDS, JIRA_RESOURCES } = require("../jira.resources");
 
 const SOURCE_ID = "jira";
@@ -34,6 +34,29 @@ const SOURCE_INSTRUCTIONS = [
   "For Jira follow-ups, reuse previously resolved sprintId, boardId, and project key as source_plan_dataset overrides when they are visible in prior tool results.",
 ].join("\n");
 
+const DISCOVERY_TARGETS = [
+  "projects",
+  "boards",
+  "sprints",
+  "versions",
+  "users",
+  "fields",
+];
+
+const SEMANTIC_INTENTS = [
+  "sprint_status",
+  "sprint_summary",
+  "bug_breakdown",
+  "release_progress",
+  "team_workload",
+  "created_resolved_trend",
+  "stale_issues",
+];
+
+function uniqueResourceValues(field) {
+  return Array.from(new Set(Object.values(JIRA_RESOURCES).flatMap((resource) => resource[field] || [])));
+}
+
 function getCapabilities() {
   return {
     source: SOURCE_ID,
@@ -46,6 +69,16 @@ function getCapabilities() {
       pagination: true,
       templates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
       chartPlacement: true,
+      directRecordSearch: true,
+      discovery: DISCOVERY_TARGETS,
+      semanticIntents: SEMANTIC_INTENTS,
+      metrics: uniqueResourceValues("metrics"),
+      dimensions: uniqueResourceValues("dimensions"),
+      dateFields: uniqueResourceValues("dateFields"),
+      riskPolicy: {
+        preview: "best_match",
+        persist: "disambiguate_meaningful_uncertainty",
+      },
     },
     caveats: [
       "Jira Cloud API tokens are supported for v1; OAuth is intentionally excluded.",
@@ -66,7 +99,13 @@ function listResources() {
       supportedModes: id === "issues" || id === "sprint_issues"
         ? ["visual", "jql", "advanced"]
         : ["advanced"],
-      transforms: getTransformsForResource(id),
+      metrics: resource.metrics || [],
+      dimensions: resource.dimensions || [],
+      filters: resource.filters || [],
+      transforms: resource.transforms || getTransformsForResource(id),
+      dateFields: resource.dateFields || [],
+      requires: resource.requires || [],
+      canAutoResolve: resource.canAutoResolve || [],
     })),
   };
 }
@@ -154,6 +193,14 @@ function normalizeDateRange(question, overrides = {}) {
   };
 }
 
+function hasExplicitDateRange(question = "", overrides = {}) {
+  const normalizedQuestion = question.toLowerCase();
+  return Boolean(overrides.dateRange)
+    || normalizedQuestion.includes("last month")
+    || normalizedQuestion.includes("today")
+    || /last\s+\d+\s+days?/.test(normalizedQuestion);
+}
+
 function quoteList(values) {
   const list = Array.isArray(values) ? values : [values];
   return list
@@ -171,18 +218,21 @@ function buildJql({ question = "", overrides = {}, intent = {} } = {}) {
 
   const normalizedQuestion = question.toLowerCase();
   const dateRange = normalizeDateRange(question, overrides);
-  const projectValue = overrides.projects || overrides.project || extractProjectKey(question, overrides) || "{{projects}}";
+  const shouldSkipDefaultDateWindow = (intent.skipDefaultDateWindow || overrides.skipDefaultDateRange || overrides.skipDefaultDateWindow)
+    && !hasExplicitDateRange(question, overrides);
+  const projectValue = overrides.projects || overrides.project || extractProjectKey(question, overrides);
   const clauses = [];
 
   if (projectValue) clauses.push(`project IN (${quoteList(projectValue)})`);
   if (intent.issueType || overrides.issueType) clauses.push(`issuetype = ${quoteList(intent.issueType || overrides.issueType)}`);
   if (overrides.statusCategory) clauses.push(`statusCategory = ${quoteList(overrides.statusCategory)}`);
+  if (intent.statusCategoryNotDone || overrides.statusCategoryNotDone) clauses.push("statusCategory != Done");
   if (overrides.status) clauses.push(`status = ${quoteList(overrides.status)}`);
   if (overrides.assignee) clauses.push(`assignee IN (${quoteList(overrides.assignee)})`);
   if (overrides.priority || intent.priority) clauses.push(`priority IN (${quoteList(overrides.priority || intent.priority)})`);
   if (overrides.fixVersion) clauses.push(`fixVersion IN (${quoteList(overrides.fixVersion)})`);
-  if (intent.resource === "sprint_issues") {
-    // Sprint endpoint already scopes the issues. Avoid introducing date variables unless asked explicitly.
+  if (intent.resource === "sprint_issues" || shouldSkipDefaultDateWindow) {
+    // Some scoped Jira requests should not get default date variables unless asked explicitly.
   } else if (normalizedQuestion.includes("completed") || normalizedQuestion.includes("resolved")) {
     clauses.push(`resolutiondate >= ${dateRange.start}`);
     clauses.push(`resolutiondate <= ${dateRange.end}`);
@@ -201,31 +251,85 @@ function buildJql({ question = "", overrides = {}, intent = {} } = {}) {
   return `${clauses.join(" AND ")} ORDER BY updated DESC`;
 }
 
+function resolveOverrideIntent(question = "", overrides = {}) {
+  if (overrides.intent === "created_resolved_trend") {
+    return {
+      id: "created_resolved_trend",
+      resource: overrides.resource || "issues",
+      transform: overrides.transform || {
+        type: "created_resolved_trend",
+        interval: overrides.interval || inferInterval(question.toLowerCase()),
+      },
+      chartType: overrides.chartType || "line",
+    };
+  }
+
+  return {
+    id: overrides.intent,
+    resource: overrides.resource || "issues",
+    transform: overrides.transform || { type: "raw" },
+    chartType: overrides.chartType || "table",
+  };
+}
+
 function resolveIntent(question = "", overrides = {}) {
   const normalizedQuestion = question.toLowerCase();
   const groupBy = overrides.groupBy || inferGroupBy(normalizedQuestion);
 
+  if (overrides.intent) {
+    return resolveOverrideIntent(question, overrides);
+  }
+
   if (overrides.resource) {
     return {
+      id: "issue_table",
       resource: overrides.resource,
       transform: overrides.transform || { type: "raw" },
       chartType: overrides.chartType || "table",
     };
   }
 
-  if (normalizedQuestion.includes("sprint") || overrides.sprintId) {
-    const sprintMetric = ["status", "statusCategory"].includes(groupBy) ? "count" : "storyPoints";
+  if (normalizedQuestion.includes("release") || normalizedQuestion.includes("version") || normalizedQuestion.includes("fix version")) {
     return {
+      id: "release_progress",
+      resource: "issues",
+      needsVersion: true,
+      transform: { type: "grouped", groupBy: "statusCategory", metric: "count" },
+      chartType: "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("sprint") || overrides.sprintId) {
+    const isSummary = normalizedQuestion.includes("summary")
+      || normalizedQuestion.includes("completion")
+      || normalizedQuestion.includes("health");
+    const sprintGroupBy = groupBy || "status";
+    const sprintMetric = ["status", "statusCategory"].includes(sprintGroupBy) ? "count" : "storyPoints";
+
+    return {
+      id: isSummary ? "sprint_summary" : "sprint_status",
       resource: "sprint_issues",
-      transform: normalizedQuestion.includes("by ") || groupBy
-        ? { type: "grouped", groupBy: groupBy || "assignee", metric: overrides.metric || sprintMetric }
-        : { type: "sprint_summary" },
-      chartType: normalizedQuestion.includes("by ") || groupBy ? "bar" : "gauge",
+      needsSprint: true,
+      transform: isSummary
+        ? { type: "sprint_summary" }
+        : { type: "grouped", groupBy: sprintGroupBy, metric: overrides.metric || sprintMetric },
+      chartType: isSummary ? "gauge" : "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("bug") || normalizedQuestion.includes("defect")) {
+    return {
+      id: "bug_breakdown",
+      resource: "issues",
+      issueType: "Bug",
+      transform: { type: "grouped", groupBy: groupBy || "priority", metric: overrides.metric || "count" },
+      chartType: "bar",
     };
   }
 
   if (normalizedQuestion.includes("stale") || normalizedQuestion.includes("stuck") || normalizedQuestion.includes("oldest")) {
     return {
+      id: "stale_issues",
       resource: "issues",
       transform: { type: "stale_table" },
       chartType: "table",
@@ -234,6 +338,7 @@ function resolveIntent(question = "", overrides = {}) {
 
   if (normalizedQuestion.includes("created vs resolved") || normalizedQuestion.includes("created and resolved") || normalizedQuestion.includes("trend") || normalizedQuestion.includes("over time")) {
     return {
+      id: "created_resolved_trend",
       resource: "issues",
       transform: {
         type: "created_resolved_trend",
@@ -243,8 +348,39 @@ function resolveIntent(question = "", overrides = {}) {
     };
   }
 
+  if (normalizedQuestion.includes("working on") || normalizedQuestion.includes("currently") || normalizedQuestion.includes("current tasks")) {
+    return {
+      id: "current_work",
+      resource: "issues",
+      needsUser: true,
+      statusCategoryNotDone: true,
+      skipDefaultDateWindow: true,
+      transform: { type: "raw" },
+      chartType: "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("completed") || normalizedQuestion.includes("done") || normalizedQuestion.includes("recent")) {
+    return {
+      id: "completed_work",
+      resource: "issues",
+      transform: { type: "raw" },
+      chartType: "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("workload") || normalizedQuestion.includes("assignee") || normalizedQuestion.includes("team load")) {
+    return {
+      id: "team_workload",
+      resource: "issues",
+      transform: { type: "grouped", groupBy: "assignee", metric: overrides.metric || "count" },
+      chartType: "bar",
+    };
+  }
+
   if (groupBy) {
     return {
+      id: "issue_breakdown",
       resource: "issues",
       transform: { type: "grouped", groupBy, metric: overrides.metric || "count" },
       chartType: normalizedQuestion.includes("doughnut") || normalizedQuestion.includes("donut") ? "doughnut" : "bar",
@@ -253,6 +389,7 @@ function resolveIntent(question = "", overrides = {}) {
 
   if (normalizedQuestion.includes("table") || normalizedQuestion.includes("recent") || normalizedQuestion.includes("latest")) {
     return {
+      id: "issue_table",
       resource: "issues",
       transform: { type: "raw" },
       chartType: "table",
@@ -260,6 +397,7 @@ function resolveIntent(question = "", overrides = {}) {
   }
 
   return {
+    id: "project_overview",
     resource: "issues",
     transform: { type: "raw" },
     chartType: "kpi",
@@ -283,96 +421,21 @@ function inferInterval(normalizedQuestion) {
 }
 
 function extractProjectKey(question = "", overrides = {}) {
-  const explicitProject = overrides.project || overrides.projects || overrides.projectIdOrKey;
-  if (explicitProject) {
-    return Array.isArray(explicitProject) ? explicitProject[0] : String(explicitProject).split(",")[0].trim();
-  }
-
-  const ignored = new Set(["JIRA", "SCRUM", "SPRINT", "STATUS", "DONE", "OPEN"]);
-  const matches = String(question || "").match(/\b[A-Z][A-Z0-9_]{1,12}\b/g) || [];
-  return matches.find((match) => !ignored.has(match)) || null;
+  return jiraResolver.extractProjectKey(question, overrides);
 }
 
-async function resolveActiveSprint({ connection, question = "", overrides = {} } = {}) {
-  if (overrides.sprintId) {
-    return {
-      status: "resolved",
-      sprintId: String(overrides.sprintId),
-      boardId: overrides.boardId ? String(overrides.boardId) : "",
-    };
-  }
+function firstOverrideValue(value) {
+  if (!value) return null;
+  if (Array.isArray(value)) return value[0] ? String(value[0]).trim() : null;
+  return String(value).split(",")[0].trim();
+}
 
-  if (!connection) return { status: "unresolved" };
+function extractVersionName(question = "", overrides = {}) {
+  const explicitVersion = firstOverrideValue(overrides.fixVersion || overrides.version);
+  if (explicitVersion) return explicitVersion;
 
-  const projectKey = extractProjectKey(question, overrides);
-  let boards = [];
-
-  if (overrides.boardId) {
-    boards = [{
-      id: overrides.boardId,
-      name: `Board ${overrides.boardId}`,
-      type: "scrum",
-    }];
-  } else if (projectKey) {
-    boards = await jiraConnection.listBoards(connection, {
-      projectKeyOrId: projectKey,
-      maxResults: 50,
-    });
-  } else {
-    return { status: "unresolved" };
-  }
-
-  const activeSprints = [];
-  const sprintBoards = boards.filter((board) => !board.type || board.type === "scrum" || board.type === "kanban");
-
-  for (const board of sprintBoards.slice(0, 10)) {
-    try {
-      // oxlint-disable-next-line no-await-in-loop
-      const sprints = await jiraConnection.listSprints(connection, {
-        boardId: board.id,
-        maxResults: 50,
-        state: "active",
-      });
-      sprints.forEach((sprint) => {
-        if (sprint.state === "active") {
-          activeSprints.push({
-            ...sprint,
-            boardId: board.id,
-            boardName: board.name,
-          });
-        }
-      });
-    } catch (error) {
-      // Some boards may not expose sprints to the current token; continue checking the rest.
-    }
-  }
-
-  if (activeSprints.length === 1) {
-    return {
-      status: "resolved",
-      sprintId: String(activeSprints[0].id),
-      boardId: String(activeSprints[0].boardId),
-      sprint: activeSprints[0],
-      projectKey,
-    };
-  }
-
-  if (activeSprints.length > 1) {
-    return {
-      status: "ambiguous",
-      projectKey,
-      options: activeSprints.slice(0, 4).map((sprint) => ({
-        label: `Use ${sprint.name} on ${sprint.boardName}`,
-        value: `sprint:${sprint.id}`,
-      })),
-    };
-  }
-
-  return {
-    status: "unresolved",
-    projectKey,
-    boardCount: boards.length,
-  };
+  const match = String(question || "").match(/\bv?\d+(?:\.\d+){1,3}(?:[-_][A-Za-z0-9]+)?\b/i);
+  return match ? match[0] : null;
 }
 
 function getOutputFields(config) {
@@ -478,67 +541,216 @@ function validateConfiguration(configuration) {
   });
 }
 
-async function planDataset({ connection = null, question = "", overrides = {} } = {}) {
-  const intent = resolveIntent(question, overrides);
-  const normalizedQuestion = question.toLowerCase();
-  const issueType = overrides.issueType || (normalizedQuestion.includes("bug") || normalizedQuestion.includes("defect") ? "Bug" : undefined);
-  let sprintResolution = { status: "unresolved" };
+function buildActions(intent, resolution = {}) {
+  const actions = [];
 
   if (intent.resource === "sprint_issues") {
-    sprintResolution = await resolveActiveSprint({ connection, question, overrides });
-
-    if (sprintResolution.status === "ambiguous") {
-      return {
-        status: "needs_disambiguation",
-        source: SOURCE_ID,
-        message: `I found multiple active sprints${sprintResolution.projectKey ? ` for ${sprintResolution.projectKey}` : ""}. Which one should I use?`,
-        options: sprintResolution.options,
-      };
-    }
-
-    if (!overrides.sprintId && sprintResolution.status !== "resolved") {
-      const projectLabel = sprintResolution.projectKey ? ` for project ${sprintResolution.projectKey}` : "";
-      return {
-        status: "needs_disambiguation",
-        source: SOURCE_ID,
-        message: `I couldn't reliably resolve the active sprint${projectLabel} from the Jira connector. Do you want me to try one of these approaches?`,
-        options: [{
-          label: sprintResolution.projectKey
-            ? `Break down issues by status for ${sprintResolution.projectKey}`
-            : "Break down issues by status",
-          value: "status_breakdown",
-        }, {
-          label: "Help me pick the correct Jira board or sprint",
-          value: "pick_board",
-        }],
-      };
-    }
+    actions.push({
+      label: "Change sprint",
+      value: "change_sprint",
+    });
+    actions.push({
+      label: "Group by assignee",
+      value: "group_by_assignee",
+      overrides: {
+        groupBy: "assignee",
+      },
+    });
   }
 
-  const sprintId = sprintResolution.status === "resolved"
-    ? sprintResolution.sprintId
-    : overrides.sprintId || "{{sprint_id}}";
-  const boardId = sprintResolution.status === "resolved"
-    ? sprintResolution.boardId
-    : overrides.boardId || "{{board_id}}";
+  if (resolution.project?.key) {
+    actions.push({
+      label: `Show status breakdown for ${resolution.project.key}`,
+      value: "status_breakdown",
+      overrides: {
+        project: resolution.project.key,
+        groupBy: "status",
+      },
+    });
+  }
+
+  if (intent.id !== "issue_table") {
+    actions.push({
+      label: "Show issue table",
+      value: "show_table",
+      overrides: {
+        intent: "issue_table",
+        transform: { type: "raw" },
+        chartType: "table",
+      },
+    });
+  }
+
+  return actions;
+}
+
+function buildProjectStatusFallback({
+  question,
+  overrides = {},
+  resolution = {},
+  reason,
+  warnings = [],
+} = {}) {
+  const projectKey = resolution.project?.key || overrides.projects || overrides.project;
+  const clauses = ["statusCategory != Done"];
+  if (projectKey) clauses.unshift(`project IN (${quoteList(projectKey)})`);
+  const jql = `${clauses.join(" AND ")} ORDER BY updated DESC`;
+  const config = {
+    source: SOURCE_ID,
+    resource: "issues",
+    mode: overrides.mode || (overrides.jql ? "jql" : "visual"),
+    jql,
+    fields: overrides.fields || DEFAULT_FIELDS,
+    projectIdOrKey: projectKey,
+    transform: {
+      type: "grouped",
+      groupBy: "status",
+      metric: "count",
+    },
+    pagination: {
+      ...DEFAULT_PAGINATION,
+      ...(overrides.pagination || {}),
+    },
+  };
+  const validation = validateConfiguration(config);
+  const chartSpec = getChartSpec(validation.configuration, question, "bar");
+  const fallbackIntent = {
+    id: "status_breakdown_fallback",
+    resource: "issues",
+  };
+
+  return {
+    status: "fallback",
+    source: SOURCE_ID,
+    message: `I could not resolve the active sprint, so I planned a project status breakdown${reason ? `: ${reason}` : "."}`,
+    datasetName: chartSpec.title,
+    configuration: validation.configuration,
+    chartSpec,
+    outputFields: getOutputFields(validation.configuration),
+    resolution,
+    actions: buildActions(fallbackIntent, resolution),
+    warnings: [
+      ...validation.warnings,
+      ...warnings,
+    ],
+    errors: validation.errors,
+    rationale: {
+      intent: fallbackIntent.id,
+      resource: validation.configuration.resource,
+      mode: validation.configuration.mode,
+      transform: validation.configuration.transform,
+    },
+  };
+}
+
+function getProjectStatusFallbackConfiguration(configuration = {}) {
+  const projectKey = configuration.projectIdOrKey && !String(configuration.projectIdOrKey).includes("{{")
+    ? configuration.projectIdOrKey
+    : null;
+  const clauses = ["statusCategory != Done"];
+  if (projectKey) clauses.unshift(`project IN (${quoteList(projectKey)})`);
+
+  return {
+    ...configuration,
+    resource: "issues",
+    sprintId: undefined,
+    boardId: undefined,
+    projectIdOrKey: projectKey,
+    jql: `${clauses.join(" AND ")} ORDER BY updated DESC`,
+    transform: {
+      type: "grouped",
+      groupBy: "status",
+      metric: "count",
+    },
+    includeDoneAt: false,
+  };
+}
+
+function shouldFallbackSprintPreview(error) {
+  return /sprint|agile|board/i.test(error?.message || "");
+}
+
+async function planDataset({
+  connection = null,
+  question = "",
+  overrides = {},
+  mode = "preview",
+} = {}) {
+  const intent = resolveIntent(question, overrides);
+  const normalizedQuestion = question.toLowerCase();
+  const issueType = overrides.issueType || intent.issueType || (normalizedQuestion.includes("bug") || normalizedQuestion.includes("defect") ? "Bug" : undefined);
+  const resolvedContext = await jiraResolver.resolveContext({
+    connection,
+    question,
+    overrides,
+    intent,
+    mode: overrides.modeContext || mode,
+  });
+  const resolution = resolvedContext.entities || {};
+
+  if (resolvedContext.needsDisambiguation) {
+    return {
+      status: "needs_disambiguation",
+      source: SOURCE_ID,
+      message: "I found multiple Jira matches. Which one should I use?",
+      options: resolvedContext.options,
+      resolution,
+      actions: buildActions(intent, resolution),
+      warnings: resolvedContext.warnings || [],
+      errors: [],
+      rationale: {
+        intent: intent.id,
+        resource: intent.resource,
+        transform: intent.transform,
+      },
+    };
+  }
+
+  if (intent.resource === "sprint_issues" && !resolution.sprint?.id) {
+    return buildProjectStatusFallback({
+      question,
+      overrides,
+      resolution,
+      reason: "no active sprint was found",
+      warnings: resolvedContext.warnings || [],
+    });
+  }
+
+  const sprintId = resolution.sprint?.id || overrides.sprintId || "{{sprint_id}}";
+  const boardId = resolution.board?.id || overrides.boardId || "{{board_id}}";
+  const projectKey = resolution.project?.key || overrides.projects || overrides.project;
+  const fixVersion = resolution.version?.name
+    || overrides.fixVersion
+    || (intent.id === "release_progress" ? extractVersionName(question, overrides) : undefined);
+  const assignee = resolution.user?.accountId || resolution.user?.displayName || overrides.assignee;
+  const includeDoneAt = overrides.includeDoneAt
+    || ["completed_work", "created_resolved_trend", "sprint_summary"].includes(intent.id);
   const config = {
     source: SOURCE_ID,
     resource: intent.resource,
     mode: overrides.mode || (overrides.jql ? "jql" : "visual"),
     jql: buildJql({
       question,
-      overrides,
+      overrides: {
+        ...overrides,
+        projects: projectKey,
+        fixVersion,
+        assignee,
+      },
       intent: {
         resource: intent.resource,
         issueType,
         priority: normalizedQuestion.includes("blocker") ? "Blocker" : undefined,
+        skipDefaultDateWindow: intent.id === "release_progress" || intent.skipDefaultDateWindow,
+        statusCategoryNotDone: intent.statusCategoryNotDone,
       },
     }),
     fields: overrides.fields || DEFAULT_FIELDS,
     sprintId,
     boardId,
-    projectIdOrKey: overrides.projectIdOrKey || "{{projects}}",
+    projectIdOrKey: projectKey,
     transform: overrides.transform || intent.transform,
+    includeDoneAt,
     pagination: {
       ...DEFAULT_PAGINATION,
       ...(overrides.pagination || {}),
@@ -554,9 +766,15 @@ async function planDataset({ connection = null, question = "", overrides = {} } 
     configuration: validation.configuration,
     chartSpec,
     outputFields: getOutputFields(validation.configuration),
-    warnings: validation.warnings,
+    resolution,
+    actions: buildActions(intent, resolution),
+    warnings: [
+      ...validation.warnings,
+      ...(resolvedContext.warnings || []),
+    ],
     errors: validation.errors,
     rationale: {
+      intent: intent.id,
       resource: validation.configuration.resource,
       mode: validation.configuration.mode,
       transform: validation.configuration.transform,
@@ -576,6 +794,111 @@ function buildColumns(rows, config) {
   }));
 }
 
+function getSearchOverrides(question = "", overrides = {}, filters = {}) {
+  const normalizedQuestion = question.toLowerCase();
+  const wantsOpenWork = filters.open === true
+    || normalizedQuestion.includes("open")
+    || normalizedQuestion.includes("working on")
+    || normalizedQuestion.includes("currently")
+    || normalizedQuestion.includes("current tasks")
+    || normalizedQuestion.includes("active");
+
+  return {
+    ...overrides,
+    ...(wantsOpenWork ? { statusCategoryNotDone: true } : {}),
+    ...(!hasExplicitDateRange(question, overrides) ? { skipDefaultDateWindow: true } : {}),
+  };
+}
+
+function pickSearchRecordFields(row, fields) {
+  const defaultFields = ["key", "summary", "status", "assignee", "priority", "issueType", "updatedAt"];
+  const fieldsToUse = Array.isArray(fields) && fields.length > 0 ? fields : defaultFields;
+
+  return fieldsToUse.reduce((record, field) => ({
+    ...record,
+    [field]: row[field],
+  }), {});
+}
+
+async function searchRecords({
+  connection,
+  question = "",
+  resource = null,
+  filters = {},
+  jql = null,
+  fields = null,
+  rowLimit = 25,
+  overrides = {},
+} = {}) {
+  const maxRecords = Math.min(Number(rowLimit || 25), 50);
+  const searchOverrides = getSearchOverrides(question, {
+    ...overrides,
+    ...(resource ? { resource } : {}),
+  }, filters);
+  const plan = jql
+    ? {
+      status: "ok",
+      configuration: {
+        source: SOURCE_ID,
+        resource: resource || "issues",
+        mode: "jql",
+        jql,
+        fields: fields || DEFAULT_FIELDS,
+        transform: { type: "raw" },
+        pagination: {
+          ...DEFAULT_PAGINATION,
+          maxResults: maxRecords,
+          maxRecords,
+        },
+      },
+      resolution: {},
+      warnings: [],
+    }
+    : await planDataset({
+      connection,
+      question,
+      overrides: searchOverrides,
+      mode: "preview",
+    });
+
+  if (["needs_disambiguation", "needs_more_context", "invalid"].includes(plan.status)) {
+    return plan;
+  }
+
+  const configuration = {
+    ...plan.configuration,
+    fields: fields || plan.configuration.fields || DEFAULT_FIELDS,
+    transform: { type: "raw" },
+    pagination: {
+      ...(plan.configuration.pagination || DEFAULT_PAGINATION),
+      maxResults: maxRecords,
+      maxRecords,
+    },
+  };
+  const jiraRows = await jiraProtocol.fetchJiraRows(connection, configuration);
+  const fieldMappings = connection?.options?.jira?.fieldMappings || {};
+  const normalizedRows = ["issues", "sprint_issues"].includes(configuration.resource)
+    ? jiraRows.map((issue) => jiraProtocol.normalizeIssue(issue, fieldMappings, {
+      includeDoneAt: Boolean(configuration.includeDoneAt),
+    }))
+    : jiraRows;
+  const rows = normalizedRows
+    .slice(0, maxRecords)
+    .map((row) => pickSearchRecordFields(row, fields));
+
+  return {
+    source: SOURCE_ID,
+    status: "ok",
+    resource: configuration.resource,
+    rows,
+    rowCount: rows.length,
+    columns: buildColumns(rows, configuration),
+    configuration,
+    resolution: plan.resolution || {},
+    warnings: plan.warnings || [],
+  };
+}
+
 async function previewConfiguration({ connection, configuration, rowLimit = 25 } = {}) {
   const validation = validateConfiguration(configuration);
   if (!validation.valid) {
@@ -592,19 +915,39 @@ async function previewConfiguration({ connection, configuration, rowLimit = 25 }
       maxRecords: Math.min(Number(validation.configuration.pagination?.maxRecords || rowLimit), rowLimit),
     },
   };
-  const jiraRows = await jiraProtocol.fetchJiraRows(connection, previewConfig);
-  const normalizedRows = ["issues", "sprint_issues"].includes(previewConfig.resource)
-    ? jiraRows.map((issue) => jiraProtocol.normalizeIssue(issue, connection?.options?.jira?.fieldMappings || {}))
+  let previewConfigToUse = previewConfig;
+  let fallbackMessage = null;
+  let jiraRows;
+
+  try {
+    jiraRows = await jiraProtocol.fetchJiraRows(connection, previewConfigToUse);
+  } catch (error) {
+    if (previewConfig.resource !== "sprint_issues" || !shouldFallbackSprintPreview(error)) throw error;
+
+    previewConfigToUse = getProjectStatusFallbackConfiguration(previewConfig);
+    jiraRows = await jiraProtocol.fetchJiraRows(connection, previewConfigToUse);
+    fallbackMessage = `I could not preview sprint issues, so I used the project status breakdown instead: ${error.message}`;
+  }
+
+  const includeDoneAt = Boolean(previewConfigToUse.includeDoneAt)
+    || ["created_resolved_trend", "sprint_summary"].includes(previewConfigToUse.transform?.type);
+  const normalizedRows = ["issues", "sprint_issues"].includes(previewConfigToUse.resource)
+    ? jiraRows.map((issue) => jiraProtocol.normalizeIssue(issue, connection?.options?.jira?.fieldMappings || {}, {
+      includeDoneAt,
+    }))
     : jiraRows;
-  const rows = jiraProtocol.transformRows(normalizedRows, previewConfig);
+  const rows = jiraProtocol.transformRows(normalizedRows, previewConfigToUse);
 
   return {
-    status: "ok",
+    status: fallbackMessage ? "fallback" : "ok",
+    ...(fallbackMessage ? { message: fallbackMessage } : {}),
     rows: rows.slice(0, rowLimit),
-    columns: buildColumns(rows, previewConfig),
+    columns: buildColumns(rows, previewConfigToUse),
     rowCount: rows.length,
-    warnings: validation.warnings,
-    chartSpec: getChartSpec(previewConfig, ""),
+    warnings: fallbackMessage
+      ? [...validation.warnings, fallbackMessage]
+      : validation.warnings,
+    chartSpec: getChartSpec(previewConfigToUse, ""),
   };
 }
 
@@ -626,6 +969,27 @@ async function getSampleData({ connection, resource = "issues", rowLimit = 5 } =
   });
 }
 
+async function resolveContext({
+  connection,
+  question = "",
+  overrides = {},
+  intent = {},
+  mode = "preview",
+} = {}) {
+  const resolution = await jiraResolver.resolveContext({
+    connection,
+    question,
+    overrides,
+    intent,
+    mode,
+  });
+
+  return {
+    source: SOURCE_ID,
+    resolution,
+  };
+}
+
 module.exports = {
   getCapabilities,
   getSampleData,
@@ -636,5 +1000,7 @@ module.exports = {
   planDataset,
   previewConfiguration,
   recommendTemplates,
+  resolveContext,
+  searchRecords,
   validateConfiguration,
 };

--- a/server/sources/plugins/jira/ai/jira.ai.js
+++ b/server/sources/plugins/jira/ai/jira.ai.js
@@ -1,0 +1,640 @@
+const moment = require("moment-timezone");
+
+const jiraConnection = require("../jira.connection");
+const jiraProtocol = require("../jira.protocol");
+const { DEFAULT_FIELDS, JIRA_RESOURCES } = require("../jira.resources");
+
+const SOURCE_ID = "jira";
+const DEFAULT_PAGINATION = { startAt: 0, maxResults: 100, maxRecords: 1000 };
+
+const TEMPLATE_RECOMMENDATIONS = [{
+  terms: ["sprint", "scrum", "velocity", "carryover", "story point"],
+  templateSlugs: ["sprint-health"],
+  chartIds: ["sprint-completion", "story-points-completed", "work-by-assignee", "carryover-issues"],
+}, {
+  terms: ["bug", "defect", "quality", "priority", "severity"],
+  templateSlugs: ["bug-tracking"],
+  chartIds: ["bugs-by-priority", "bug-trend", "oldest-open-bugs"],
+}, {
+  terms: ["workload", "assignee", "team load", "stale", "wip", "in progress"],
+  templateSlugs: ["team-workload"],
+  chartIds: ["open-by-assignee", "wip-by-assignee", "stale-issues"],
+}, {
+  terms: ["overview", "project", "status", "created", "resolved", "completed"],
+  templateSlugs: ["project-overview"],
+  chartIds: ["issues-created-resolved", "issues-by-status", "issues-by-assignee", "recent-completed-work"],
+}];
+
+const SOURCE_INSTRUCTIONS = [
+  "Jira is a source-owned configuration connector for Jira Cloud only. Return DataRequest.configuration objects with source=jira; do not invent REST routes.",
+  "Use issue search and JQL for issue datasets. Use sprint_issues with sprintId for Agile sprint datasets.",
+  "Use normalized issue fields such as key, summary, status, statusCategory, assignee, priority, issueType, createdAt, updatedAt, resolvedAt, doneAt, isDone, storyPoints, fixVersions, and epicKey.",
+  "Use grouped, created_resolved_trend, sprint_summary, stale_table, or raw transforms to return chart-friendly rows.",
+  "Keep previews capped. Use source_preview_configuration before creating charts when the user asks for unfamiliar JQL or sprint data.",
+  "For Jira follow-ups, reuse previously resolved sprintId, boardId, and project key as source_plan_dataset overrides when they are visible in prior tool results.",
+].join("\n");
+
+function getCapabilities() {
+  return {
+    source: SOURCE_ID,
+    instructions: SOURCE_INSTRUCTIONS,
+    supports: {
+      modes: ["visual", "jql", "advanced"],
+      resources: Object.keys(JIRA_RESOURCES),
+      agile: true,
+      variables: true,
+      pagination: true,
+      templates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+      chartPlacement: true,
+    },
+    caveats: [
+      "Jira Cloud API tokens are supported for v1; OAuth is intentionally excluded.",
+      "Story points, severity, and team fields depend on saved Jira field mappings.",
+      "Dashboard-level Jira variables are still created with datasets today; pre-defining them at template selection needs a separate workflow.",
+    ],
+  };
+}
+
+function listResources() {
+  return {
+    source: SOURCE_ID,
+    resources: Object.entries(JIRA_RESOURCES).map(([id, resource]) => ({
+      id,
+      label: resource.label,
+      endpoint: resource.endpoint,
+      fields: resource.fields || [],
+      supportedModes: id === "issues" || id === "sprint_issues"
+        ? ["visual", "jql", "advanced"]
+        : ["advanced"],
+      transforms: getTransformsForResource(id),
+    })),
+  };
+}
+
+function getTransformsForResource(resource) {
+  if (resource === "sprint_issues") {
+    return ["raw", "grouped", "sprint_summary", "stale_table"];
+  }
+  if (resource === "issues") {
+    return ["raw", "grouped", "created_resolved_trend", "stale_table"];
+  }
+  return ["raw"];
+}
+
+function getSchema() {
+  return jiraProtocol.getSchema();
+}
+
+function getTemplates() {
+  const { listTemplates } = require("../../../shared/templates/chartTemplateLoader"); // eslint-disable-line global-require
+
+  return {
+    source: SOURCE_ID,
+    templates: listTemplates(SOURCE_ID),
+  };
+}
+
+function recommendTemplates({ question = "" } = {}) {
+  const normalizedQuestion = question.toLowerCase();
+  const matches = TEMPLATE_RECOMMENDATIONS.filter((recommendation) => {
+    return recommendation.terms.some((term) => normalizedQuestion.includes(term));
+  });
+  const selected = matches.length > 0
+    ? matches
+    : [TEMPLATE_RECOMMENDATIONS[3]];
+  const templateSlugs = Array.from(new Set(selected.flatMap((match) => match.templateSlugs)));
+  const chartIds = Array.from(new Set(selected.flatMap((match) => match.chartIds)));
+
+  return {
+    source: SOURCE_ID,
+    question,
+    recommendations: getTemplates().templates
+      .filter((template) => templateSlugs.includes(template.slug))
+      .map((template) => ({
+        ...template,
+        recommendedCharts: template.charts.filter((chart) => chartIds.includes(chart.id)),
+      })),
+  };
+}
+
+function normalizeDateRange(question, overrides = {}) {
+  if (overrides.dateRange) {
+    return {
+      start: overrides.dateRange.start || "{{start_date}}",
+      end: overrides.dateRange.end || "{{end_date}}",
+    };
+  }
+
+  const normalizedQuestion = question.toLowerCase();
+  if (normalizedQuestion.includes("last month")) {
+    const previousMonth = moment().subtract(1, "month");
+    return {
+      start: previousMonth.clone().startOf("month").format("YYYY-MM-DD"),
+      end: previousMonth.clone().endOf("month").format("YYYY-MM-DD"),
+    };
+  }
+  if (normalizedQuestion.includes("today")) {
+    return {
+      start: moment().startOf("day").format("YYYY-MM-DD"),
+      end: moment().format("YYYY-MM-DD"),
+    };
+  }
+
+  const daysMatch = normalizedQuestion.match(/last\s+(\d+)\s+days?/);
+  if (daysMatch) {
+    return {
+      start: `-${daysMatch[1]}d`,
+      end: "now()",
+    };
+  }
+
+  return {
+    start: "{{start_date}}",
+    end: "{{end_date}}",
+  };
+}
+
+function quoteList(values) {
+  const list = Array.isArray(values) ? values : [values];
+  return list
+    .filter((value) => value !== undefined && value !== null && `${value}`.trim() !== "")
+    .map((value) => {
+      const stringValue = `${value}`.trim();
+      if (/^\{\{.+\}\}$/.test(stringValue)) return stringValue;
+      return `"${stringValue.replace(/"/g, "\\\"")}"`;
+    })
+    .join(", ");
+}
+
+function buildJql({ question = "", overrides = {}, intent = {} } = {}) {
+  if (overrides.jql) return overrides.jql;
+
+  const normalizedQuestion = question.toLowerCase();
+  const dateRange = normalizeDateRange(question, overrides);
+  const projectValue = overrides.projects || overrides.project || extractProjectKey(question, overrides) || "{{projects}}";
+  const clauses = [];
+
+  if (projectValue) clauses.push(`project IN (${quoteList(projectValue)})`);
+  if (intent.issueType || overrides.issueType) clauses.push(`issuetype = ${quoteList(intent.issueType || overrides.issueType)}`);
+  if (overrides.statusCategory) clauses.push(`statusCategory = ${quoteList(overrides.statusCategory)}`);
+  if (overrides.status) clauses.push(`status = ${quoteList(overrides.status)}`);
+  if (overrides.assignee) clauses.push(`assignee IN (${quoteList(overrides.assignee)})`);
+  if (overrides.priority || intent.priority) clauses.push(`priority IN (${quoteList(overrides.priority || intent.priority)})`);
+  if (overrides.fixVersion) clauses.push(`fixVersion IN (${quoteList(overrides.fixVersion)})`);
+  if (intent.resource === "sprint_issues") {
+    // Sprint endpoint already scopes the issues. Avoid introducing date variables unless asked explicitly.
+  } else if (normalizedQuestion.includes("completed") || normalizedQuestion.includes("resolved")) {
+    clauses.push(`resolutiondate >= ${dateRange.start}`);
+    clauses.push(`resolutiondate <= ${dateRange.end}`);
+  } else if (normalizedQuestion.includes("stale") || normalizedQuestion.includes("stuck") || normalizedQuestion.includes("oldest")) {
+    clauses.push("statusCategory != Done");
+    clauses.push(`updated <= ${overrides.staleBefore || "-14d"}`);
+  } else {
+    clauses.push(`created >= ${dateRange.start}`);
+    clauses.push(`created <= ${dateRange.end}`);
+  }
+
+  if (normalizedQuestion.includes("open") || normalizedQuestion.includes("backlog")) {
+    clauses.push("resolution = Unresolved");
+  }
+
+  return `${clauses.join(" AND ")} ORDER BY updated DESC`;
+}
+
+function resolveIntent(question = "", overrides = {}) {
+  const normalizedQuestion = question.toLowerCase();
+  const groupBy = overrides.groupBy || inferGroupBy(normalizedQuestion);
+
+  if (overrides.resource) {
+    return {
+      resource: overrides.resource,
+      transform: overrides.transform || { type: "raw" },
+      chartType: overrides.chartType || "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("sprint") || overrides.sprintId) {
+    const sprintMetric = ["status", "statusCategory"].includes(groupBy) ? "count" : "storyPoints";
+    return {
+      resource: "sprint_issues",
+      transform: normalizedQuestion.includes("by ") || groupBy
+        ? { type: "grouped", groupBy: groupBy || "assignee", metric: overrides.metric || sprintMetric }
+        : { type: "sprint_summary" },
+      chartType: normalizedQuestion.includes("by ") || groupBy ? "bar" : "gauge",
+    };
+  }
+
+  if (normalizedQuestion.includes("stale") || normalizedQuestion.includes("stuck") || normalizedQuestion.includes("oldest")) {
+    return {
+      resource: "issues",
+      transform: { type: "stale_table" },
+      chartType: "table",
+    };
+  }
+
+  if (normalizedQuestion.includes("created vs resolved") || normalizedQuestion.includes("created and resolved") || normalizedQuestion.includes("trend") || normalizedQuestion.includes("over time")) {
+    return {
+      resource: "issues",
+      transform: {
+        type: "created_resolved_trend",
+        interval: overrides.interval || inferInterval(normalizedQuestion),
+      },
+      chartType: "line",
+    };
+  }
+
+  if (groupBy) {
+    return {
+      resource: "issues",
+      transform: { type: "grouped", groupBy, metric: overrides.metric || "count" },
+      chartType: normalizedQuestion.includes("doughnut") || normalizedQuestion.includes("donut") ? "doughnut" : "bar",
+    };
+  }
+
+  if (normalizedQuestion.includes("table") || normalizedQuestion.includes("recent") || normalizedQuestion.includes("latest")) {
+    return {
+      resource: "issues",
+      transform: { type: "raw" },
+      chartType: "table",
+    };
+  }
+
+  return {
+    resource: "issues",
+    transform: { type: "raw" },
+    chartType: "kpi",
+  };
+}
+
+function inferGroupBy(normalizedQuestion) {
+  if (normalizedQuestion.includes("status category")) return "statusCategory";
+  if (normalizedQuestion.includes("status")) return "status";
+  if (normalizedQuestion.includes("assignee") || normalizedQuestion.includes("workload") || normalizedQuestion.includes("team load")) return "assignee";
+  if (normalizedQuestion.includes("priority")) return "priority";
+  if (normalizedQuestion.includes("issue type") || normalizedQuestion.includes("type")) return "issueType";
+  if (normalizedQuestion.includes("project")) return "projectKey";
+  return null;
+}
+
+function inferInterval(normalizedQuestion) {
+  if (normalizedQuestion.includes("month")) return "month";
+  if (normalizedQuestion.includes("week")) return "week";
+  return "day";
+}
+
+function extractProjectKey(question = "", overrides = {}) {
+  const explicitProject = overrides.project || overrides.projects || overrides.projectIdOrKey;
+  if (explicitProject) {
+    return Array.isArray(explicitProject) ? explicitProject[0] : String(explicitProject).split(",")[0].trim();
+  }
+
+  const ignored = new Set(["JIRA", "SCRUM", "SPRINT", "STATUS", "DONE", "OPEN"]);
+  const matches = String(question || "").match(/\b[A-Z][A-Z0-9_]{1,12}\b/g) || [];
+  return matches.find((match) => !ignored.has(match)) || null;
+}
+
+async function resolveActiveSprint({ connection, question = "", overrides = {} } = {}) {
+  if (overrides.sprintId) {
+    return {
+      status: "resolved",
+      sprintId: String(overrides.sprintId),
+      boardId: overrides.boardId ? String(overrides.boardId) : "",
+    };
+  }
+
+  if (!connection) return { status: "unresolved" };
+
+  const projectKey = extractProjectKey(question, overrides);
+  let boards = [];
+
+  if (overrides.boardId) {
+    boards = [{
+      id: overrides.boardId,
+      name: `Board ${overrides.boardId}`,
+      type: "scrum",
+    }];
+  } else if (projectKey) {
+    boards = await jiraConnection.listBoards(connection, {
+      projectKeyOrId: projectKey,
+      maxResults: 50,
+    });
+  } else {
+    return { status: "unresolved" };
+  }
+
+  const activeSprints = [];
+  const sprintBoards = boards.filter((board) => !board.type || board.type === "scrum" || board.type === "kanban");
+
+  for (const board of sprintBoards.slice(0, 10)) {
+    try {
+      // oxlint-disable-next-line no-await-in-loop
+      const sprints = await jiraConnection.listSprints(connection, {
+        boardId: board.id,
+        maxResults: 50,
+        state: "active",
+      });
+      sprints.forEach((sprint) => {
+        if (sprint.state === "active") {
+          activeSprints.push({
+            ...sprint,
+            boardId: board.id,
+            boardName: board.name,
+          });
+        }
+      });
+    } catch (error) {
+      // Some boards may not expose sprints to the current token; continue checking the rest.
+    }
+  }
+
+  if (activeSprints.length === 1) {
+    return {
+      status: "resolved",
+      sprintId: String(activeSprints[0].id),
+      boardId: String(activeSprints[0].boardId),
+      sprint: activeSprints[0],
+      projectKey,
+    };
+  }
+
+  if (activeSprints.length > 1) {
+    return {
+      status: "ambiguous",
+      projectKey,
+      options: activeSprints.slice(0, 4).map((sprint) => ({
+        label: `Use ${sprint.name} on ${sprint.boardName}`,
+        value: `sprint:${sprint.id}`,
+      })),
+    };
+  }
+
+  return {
+    status: "unresolved",
+    projectKey,
+    boardCount: boards.length,
+  };
+}
+
+function getOutputFields(config) {
+  const transform = config.transform || {};
+
+  if (transform.type === "grouped") {
+    return [`root[].${transform.groupBy || "status"}`, "root[].issueCount", "root[].storyPoints"];
+  }
+  if (transform.type === "created_resolved_trend") {
+    return ["root[].period", "root[].created", "root[].resolved", "root[].open"];
+  }
+  if (transform.type === "sprint_summary") {
+    return ["root[].committedIssues", "root[].completedIssues", "root[].completionRate", "root[].committedStoryPoints", "root[].completedStoryPoints"];
+  }
+
+  return ["root[].key", "root[].summary", "root[].status", "root[].assignee", "root[].priority", "root[].createdAt", "root[].updatedAt", "root[].resolvedAt", "root[].doneAt"];
+}
+
+function getChartSpec(config, question, chartType) {
+  const transform = config.transform || {};
+  const title = makeTitle(question, config);
+
+  if (transform.type === "grouped") {
+    return {
+      type: chartType || "bar",
+      title,
+      xAxis: `root[].${transform.groupBy || "status"}`,
+      yAxis: transform.metric === "storyPoints" ? "root[].storyPoints" : "root[].issueCount",
+      yAxisOperation: "none",
+      legend: transform.metric === "storyPoints" ? "Story points" : "Issues",
+      horizontal: true,
+    };
+  }
+  if (transform.type === "created_resolved_trend") {
+    return {
+      type: "line",
+      title,
+      xAxis: "root[].period",
+      yAxis: "root[].created",
+      yAxisOperation: "none",
+      dateField: "root[].period",
+      timeInterval: transform.interval || "day",
+      pointRadius: 0,
+      includeZeros: true,
+      legend: "Created",
+    };
+  }
+  if (transform.type === "sprint_summary") {
+    return {
+      type: "gauge",
+      title,
+      xAxis: "root[].completionRate",
+      yAxis: "root[].completionRate",
+      yAxisOperation: "none",
+      formula: "{val * 100}%",
+      maxValue: 1,
+      ranges: [
+        { min: 0, max: 0.6, label: "At risk", color: "#EF4444" },
+        { min: 0.6, max: 0.85, label: "Watch", color: "#F59E0B" },
+        { min: 0.85, max: 1, label: "On track", color: "#10B981" },
+      ],
+    };
+  }
+  if (chartType === "table" || transform.type === "stale_table") {
+    const columnsOrder = getOutputFields(config);
+    return {
+      type: "table",
+      title,
+      xAxis: "root[]",
+      yAxis: columnsOrder[0],
+      yAxisOperation: "none",
+      columnsOrder,
+      maxRecords: 100,
+    };
+  }
+
+  return {
+    type: "kpi",
+    title,
+    xAxis: "root[].key",
+    yAxis: "root[].key",
+    yAxisOperation: "count",
+    subType: "AddTimeseries",
+    legend: "Issues",
+  };
+}
+
+function makeTitle(question, config) {
+  const normalizedQuestion = String(question || "").trim();
+  if (normalizedQuestion) {
+    return normalizedQuestion.charAt(0).toUpperCase() + normalizedQuestion.slice(1).replace(/[?.!]+$/, "");
+  }
+  return JIRA_RESOURCES[config.resource]?.label || "Jira report";
+}
+
+function validateConfiguration(configuration) {
+  return jiraProtocol.validateConfiguration({
+    ...(configuration || {}),
+    pagination: {
+      ...DEFAULT_PAGINATION,
+      ...(configuration?.pagination || {}),
+    },
+  });
+}
+
+async function planDataset({ connection = null, question = "", overrides = {} } = {}) {
+  const intent = resolveIntent(question, overrides);
+  const normalizedQuestion = question.toLowerCase();
+  const issueType = overrides.issueType || (normalizedQuestion.includes("bug") || normalizedQuestion.includes("defect") ? "Bug" : undefined);
+  let sprintResolution = { status: "unresolved" };
+
+  if (intent.resource === "sprint_issues") {
+    sprintResolution = await resolveActiveSprint({ connection, question, overrides });
+
+    if (sprintResolution.status === "ambiguous") {
+      return {
+        status: "needs_disambiguation",
+        source: SOURCE_ID,
+        message: `I found multiple active sprints${sprintResolution.projectKey ? ` for ${sprintResolution.projectKey}` : ""}. Which one should I use?`,
+        options: sprintResolution.options,
+      };
+    }
+
+    if (!overrides.sprintId && sprintResolution.status !== "resolved") {
+      const projectLabel = sprintResolution.projectKey ? ` for project ${sprintResolution.projectKey}` : "";
+      return {
+        status: "needs_disambiguation",
+        source: SOURCE_ID,
+        message: `I couldn't reliably resolve the active sprint${projectLabel} from the Jira connector. Do you want me to try one of these approaches?`,
+        options: [{
+          label: sprintResolution.projectKey
+            ? `Break down issues by status for ${sprintResolution.projectKey}`
+            : "Break down issues by status",
+          value: "status_breakdown",
+        }, {
+          label: "Help me pick the correct Jira board or sprint",
+          value: "pick_board",
+        }],
+      };
+    }
+  }
+
+  const sprintId = sprintResolution.status === "resolved"
+    ? sprintResolution.sprintId
+    : overrides.sprintId || "{{sprint_id}}";
+  const boardId = sprintResolution.status === "resolved"
+    ? sprintResolution.boardId
+    : overrides.boardId || "{{board_id}}";
+  const config = {
+    source: SOURCE_ID,
+    resource: intent.resource,
+    mode: overrides.mode || (overrides.jql ? "jql" : "visual"),
+    jql: buildJql({
+      question,
+      overrides,
+      intent: {
+        resource: intent.resource,
+        issueType,
+        priority: normalizedQuestion.includes("blocker") ? "Blocker" : undefined,
+      },
+    }),
+    fields: overrides.fields || DEFAULT_FIELDS,
+    sprintId,
+    boardId,
+    projectIdOrKey: overrides.projectIdOrKey || "{{projects}}",
+    transform: overrides.transform || intent.transform,
+    pagination: {
+      ...DEFAULT_PAGINATION,
+      ...(overrides.pagination || {}),
+    },
+  };
+  const validation = validateConfiguration(config);
+  const chartSpec = getChartSpec(validation.configuration, question, intent.chartType);
+
+  return {
+    status: validation.valid ? "ok" : "invalid",
+    source: SOURCE_ID,
+    datasetName: chartSpec.title,
+    configuration: validation.configuration,
+    chartSpec,
+    outputFields: getOutputFields(validation.configuration),
+    warnings: validation.warnings,
+    errors: validation.errors,
+    rationale: {
+      resource: validation.configuration.resource,
+      mode: validation.configuration.mode,
+      transform: validation.configuration.transform,
+      issueType,
+    },
+  };
+}
+
+function buildColumns(rows, config) {
+  if (rows[0]) {
+    return Object.keys(rows[0]).map((name) => ({ name, type: typeof rows[0][name] }));
+  }
+
+  return getOutputFields(config).map((field) => ({
+    name: field.replace("root[].", ""),
+    type: field.includes("Count") || field.includes("Points") || field.includes("Rate") ? "number" : "string",
+  }));
+}
+
+async function previewConfiguration({ connection, configuration, rowLimit = 25 } = {}) {
+  const validation = validateConfiguration(configuration);
+  if (!validation.valid) {
+    return {
+      status: "invalid",
+      ...validation,
+    };
+  }
+
+  const previewConfig = {
+    ...validation.configuration,
+    pagination: {
+      ...validation.configuration.pagination,
+      maxRecords: Math.min(Number(validation.configuration.pagination?.maxRecords || rowLimit), rowLimit),
+    },
+  };
+  const jiraRows = await jiraProtocol.fetchJiraRows(connection, previewConfig);
+  const normalizedRows = ["issues", "sprint_issues"].includes(previewConfig.resource)
+    ? jiraRows.map((issue) => jiraProtocol.normalizeIssue(issue, connection?.options?.jira?.fieldMappings || {}))
+    : jiraRows;
+  const rows = jiraProtocol.transformRows(normalizedRows, previewConfig);
+
+  return {
+    status: "ok",
+    rows: rows.slice(0, rowLimit),
+    columns: buildColumns(rows, previewConfig),
+    rowCount: rows.length,
+    warnings: validation.warnings,
+    chartSpec: getChartSpec(previewConfig, ""),
+  };
+}
+
+async function getSampleData({ connection, resource = "issues", rowLimit = 5 } = {}) {
+  const plan = await planDataset({
+    connection,
+    question: resource === "sprint_issues" ? "sprint issue table" : "latest Jira issue table",
+    overrides: {
+      resource,
+      transform: { type: "raw" },
+      pagination: { maxRecords: rowLimit },
+    },
+  });
+
+  return previewConfiguration({
+    connection,
+    configuration: plan.configuration,
+    rowLimit,
+  });
+}
+
+module.exports = {
+  getCapabilities,
+  getSampleData,
+  getSchema,
+  instructions: SOURCE_INSTRUCTIONS,
+  listResources,
+  listTemplates: getTemplates,
+  planDataset,
+  previewConfiguration,
+  recommendTemplates,
+  validateConfiguration,
+};

--- a/server/sources/plugins/jira/ai/jira.resolver.js
+++ b/server/sources/plugins/jira/ai/jira.resolver.js
@@ -1,0 +1,309 @@
+const jiraConnection = require("../jira.connection");
+
+const PROJECT_TOKEN_IGNORE = new Set(["JIRA", "SCRUM", "SPRINT", "STATUS", "DONE", "OPEN"]);
+
+function normalizeText(value = "") {
+  return String(value || "").trim().toLowerCase();
+}
+
+function firstOverrideValue(value) {
+  if (!value) return null;
+  if (Array.isArray(value)) return value[0] ? String(value[0]).trim() : null;
+  return String(value).split(",")[0].trim();
+}
+
+function extractProjectKey(question = "", overrides = {}) {
+  const explicitProject = firstOverrideValue(overrides.project || overrides.projects || overrides.projectIdOrKey);
+  if (explicitProject) return explicitProject;
+
+  const matches = String(question || "").match(/\b[A-Z][A-Z0-9_]{1,12}\b/g) || [];
+  return matches.find((match) => !PROJECT_TOKEN_IGNORE.has(match)) || null;
+}
+
+function extractAssigneeQuery(question = "", overrides = {}) {
+  const explicitAssignee = firstOverrideValue(overrides.assigneeName || overrides.assignee);
+  if (explicitAssignee) return explicitAssignee;
+
+  const directMatch = String(question || "").match(/\b(?:assigned\s+to|assignee|by)\s+([A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)?)/);
+  if (directMatch) return directMatch[1].trim();
+
+  const currentWorkMatch = String(question || "").match(/\b(?:is|are)\s+([A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)?)\s+(?:working|doing)/);
+  if (currentWorkMatch) return currentWorkMatch[1].trim();
+
+  const possessiveMatch = String(question || "").match(/\b([A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)?)'s\s+(?:tasks|issues|work)\b/);
+  return possessiveMatch ? possessiveMatch[1].trim() : null;
+}
+
+function extractVersionName(question = "", overrides = {}) {
+  const explicitVersion = firstOverrideValue(overrides.fixVersion || overrides.version);
+  if (explicitVersion) return explicitVersion;
+
+  const match = String(question || "").match(/\bv?\d+(?:\.\d+){1,3}(?:[-_][A-Za-z0-9]+)?\b/i);
+  return match ? match[0] : null;
+}
+
+function shouldResolveSprints(question = "", intent = {}) {
+  return intent.resource === "sprint_issues"
+    || intent.needsSprint === true
+    || normalizeText(question).includes("sprint");
+}
+
+function shouldResolveUser(question = "", intent = {}) {
+  const normalizedQuestion = normalizeText(question);
+  return intent.needsUser === true
+    || normalizedQuestion.includes("assignee")
+    || normalizedQuestion.includes("assigned to")
+    || normalizedQuestion.includes("workload for")
+    || normalizedQuestion.includes("workload by")
+    || normalizedQuestion.includes("working on")
+    || /\bfor\s+[A-Z][a-zA-Z]+/.test(String(question || ""))
+    || /\bby\s+[A-Z][a-zA-Z]+/.test(String(question || ""));
+}
+
+function shouldResolveVersion(question = "", intent = {}) {
+  const normalizedQuestion = normalizeText(question);
+  return intent.needsVersion === true
+    || normalizedQuestion.includes("release")
+    || normalizedQuestion.includes("version")
+    || normalizedQuestion.includes("fix version");
+}
+
+async function resolveProject(connection, question, overrides) {
+  const inferredKey = extractProjectKey(question, overrides);
+  if (!inferredKey) return null;
+
+  try {
+    const projects = await jiraConnection.listProjects(connection);
+    const projectList = Array.isArray(projects) ? projects : [];
+    const exactProject = projectList.find((project) => project.key === inferredKey);
+    if (exactProject) {
+      return {
+        id: String(exactProject.id),
+        key: exactProject.key,
+        name: exactProject.name,
+        confidence: 0.98,
+      };
+    }
+
+    const normalizedKey = normalizeText(inferredKey);
+    const fuzzyProject = projectList.find((project) => normalizeText(project.name).includes(normalizedKey));
+    if (fuzzyProject) {
+      return {
+        id: String(fuzzyProject.id),
+        key: fuzzyProject.key,
+        name: fuzzyProject.name,
+        confidence: 0.75,
+      };
+    }
+  } catch (error) {
+    // If Jira discovery is unavailable, keep the user's explicit project token.
+  }
+
+  return {
+    key: inferredKey,
+    confidence: 0.9,
+  };
+}
+
+function buildSprintOption(sprint) {
+  return {
+    label: `Use ${sprint.name}${sprint.boardName ? ` on ${sprint.boardName}` : ""}`,
+    value: `sprint:${sprint.id}`,
+  };
+}
+
+function assignBoardAndSprint(entities, sprint, confidence) {
+  entities.board = {
+    id: String(sprint.boardId),
+    name: sprint.boardName,
+    type: sprint.boardType,
+    confidence: 0.9,
+  };
+  entities.sprint = {
+    id: String(sprint.id),
+    name: sprint.name,
+    state: sprint.state,
+    confidence,
+  };
+}
+
+async function resolveBoardAndSprint({ connection, entities, overrides = {}, mode = "preview" }) {
+  if (overrides.sprintId) {
+    entities.sprint = {
+      id: String(overrides.sprintId),
+      confidence: 1,
+    };
+    if (overrides.boardId) {
+      entities.board = {
+        id: String(overrides.boardId),
+        confidence: 1,
+      };
+    }
+    return { needsDisambiguation: false, options: [] };
+  }
+
+  if (!connection || !entities.project?.key) return { needsDisambiguation: false, options: [] };
+
+  let boards = [];
+  if (overrides.boardId) {
+    boards = [{
+      id: overrides.boardId,
+      name: `Board ${overrides.boardId}`,
+      type: "scrum",
+    }];
+  } else {
+    try {
+      const listedBoards = await jiraConnection.listBoards(connection, {
+        projectKeyOrId: entities.project.key,
+        maxResults: 50,
+      });
+      boards = Array.isArray(listedBoards) ? listedBoards : [];
+    } catch (error) {
+      return { needsDisambiguation: false, options: [] };
+    }
+  }
+
+  const candidateBoards = boards
+    .filter((board) => ["scrum", "kanban"].includes(board.type))
+    .slice(0, 10);
+  if (candidateBoards.length === 0) return { needsDisambiguation: false, options: [] };
+
+  const activeSprints = [];
+  for (const board of candidateBoards) {
+    let sprints = [];
+    try {
+      sprints = await jiraConnection.listSprints(connection, {
+        boardId: board.id,
+        maxResults: 50,
+        state: "active",
+      });
+    } catch (error) {
+      continue;
+    }
+
+    activeSprints.push(...(Array.isArray(sprints) ? sprints : [])
+      .filter((sprint) => sprint.state === "active")
+      .map((sprint) => ({
+        ...sprint,
+        id: String(sprint.id),
+        boardId: String(board.id),
+        boardName: board.name,
+        boardType: board.type,
+      })));
+  }
+
+  const options = activeSprints.slice(0, 4).map(buildSprintOption);
+
+  if (activeSprints.length === 1) {
+    assignBoardAndSprint(entities, activeSprints[0], 0.95);
+  } else if (activeSprints.length > 1 && mode === "persist") {
+    return { needsDisambiguation: true, options };
+  } else if (activeSprints.length > 1) {
+    assignBoardAndSprint(entities, activeSprints[0], 0.7);
+  }
+
+  return { needsDisambiguation: false, options };
+}
+
+async function resolveUser({ connection, question, overrides, intent, entities, warnings }) {
+  if (!connection || !shouldResolveUser(question, intent)) return;
+
+  const query = extractAssigneeQuery(question, overrides);
+  if (!query) return;
+
+  let users = [];
+  try {
+    const listedUsers = await jiraConnection.listUsers(connection, {
+      query,
+      maxResults: 20,
+    });
+    users = Array.isArray(listedUsers) ? listedUsers : [];
+  } catch (error) {
+    entities.user = null;
+    warnings.push("Could not resolve Jira user.");
+    return;
+  }
+
+  const exactUser = users.find((user) => normalizeText(user.displayName) === normalizeText(query));
+  const selectedUser = exactUser || users[0];
+
+  if (selectedUser) {
+    entities.user = {
+      accountId: String(selectedUser.accountId),
+      displayName: selectedUser.displayName,
+      confidence: exactUser ? 0.95 : 0.8,
+    };
+  }
+}
+
+async function resolveVersion({ connection, question, overrides, intent, entities, warnings }) {
+  if (!connection || !entities.project?.key || !shouldResolveVersion(question, intent)) return;
+
+  const versionName = extractVersionName(question, overrides);
+  if (!versionName) return;
+
+  let versions = [];
+  try {
+    const listedVersions = await jiraConnection.listVersions(connection, {
+      projectIdOrKey: entities.project.key,
+    });
+    versions = Array.isArray(listedVersions) ? listedVersions : [];
+  } catch (error) {
+    entities.version = null;
+    warnings.push("Could not resolve Jira version.");
+    return;
+  }
+
+  const exactVersion = versions.find((version) => normalizeText(version.name) === normalizeText(versionName));
+  const fuzzyVersion = versions.find((version) => normalizeText(version.name).includes(normalizeText(versionName)));
+  const selectedVersion = exactVersion || fuzzyVersion;
+
+  if (selectedVersion) {
+    entities.version = {
+      id: String(selectedVersion.id),
+      name: selectedVersion.name,
+      confidence: exactVersion ? 0.95 : 0.8,
+    };
+  }
+}
+
+async function resolveContext({
+  connection,
+  question = "",
+  overrides = {},
+  intent = {},
+  mode = "preview",
+} = {}) {
+  const entities = {};
+  const warnings = [];
+  const project = await resolveProject(connection, question, overrides);
+  if (project) entities.project = project;
+
+  let needsDisambiguation = false;
+  let options = [];
+  if (shouldResolveSprints(question, intent)) {
+    const sprintResolution = await resolveBoardAndSprint({
+      connection,
+      entities,
+      overrides,
+      mode,
+    });
+    needsDisambiguation = sprintResolution.needsDisambiguation;
+    options = sprintResolution.options;
+  }
+
+  await resolveUser({ connection, question, overrides, intent, entities, warnings });
+  await resolveVersion({ connection, question, overrides, intent, entities, warnings });
+
+  return {
+    needsDisambiguation,
+    entities,
+    options,
+    warnings,
+  };
+}
+
+module.exports = {
+  extractProjectKey,
+  resolveContext,
+};

--- a/server/sources/plugins/jira/ai/jira.resolver.js
+++ b/server/sources/plugins/jira/ai/jira.resolver.js
@@ -168,29 +168,28 @@ async function resolveBoardAndSprint({ connection, entities, overrides = {}, mod
     .slice(0, 10);
   if (candidateBoards.length === 0) return { needsDisambiguation: false, options: [] };
 
-  const activeSprints = [];
-  for (const board of candidateBoards) {
-    let sprints = [];
+  const sprintResults = await Promise.all(candidateBoards.map(async (board) => {
     try {
-      sprints = await jiraConnection.listSprints(connection, {
+      const sprints = await jiraConnection.listSprints(connection, {
         boardId: board.id,
         maxResults: 50,
         state: "active",
       });
+      return (Array.isArray(sprints) ? sprints : [])
+        .filter((sprint) => sprint.state === "active")
+        .map((sprint) => ({
+          ...sprint,
+          id: String(sprint.id),
+          boardId: String(board.id),
+          boardName: board.name,
+          boardType: board.type,
+        }));
     } catch (error) {
-      continue;
+      return [];
     }
+  }));
 
-    activeSprints.push(...(Array.isArray(sprints) ? sprints : [])
-      .filter((sprint) => sprint.state === "active")
-      .map((sprint) => ({
-        ...sprint,
-        id: String(sprint.id),
-        boardId: String(board.id),
-        boardName: board.name,
-        boardType: board.type,
-      })));
-  }
+  const activeSprints = sprintResults.flat();
 
   const options = activeSprints.slice(0, 4).map(buildSprintOption);
 

--- a/server/sources/plugins/jira/jira.connection.js
+++ b/server/sources/plugins/jira/jira.connection.js
@@ -1,0 +1,303 @@
+const request = require("request-promise");
+
+const { FIELD_MAPPING_NAMES } = require("./jira.resources");
+
+function normalizeSiteUrl(siteUrl = "") {
+  const trimmed = String(siteUrl).trim().replace(/\/+$/, "");
+  if (!/^https:\/\/[^/]+\.atlassian\.net$/i.test(trimmed)) {
+    throw new Error("Enter a Jira Cloud site URL like https://example.atlassian.net");
+  }
+  return trimmed;
+}
+
+function toPlainObject(value) {
+  if (!value) return {};
+  if (typeof value.toJSON === "function") return value.toJSON();
+  return { ...value };
+}
+
+function getCredentials(connection) {
+  const plainConnection = toPlainObject(connection);
+  const siteUrl = normalizeSiteUrl(
+    plainConnection.host
+      || plainConnection.options?.jira?.siteUrl
+      || plainConnection.authentication?.siteUrl
+  );
+  const email = plainConnection.authentication?.email
+    || plainConnection.authentication?.user
+    || plainConnection.username
+    || "";
+  const apiToken = plainConnection.authentication?.apiToken
+    || plainConnection.authentication?.token
+    || plainConnection.password
+    || "";
+
+  if (!email) throw new Error("Enter your Jira account email");
+  if (!apiToken) throw new Error("Enter your Jira API token");
+
+  return { siteUrl, email, apiToken };
+}
+
+function parseErrorBody(body) {
+  if (!body) return {};
+  if (typeof body === "object") return body;
+
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    return { message: String(body).slice(0, 500) };
+  }
+}
+
+function getSafeJiraErrorMessage(error = {}) {
+  const statusCode = error.statusCode || error.response?.statusCode || null;
+  const body = parseErrorBody(error.error || error.response?.body);
+  const messages = [];
+
+  if (Array.isArray(body.errorMessages)) {
+    messages.push(...body.errorMessages);
+  }
+
+  if (body.errors && typeof body.errors === "object") {
+    messages.push(...Object.values(body.errors));
+  }
+
+  if (body.message) {
+    messages.push(body.message);
+  }
+
+  const message = messages.filter(Boolean).join(" ");
+  return `${statusCode ? `${statusCode} - ` : ""}${message || "Jira request failed"}`;
+}
+
+function toSafeJiraError(error) {
+  const safeError = new Error(getSafeJiraErrorMessage(error));
+  safeError.statusCode = error?.statusCode || error?.response?.statusCode || null;
+  return safeError;
+}
+
+function jiraRequest(connection, route, options = {}) {
+  const { siteUrl, email, apiToken } = getCredentials(connection);
+  return request({
+    method: options.method || "GET",
+    uri: `${siteUrl}${route}`,
+    auth: {
+      user: email,
+      pass: apiToken,
+    },
+    qs: options.qs || undefined,
+    body: options.body || undefined,
+    json: true,
+    resolveWithFullResponse: false,
+  }).catch((error) => {
+    throw toSafeJiraError(error);
+  });
+}
+
+function getMyself(connection) {
+  return jiraRequest(connection, "/rest/api/3/myself");
+}
+
+function listProjects(connection) {
+  return jiraRequest(connection, "/rest/api/3/project/search", {
+    qs: { maxResults: 50 },
+  }).then((response) => {
+    return (response.values || []).map((project) => ({
+      id: project.id,
+      key: project.key,
+      name: project.name,
+      projectTypeKey: project.projectTypeKey,
+    }));
+  });
+}
+
+function listIssueTypes(connection) {
+  return jiraRequest(connection, "/rest/api/3/issuetype")
+    .then((issueTypes) => {
+      return (issueTypes || []).map((issueType) => ({
+        id: issueType.id,
+        name: issueType.name,
+        description: issueType.description || "",
+        subtask: issueType.subtask === true,
+      }));
+    });
+}
+
+function listStatuses(connection) {
+  return jiraRequest(connection, "/rest/api/3/status")
+    .then((statuses) => {
+      return (statuses || []).map((status) => ({
+        id: status.id,
+        name: status.name,
+        statusCategory: status.statusCategory?.name || null,
+        statusCategoryId: status.statusCategory?.id || null,
+        statusCategoryKey: status.statusCategory?.key || null,
+      }));
+    });
+}
+
+function listUsers(connection, params = {}) {
+  return jiraRequest(connection, "/rest/api/3/user/search", {
+    qs: {
+      query: params.query || "",
+      maxResults: Math.min(Number(params.maxResults || 50), 50),
+    },
+  }).then((users) => {
+    return (users || []).map((user) => ({
+      accountId: user.accountId,
+      displayName: user.displayName,
+      emailAddress: user.emailAddress || null,
+      active: user.active,
+    }));
+  });
+}
+
+function listBoards(connection, params = {}) {
+  return jiraRequest(connection, "/rest/agile/1.0/board", {
+    qs: {
+      maxResults: Math.min(Number(params.maxResults || 50), 50),
+      projectKeyOrId: params.projectKeyOrId || undefined,
+      type: params.type || undefined,
+    },
+  }).then((response) => {
+    return (response.values || []).map((board) => ({
+      id: board.id,
+      name: board.name,
+      type: board.type,
+    }));
+  });
+}
+
+function listSprints(connection, params = {}) {
+  if (!params.boardId) {
+    throw new Error("boardId is required");
+  }
+
+  return jiraRequest(connection, `/rest/agile/1.0/board/${params.boardId}/sprint`, {
+    qs: {
+      maxResults: Math.min(Number(params.maxResults || 50), 50),
+      state: params.state || undefined,
+    },
+  }).then((response) => {
+    return (response.values || []).map((sprint) => ({
+      id: sprint.id,
+      name: sprint.name,
+      state: sprint.state,
+      startDate: sprint.startDate || null,
+      endDate: sprint.endDate || null,
+      completeDate: sprint.completeDate || null,
+    }));
+  });
+}
+
+function listVersions(connection, params = {}) {
+  if (!params.projectIdOrKey) {
+    throw new Error("projectIdOrKey is required");
+  }
+
+  return jiraRequest(connection, `/rest/api/3/project/${params.projectIdOrKey}/versions`)
+    .then((versions) => {
+      return (versions || []).map((version) => ({
+        id: version.id,
+        name: version.name,
+        released: version.released === true,
+        archived: version.archived === true,
+        releaseDate: version.releaseDate || null,
+      }));
+    });
+}
+
+function listFields(connection) {
+  return jiraRequest(connection, "/rest/api/3/field")
+    .then((fields) => {
+      return (fields || []).map((field) => ({
+        id: field.id,
+        key: field.key,
+        name: field.name,
+        custom: field.custom === true,
+        schema: field.schema || {},
+      }));
+    });
+}
+
+function normalizeFieldName(name = "") {
+  return String(name).trim().toLowerCase();
+}
+
+function detectFieldMappingsFromFields(fields = []) {
+  const candidates = {};
+  const fieldMappings = {};
+
+  Object.entries(FIELD_MAPPING_NAMES).forEach(([semanticName, names]) => {
+    const matches = fields.filter((field) => {
+      const fieldName = normalizeFieldName(field.name);
+      return names.some((name) => fieldName.includes(name));
+    });
+
+    candidates[semanticName] = matches.map((field) => ({
+      id: field.id,
+      name: field.name,
+      schema: field.schema || {},
+    }));
+
+    if (matches[0]) {
+      fieldMappings[semanticName] = matches[0].id;
+    }
+  });
+
+  return { fieldMappings, candidates };
+}
+
+async function detectFieldMappings(connection) {
+  const fields = await listFields(connection);
+  return detectFieldMappingsFromFields(fields);
+}
+
+function validateJql(connection, params = {}) {
+  const jql = String(params.jql || "").trim();
+  if (!jql) {
+    throw new Error("jql is required");
+  }
+
+  return jiraRequest(connection, "/rest/api/3/jql/parse", {
+    method: "POST",
+    qs: { validation: "strict" },
+    body: { queries: [jql] },
+  });
+}
+
+function previewJql(connection, params = {}) {
+  const jql = String(params.jql || "").trim();
+  if (!jql) {
+    throw new Error("jql is required");
+  }
+
+  return jiraRequest(connection, "/rest/api/3/search/jql", {
+    method: "POST",
+    body: {
+      jql,
+      fields: Array.isArray(params.fields) ? params.fields : String(params.fields || "").split(",").filter(Boolean),
+      maxResults: Math.min(Number(params.maxResults || 10), 50),
+    },
+  });
+}
+
+module.exports = {
+  detectFieldMappings,
+  detectFieldMappingsFromFields,
+  getCredentials,
+  getMyself,
+  getSafeJiraErrorMessage,
+  jiraRequest,
+  listBoards,
+  listFields,
+  listIssueTypes,
+  listProjects,
+  listSprints,
+  listStatuses,
+  listUsers,
+  listVersions,
+  normalizeSiteUrl,
+  previewJql,
+  validateJql,
+};

--- a/server/sources/plugins/jira/jira.plugin.js
+++ b/server/sources/plugins/jira/jira.plugin.js
@@ -1,0 +1,67 @@
+const path = require("path");
+
+const jiraAi = require("./ai/jira.ai");
+const jiraProtocol = require("./jira.protocol");
+
+module.exports = {
+  id: "jira",
+  type: "jira",
+  subType: "jira",
+  name: "Jira",
+  category: "productivity",
+  description: "Connect to Jira Cloud projects, issues, boards, and sprints.",
+
+  capabilities: {
+    actions: [
+      "listProjects",
+      "listIssueTypes",
+      "listStatuses",
+      "listUsers",
+      "listBoards",
+      "listSprints",
+      "listVersions",
+      "listFields",
+      "validateJql",
+      "previewJql",
+      "detectFieldMappings",
+    ],
+    connection: {
+      supportsTest: true,
+      supportsOAuth: false,
+      supportsFiles: false,
+      authModes: ["api_token"],
+    },
+    data: {
+      supportsQuery: false,
+      supportsSchema: true,
+      supportsResourcePicker: true,
+      supportsPagination: true,
+      supportsVariables: true,
+      supportsJoins: true,
+    },
+    templates: {
+      datasets: true,
+      charts: true,
+      dashboards: false,
+    },
+    ai: {
+      canGenerateDatasets: true,
+      canGenerateQueries: false,
+      hasSourceInstructions: true,
+      hasTools: true,
+    },
+  },
+
+  backend: {
+    ...jiraProtocol,
+    ai: jiraAi,
+  },
+
+  templates: {
+    directory: path.join(__dirname, "templates"),
+    chartTemplates: ["project-overview", "sprint-health", "bug-tracking", "team-workload"],
+    defaults: {
+      dataRequest: jiraProtocol.getDefaultDataRequest(),
+    },
+  },
+};

--- a/server/sources/plugins/jira/jira.protocol.js
+++ b/server/sources/plugins/jira/jira.protocol.js
@@ -310,8 +310,7 @@ function normalizeIssue(issue, fieldMappings = {}, options = {}) {
   const doneAtFromChangelog = options.includeDoneAt
     ? getDoneAtFromChangelog(issue, options.doneStatusLookup)
     : null;
-
-  return {
+  const normalizedIssue = {
     key: issue.key,
     summary: fields.summary || "",
     projectKey: fields.project?.key || null,
@@ -333,6 +332,12 @@ function normalizeIssue(issue, fieldMappings = {}, options = {}) {
     fixVersions: (fields.fixVersions || []).map((version) => version.name),
     epicKey: fields.parent?.key || readMappedField(fields, fieldMappings.epic) || null,
   };
+
+  if (issue._trendEvent) {
+    normalizedIssue._trendEvent = issue._trendEvent;
+  }
+
+  return normalizedIssue;
 }
 
 function getGroupValue(row, groupBy) {
@@ -374,14 +379,17 @@ function transformCreatedResolvedTrend(rows, transform = {}) {
   const interval = transform.interval || "day";
 
   rows.forEach((row) => {
-    const createdPeriod = getPeriod(row.createdAt, interval);
+    const shouldCountCreated = !row._trendEvent || row._trendEvent === "created";
+    const shouldCountResolved = !row._trendEvent || row._trendEvent === "resolved";
+
+    const createdPeriod = shouldCountCreated ? getPeriod(row.createdAt, interval) : null;
     if (createdPeriod) {
       const current = byPeriod.get(createdPeriod) || { period: createdPeriod, created: 0, resolved: 0, open: 0 };
       current.created += 1;
       byPeriod.set(createdPeriod, current);
     }
 
-    const resolvedPeriod = getPeriod(row.doneAt || row.resolvedAt, interval);
+    const resolvedPeriod = shouldCountResolved ? getPeriod(row.doneAt || row.resolvedAt, interval) : null;
     if (resolvedPeriod) {
       const current = byPeriod.get(resolvedPeriod) || { period: resolvedPeriod, created: 0, resolved: 0, open: 0 };
       current.resolved += 1;
@@ -490,15 +498,124 @@ function buildIssueSearchBody(config, nextPageToken = null) {
   return body;
 }
 
+function stripOrderBy(jql = "") {
+  return String(jql || "").replace(/\s+ORDER\s+BY[\s\S]*$/i, "").trim();
+}
+
+function extractTrendDateValue(jql = "", field, operator) {
+  const escapedField = String(field).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedOperator = String(operator).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = String(jql || "").match(new RegExp(`${escapedField}\\s*${escapedOperator}\\s*("(?:\\\\"|[^"])*"|now\\(\\)|[^\\s)]+)`, "i"));
+  return match?.[1]?.trim() || "";
+}
+
+function getTrendDateRange(config = {}) {
+  const jql = config.jql || "";
+  const visual = config.visual || {};
+  const startDate = extractTrendDateValue(jql, "created", ">=")
+    || extractTrendDateValue(jql, "statusCategoryChangedDate", ">=")
+    || (visual.startDate && !String(visual.startDate).includes("{{") ? visual.startDate : "");
+  const endDate = extractTrendDateValue(jql, "created", "<=")
+    || extractTrendDateValue(jql, "statusCategoryChangedDate", "<=")
+    || (visual.endDate && !String(visual.endDate).includes("{{") ? visual.endDate : "");
+
+  return { startDate, endDate };
+}
+
+function getTrendBaseJql(jql = "") {
+  const withoutOrder = stripOrderBy(jql);
+  const templateDateBlockIndex = withoutOrder.search(/\s+AND\s+\(\(\s*created\s*>=/i);
+  if (templateDateBlockIndex > -1) {
+    return withoutOrder.slice(0, templateDateBlockIndex).trim();
+  }
+
+  return withoutOrder
+    .replace(/\s+AND\s+created\s*>=\s*[^\s)]+/gi, "")
+    .replace(/\s+AND\s+created\s*<=\s*[^\s)]+/gi, "")
+    .replace(/\s+AND\s+statusCategoryChangedDate\s*>=\s*[^\s)]+/gi, "")
+    .replace(/\s+AND\s+statusCategoryChangedDate\s*<=\s*[^\s)]+/gi, "")
+    .trim();
+}
+
+function appendJqlClause(baseJql, clause) {
+  const base = String(baseJql || "").trim();
+  return base ? `${base} AND ${clause}` : clause;
+}
+
+function getCreatedResolvedTrendConfigs(config = {}) {
+  const { startDate, endDate } = getTrendDateRange(config);
+  if (!startDate || !endDate) return null;
+
+  const baseJql = getTrendBaseJql(config.jql);
+
+  return [{
+    event: "created",
+    config: {
+      ...config,
+      jql: `${appendJqlClause(baseJql, `created >= ${startDate} AND created <= ${endDate}`)} ORDER BY created ASC`,
+    },
+  }, {
+    event: "resolved",
+    config: {
+      ...config,
+      jql: `${appendJqlClause(baseJql, `statusCategory = Done AND statusCategoryChangedDate >= ${startDate} AND statusCategoryChangedDate <= ${endDate}`)} ORDER BY updated ASC`,
+    },
+  }];
+}
+
+async function fetchIssueRows(connection, config) {
+  const rows = [];
+  const maxRecords = Math.min(Number(config.pagination?.maxRecords || 5000), 10000);
+  let nextPageToken = null;
+  let hasMore = true;
+
+  while (hasMore && rows.length < maxRecords) {
+    // oxlint-disable-next-line no-await-in-loop
+    const response = await jiraConnection.jiraRequest(connection, getSearchRoute(config), {
+      method: "POST",
+      body: buildIssueSearchBody(config, nextPageToken),
+    });
+    const pageRows = Array.isArray(response?.issues) ? response.issues : [];
+    rows.push(...pageRows);
+    nextPageToken = response?.nextPageToken || null;
+    hasMore = pageRows.length > 0 && Boolean(nextPageToken) && rows.length < maxRecords;
+  }
+
+  return rows.slice(0, maxRecords);
+}
+
+async function fetchCreatedResolvedTrendIssueRows(connection, config) {
+  const trendConfigs = getCreatedResolvedTrendConfigs(config);
+  if (!trendConfigs) {
+    return fetchIssueRows(connection, config);
+  }
+
+  const rows = [];
+
+  await trendConfigs.reduce((promise, trendConfig) => promise.then(async () => {
+    const trendRows = await fetchIssueRows(connection, trendConfig.config);
+    rows.push(...trendRows.map((row) => ({
+      ...row,
+      _trendEvent: trendConfig.event,
+    })));
+  }), Promise.resolve());
+
+  return rows;
+}
+
 function buildSprintIssueSearchParams(config, startAt) {
   const maxResults = Math.min(Number(config.pagination?.maxResults || 100), 100);
   const expand = getExpandValues(config);
   const params = {
-    jql: config.jql,
     fields: Array.isArray(config.fields) ? config.fields.join(",") : config.fields,
     startAt,
     maxResults,
   };
+  const jql = String(config.jql || "").trim();
+
+  if (jql && !jql.includes("{{")) {
+    params.jql = jql;
+  }
 
   if (expand.length > 0) {
     params.expand = expand.join(",");
@@ -534,24 +651,11 @@ async function fetchJiraRows(connection, config) {
   }
 
   if (config.resource === "issues") {
-    const rows = [];
-    const maxRecords = Math.min(Number(config.pagination?.maxRecords || 5000), 10000);
-    let nextPageToken = null;
-    let hasMore = true;
-
-    while (hasMore && rows.length < maxRecords) {
-      // oxlint-disable-next-line no-await-in-loop
-      const response = await jiraConnection.jiraRequest(connection, getSearchRoute(config), {
-        method: "POST",
-        body: buildIssueSearchBody(config, nextPageToken),
-      });
-      const pageRows = Array.isArray(response?.issues) ? response.issues : [];
-      rows.push(...pageRows);
-      nextPageToken = response?.nextPageToken || null;
-      hasMore = pageRows.length > 0 && Boolean(nextPageToken) && rows.length < maxRecords;
+    if (config.transform?.type === "created_resolved_trend") {
+      return fetchCreatedResolvedTrendIssueRows(connection, config);
     }
 
-    return rows.slice(0, maxRecords);
+    return fetchIssueRows(connection, config);
   }
 
   const rows = [];

--- a/server/sources/plugins/jira/jira.protocol.js
+++ b/server/sources/plugins/jira/jira.protocol.js
@@ -1,0 +1,746 @@
+const moment = require("moment-timezone");
+
+const db = require("../../../models/models");
+const drCacheController = require("../../../controllers/DataRequestCacheController");
+const { processVariablesInString } = require("../../shared/variables/stringVariables");
+const { serializeResponsePreview } = require("../../../modules/updateAudit");
+const {
+  checkAndGetCache,
+  completeConnectorAudit,
+  failConnectorAudit,
+} = require("../../shared/connectorRuntime");
+const jiraConnection = require("./jira.connection");
+const { DEFAULT_FIELDS, JIRA_RESOURCES } = require("./jira.resources");
+
+const DEFAULT_CONFIGURATION = {
+  source: "jira",
+  resource: "issues",
+  mode: "visual",
+  jql: "created >= {{start_date}} AND created <= {{end_date}} ORDER BY updated DESC",
+  fields: DEFAULT_FIELDS,
+  transform: {
+    type: "raw",
+  },
+  includeDoneAt: false,
+  visual: {
+    dateField: "created",
+    startDate: "last_30_days",
+    endDate: "now",
+  },
+  pagination: {
+    startAt: 0,
+    maxResults: 100,
+    maxRecords: 5000,
+  },
+};
+
+function getDefaultDataRequest() {
+  return {
+    method: "GET",
+    route: null,
+    headers: {},
+    body: null,
+    conditions: null,
+    configuration: { ...DEFAULT_CONFIGURATION },
+    query: null,
+    pagination: true,
+    items: "issues",
+    itemsLimit: 5000,
+    offset: "startAt",
+    paginationField: null,
+    template: "jira",
+    useGlobalHeaders: true,
+  };
+}
+
+function getConfiguration(dataRequest = {}) {
+  const configuration = dataRequest.configuration || {};
+  return {
+    ...DEFAULT_CONFIGURATION,
+    ...configuration,
+    fields: configuration.fields || DEFAULT_CONFIGURATION.fields,
+    transform: {
+      ...DEFAULT_CONFIGURATION.transform,
+      ...(configuration.transform || {}),
+    },
+    visual: {
+      ...DEFAULT_CONFIGURATION.visual,
+      ...(configuration.visual || {}),
+    },
+    pagination: {
+      ...DEFAULT_CONFIGURATION.pagination,
+      ...(configuration.pagination || {}),
+    },
+  };
+}
+
+function validateConfiguration(configuration = {}) {
+  const config = getConfiguration({ configuration });
+  const errors = [];
+
+  if (config.source !== "jira") {
+    errors.push("configuration.source must be jira");
+  }
+
+  if (!JIRA_RESOURCES[config.resource]) {
+    errors.push(`Unsupported Jira resource: ${config.resource || "missing"}`);
+  }
+
+  if (!["visual", "jql", "advanced"].includes(config.mode)) {
+    errors.push("mode must be visual, jql, or advanced");
+  }
+
+  if (config.resource === "issues" && !String(config.jql || "").trim()) {
+    errors.push("jql is required for issue searches");
+  }
+  if (config.resource === "sprints" && !config.boardId) {
+    errors.push("boardId is required for sprint requests");
+  }
+  if (config.resource === "versions" && !config.projectIdOrKey) {
+    errors.push("projectIdOrKey is required for version requests");
+  }
+
+  const maxResults = Number(config.pagination?.maxResults);
+  const maxRecords = Number(config.pagination?.maxRecords);
+  if (!Number.isFinite(maxResults) || maxResults <= 0 || maxResults > 100) {
+    errors.push("pagination.maxResults must be between 1 and 100");
+  }
+  if (!Number.isFinite(maxRecords) || maxRecords <= 0 || maxRecords > 10000) {
+    errors.push("pagination.maxRecords must be between 1 and 10000");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings: [],
+    configuration: config,
+  };
+}
+
+function assertValidConfiguration(configuration) {
+  const validation = validateConfiguration(configuration);
+  if (!validation.valid) {
+    throw new Error(validation.errors.join(" "));
+  }
+  return validation.configuration;
+}
+
+function getBuilderMetadata() {
+  return Promise.resolve({
+    source: "jira",
+    resources: JIRA_RESOURCES,
+    defaults: DEFAULT_CONFIGURATION,
+  });
+}
+
+function getSavedConnection(connection) {
+  if (!connection?.id) return Promise.resolve(connection);
+
+  return db.Connection.findByPk(connection.id)
+    .then((savedConnection) => savedConnection || connection)
+    .catch(() => connection);
+}
+
+function parseMaybeJson(value, fallback) {
+  if (!value) return fallback;
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return fallback;
+  }
+}
+
+function getJiraOptions(connection) {
+  const options = parseMaybeJson(connection?.options, {});
+  return options?.jira || {};
+}
+
+function convertVariableValue(value) {
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  return String(value);
+}
+
+function processConfigValue(value, dataRequest, variables) {
+  if (typeof value === "string") {
+    return processVariablesInString({
+      value,
+      dataRequest: {
+        ...dataRequest,
+        VariableBindings: dataRequest.VariableBindings || [],
+      },
+      variables,
+      convertValue: convertVariableValue,
+    });
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => processConfigValue(item, dataRequest, variables));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value).reduce((processed, key) => ({
+      ...processed,
+      [key]: processConfigValue(value[key], dataRequest, variables),
+    }), {});
+  }
+
+  return value;
+}
+
+function applyVariables({ dataRequest, variables }) {
+  const processedConfiguration = processConfigValue(dataRequest.configuration || {}, dataRequest, variables || {});
+
+  return {
+    dataRequest,
+    processedDataRequest: {
+      ...dataRequest,
+      configuration: processedConfiguration,
+      Connection: dataRequest.Connection,
+      VariableBindings: dataRequest.VariableBindings,
+    },
+  };
+}
+
+function getSchema() {
+  return Promise.resolve({
+    source: "jira",
+    entities: Object.entries(JIRA_RESOURCES).map(([name, resource]) => ({
+      name,
+      label: resource.label,
+      endpoint: resource.endpoint,
+      columns: (resource.fields || []).map((field) => ({
+        name: field,
+        type: field.includes("date") || ["created", "updated", "resolutiondate"].includes(field) ? "date" : "string",
+      })),
+    })),
+  });
+}
+
+function readMappedField(fields, fieldId) {
+  if (!fieldId) return null;
+  const value = fields[fieldId];
+  if (value === undefined || value === null) return null;
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value.value || value.name || value.displayName || value.key || null;
+  }
+  return value;
+}
+
+function normalizeLookupValue(value = "") {
+  return String(value || "").trim().toLowerCase();
+}
+
+function isDoneStatusCategory(statusCategory = {}) {
+  return ["done", "completed"].includes(normalizeLookupValue(statusCategory.key))
+    || normalizeLookupValue(statusCategory.name) === "done";
+}
+
+function getDefaultDoneStatusLookup() {
+  return {
+    ids: new Set(),
+    names: new Set(["done", "closed", "resolved"]),
+  };
+}
+
+function getDoneStatusLookup(statuses = []) {
+  const lookup = getDefaultDoneStatusLookup();
+
+  statuses.forEach((status) => {
+    if (isDoneStatusCategory({
+      key: status.statusCategoryKey,
+      name: status.statusCategory,
+    })) {
+      if (status.id) lookup.ids.add(String(status.id));
+      if (status.name) lookup.names.add(normalizeLookupValue(status.name));
+    }
+  });
+
+  return lookup;
+}
+
+async function loadDoneStatusLookup(connection) {
+  try {
+    const statuses = await jiraConnection.listStatuses(connection);
+    return getDoneStatusLookup(statuses);
+  } catch (error) {
+    return getDefaultDoneStatusLookup();
+  }
+}
+
+function getChangelogHistories(issue = {}) {
+  if (Array.isArray(issue.changelog?.histories)) return issue.changelog.histories;
+  if (Array.isArray(issue.changelog?.values)) return issue.changelog.values;
+  return [];
+}
+
+function getDoneAtFromChangelog(issue, doneStatusLookup) {
+  const fields = issue.fields || {};
+  const currentStatus = fields.status || {};
+
+  if (!isDoneStatusCategory(currentStatus.statusCategory || {})) {
+    return null;
+  }
+
+  const lookup = doneStatusLookup || getDefaultDoneStatusLookup();
+  const histories = getChangelogHistories(issue)
+    .filter((history) => history?.created)
+    .sort((a, b) => String(a.created).localeCompare(String(b.created)));
+  let doneAt = null;
+
+  histories.forEach((history) => {
+    (history.items || []).forEach((item) => {
+      if (normalizeLookupValue(item.fieldId || item.field) !== "status") return;
+
+      const targetStatusId = String(item.to || "");
+      const targetStatusName = normalizeLookupValue(item.toString);
+      if (lookup.ids.has(targetStatusId) || lookup.names.has(targetStatusName)) {
+        doneAt = history.created;
+      }
+    });
+  });
+
+  return doneAt;
+}
+
+function normalizeIssue(issue, fieldMappings = {}, options = {}) {
+  const fields = issue.fields || {};
+  const doneAtFromChangelog = options.includeDoneAt
+    ? getDoneAtFromChangelog(issue, options.doneStatusLookup)
+    : null;
+
+  return {
+    key: issue.key,
+    summary: fields.summary || "",
+    projectKey: fields.project?.key || null,
+    issueType: fields.issuetype?.name || null,
+    status: fields.status?.name || null,
+    statusCategory: fields.status?.statusCategory?.name || null,
+    assignee: fields.assignee?.displayName || null,
+    reporter: fields.reporter?.displayName || null,
+    priority: fields.priority?.name || null,
+    createdAt: fields.created || null,
+    updatedAt: fields.updated || null,
+    resolvedAt: fields.resolutiondate || null,
+    doneAt: doneAtFromChangelog || fields.resolutiondate || null,
+    isDone: isDoneStatusCategory(fields.status?.statusCategory || {}),
+    storyPoints: Number(readMappedField(fields, fieldMappings.storyPoints) || 0),
+    severity: readMappedField(fields, fieldMappings.severity),
+    team: readMappedField(fields, fieldMappings.team),
+    labels: fields.labels || [],
+    fixVersions: (fields.fixVersions || []).map((version) => version.name),
+    epicKey: fields.parent?.key || readMappedField(fields, fieldMappings.epic) || null,
+  };
+}
+
+function getGroupValue(row, groupBy) {
+  const value = row[groupBy];
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "None";
+  return value || "None";
+}
+
+function transformGrouped(rows, transform = {}) {
+  const groupBy = transform.groupBy || "status";
+  const grouped = new Map();
+
+  rows.forEach((row) => {
+    const label = getGroupValue(row, groupBy);
+    const current = grouped.get(label) || {
+      [groupBy]: label,
+      issueCount: 0,
+      storyPoints: 0,
+    };
+
+    current.issueCount += 1;
+    current.storyPoints += Number(row.storyPoints || 0);
+    grouped.set(label, current);
+  });
+
+  return Array.from(grouped.values());
+}
+
+function getPeriod(value, interval = "day") {
+  const date = moment(value);
+  if (!date.isValid()) return null;
+  if (interval === "week") return date.startOf("isoWeek").format("YYYY-MM-DD");
+  if (interval === "month") return date.startOf("month").format("YYYY-MM-DD");
+  return date.format("YYYY-MM-DD");
+}
+
+function transformCreatedResolvedTrend(rows, transform = {}) {
+  const byPeriod = new Map();
+  const interval = transform.interval || "day";
+
+  rows.forEach((row) => {
+    const createdPeriod = getPeriod(row.createdAt, interval);
+    if (createdPeriod) {
+      const current = byPeriod.get(createdPeriod) || { period: createdPeriod, created: 0, resolved: 0, open: 0 };
+      current.created += 1;
+      byPeriod.set(createdPeriod, current);
+    }
+
+    const resolvedPeriod = getPeriod(row.doneAt || row.resolvedAt, interval);
+    if (resolvedPeriod) {
+      const current = byPeriod.get(resolvedPeriod) || { period: resolvedPeriod, created: 0, resolved: 0, open: 0 };
+      current.resolved += 1;
+      byPeriod.set(resolvedPeriod, current);
+    }
+  });
+
+  let open = 0;
+  return Array.from(byPeriod.values())
+    .sort((a, b) => a.period.localeCompare(b.period))
+    .map((row) => {
+      open += row.created - row.resolved;
+      return { ...row, open };
+    });
+}
+
+function transformSprintSummary(rows) {
+  const completedRows = rows.filter((row) => row.statusCategory === "Done");
+  const totalStoryPoints = rows.reduce((sum, row) => sum + Number(row.storyPoints || 0), 0);
+  const completedStoryPoints = completedRows.reduce((sum, row) => sum + Number(row.storyPoints || 0), 0);
+
+  return [{
+    committedIssues: rows.length,
+    completedIssues: completedRows.length,
+    completionRate: rows.length ? completedRows.length / rows.length : 0,
+    committedStoryPoints: totalStoryPoints,
+    completedStoryPoints,
+  }];
+}
+
+function transformRows(rows, config = {}) {
+  const transform = config.transform || {};
+
+  if (transform.type === "grouped") {
+    return transformGrouped(rows, transform);
+  }
+  if (transform.type === "created_resolved_trend") {
+    return transformCreatedResolvedTrend(rows, transform);
+  }
+  if (transform.type === "sprint_summary") {
+    return transformSprintSummary(rows);
+  }
+  if (transform.type === "stale_table") {
+    return [...rows].sort((a, b) => String(a.updatedAt || "").localeCompare(String(b.updatedAt || "")));
+  }
+
+  return rows;
+}
+
+function getFieldMappings(connection) {
+  return getJiraOptions(connection).fieldMappings || {};
+}
+
+function getSearchRoute(config) {
+  if (config.resource === "sprint_issues") {
+    if (!config.sprintId) {
+      throw new Error("sprintId is required for sprint issue requests");
+    }
+    return `/rest/agile/1.0/sprint/${config.sprintId}/issue`;
+  }
+
+  return "/rest/api/3/search/jql";
+}
+
+function normalizeFields(fields) {
+  if (Array.isArray(fields)) return fields;
+  return String(fields || "").split(",").map((field) => field.trim()).filter(Boolean);
+}
+
+function shouldIncludeDoneAt(config = {}) {
+  const transformType = config.transform?.type || "raw";
+  return Boolean(config.includeDoneAt)
+    || ["created_resolved_trend", "sprint_summary"].includes(transformType);
+}
+
+function getExpandValues(config = {}) {
+  const expand = Array.isArray(config.expand)
+    ? config.expand
+    : String(config.expand || "").split(",");
+  const expandValues = expand.map((value) => String(value || "").trim()).filter(Boolean);
+
+  if (shouldIncludeDoneAt(config) && !expandValues.includes("changelog")) {
+    expandValues.push("changelog");
+  }
+
+  return expandValues;
+}
+
+function buildIssueSearchBody(config, nextPageToken = null) {
+  const maxResults = Math.min(Number(config.pagination?.maxResults || 100), 100);
+  const expand = getExpandValues(config);
+  const body = {
+    jql: config.jql,
+    fields: normalizeFields(config.fields),
+    maxResults,
+  };
+
+  if (expand.length > 0) {
+    body.expand = expand.join(",");
+  }
+
+  if (nextPageToken) {
+    body.nextPageToken = nextPageToken;
+  }
+
+  return body;
+}
+
+function buildSprintIssueSearchParams(config, startAt) {
+  const maxResults = Math.min(Number(config.pagination?.maxResults || 100), 100);
+  const expand = getExpandValues(config);
+  const params = {
+    jql: config.jql,
+    fields: Array.isArray(config.fields) ? config.fields.join(",") : config.fields,
+    startAt,
+    maxResults,
+  };
+
+  if (expand.length > 0) {
+    params.expand = expand.join(",");
+  }
+
+  return params;
+}
+
+async function fetchJiraRows(connection, config) {
+  if (config.resource === "boards") {
+    const boards = await jiraConnection.listBoards(connection, {
+      maxResults: Math.min(Number(config.pagination?.maxRecords || 50), 50),
+      projectKeyOrId: config.projectIdOrKey,
+      type: config.boardType,
+    });
+    return boards;
+  }
+
+  if (config.resource === "sprints") {
+    const sprints = await jiraConnection.listSprints(connection, {
+      boardId: config.boardId,
+      maxResults: Math.min(Number(config.pagination?.maxRecords || 50), 50),
+      state: config.state,
+    });
+    return sprints;
+  }
+
+  if (config.resource === "versions") {
+    const versions = await jiraConnection.listVersions(connection, {
+      projectIdOrKey: config.projectIdOrKey,
+    });
+    return versions.slice(0, Number(config.pagination?.maxRecords || 100));
+  }
+
+  if (config.resource === "issues") {
+    const rows = [];
+    const maxRecords = Math.min(Number(config.pagination?.maxRecords || 5000), 10000);
+    let nextPageToken = null;
+    let hasMore = true;
+
+    while (hasMore && rows.length < maxRecords) {
+      // oxlint-disable-next-line no-await-in-loop
+      const response = await jiraConnection.jiraRequest(connection, getSearchRoute(config), {
+        method: "POST",
+        body: buildIssueSearchBody(config, nextPageToken),
+      });
+      const pageRows = Array.isArray(response?.issues) ? response.issues : [];
+      rows.push(...pageRows);
+      nextPageToken = response?.nextPageToken || null;
+      hasMore = pageRows.length > 0 && Boolean(nextPageToken) && rows.length < maxRecords;
+    }
+
+    return rows.slice(0, maxRecords);
+  }
+
+  const rows = [];
+  const maxResults = Math.min(Number(config.pagination?.maxResults || 100), 100);
+  const maxRecords = Math.min(Number(config.pagination?.maxRecords || 5000), 10000);
+  let startAt = Number(config.pagination?.startAt || 0);
+  let hasMore = true;
+
+  while (hasMore && rows.length < maxRecords) {
+    // oxlint-disable-next-line no-await-in-loop
+    const response = await jiraConnection.jiraRequest(connection, getSearchRoute(config), {
+      qs: buildSprintIssueSearchParams(config, startAt),
+    });
+    const pageRows = Array.isArray(response?.issues) ? response.issues : [];
+    rows.push(...pageRows);
+
+    const nextStart = startAt + maxResults;
+    const total = Number(response?.total || rows.length);
+    hasMore = pageRows.length > 0
+      && pageRows.length >= maxResults
+      && nextStart < total
+      && rows.length < maxRecords;
+    startAt = nextStart;
+  }
+
+  return rows.slice(0, maxRecords);
+}
+
+async function testConnection({ connection }) {
+  const myself = await jiraConnection.getMyself(connection);
+  return {
+    success: true,
+    metadata: {
+      accountId: myself.accountId || null,
+      displayName: myself.displayName || null,
+      emailAddress: myself.emailAddress || null,
+    },
+  };
+}
+
+function testUnsavedConnection({ connection }) {
+  return testConnection({ connection });
+}
+
+async function prepareConnectionData({ connection }) {
+  const credentials = jiraConnection.getCredentials(connection);
+  let metadata = null;
+
+  try {
+    metadata = await jiraConnection.getMyself(connection);
+  } catch (error) {
+    metadata = null;
+  }
+
+  return {
+    ...connection,
+    type: "jira",
+    subType: "jira",
+    host: credentials.siteUrl,
+    schema: {
+      ...(connection.schema || {}),
+      jira: {
+        accountId: metadata?.accountId || null,
+        displayName: metadata?.displayName || null,
+        emailAddress: metadata?.emailAddress || null,
+        siteUrl: credentials.siteUrl,
+      },
+      resources: Object.keys(JIRA_RESOURCES),
+    },
+    options: {
+      ...(connection.options || {}),
+      jira: {
+        ...(connection.options?.jira || {}),
+        siteUrl: credentials.siteUrl,
+      },
+    },
+  };
+}
+
+async function runDataRequest({
+  connection,
+  dataRequest,
+  getCache,
+  processedDataRequest = null,
+  auditContext = null,
+}) {
+  const savedConnection = await getSavedConnection(connection);
+  const dataRequestToRun = processedDataRequest || dataRequest;
+  const config = assertValidConfiguration(dataRequestToRun.configuration || {});
+
+  if (getCache) {
+    const drCache = await checkAndGetCache(savedConnection.id, dataRequest);
+    if (drCache) {
+      await completeConnectorAudit(auditContext, {
+        cacheHit: true,
+        connectionType: "jira",
+        resource: config.resource,
+        ...serializeResponsePreview(drCache.responseData),
+      });
+      return drCache;
+    }
+  }
+
+  try {
+    const jiraRows = await fetchJiraRows(savedConnection, config);
+    const fieldMappings = getFieldMappings(savedConnection);
+    const includeDoneAt = shouldIncludeDoneAt(config);
+    const doneStatusLookup = includeDoneAt ? await loadDoneStatusLookup(savedConnection) : null;
+    const normalizedRows = ["issues", "sprint_issues"].includes(config.resource)
+      ? jiraRows.map((issue) => normalizeIssue(issue, fieldMappings, { includeDoneAt, doneStatusLookup }))
+      : jiraRows;
+    const transformedRows = transformRows(normalizedRows, config);
+    const dataToCache = {
+      dataRequest,
+      responseData: {
+        data: transformedRows,
+      },
+      connection_id: savedConnection.id,
+    };
+
+    await drCacheController.create(dataRequest.id, dataToCache);
+    await completeConnectorAudit(auditContext, {
+      cacheHit: false,
+      connectionType: "jira",
+      resource: config.resource,
+      recordsProcessed: jiraRows.length,
+      ...serializeResponsePreview(dataToCache.responseData),
+    });
+
+    return dataToCache;
+  } catch (error) {
+    await failConnectorAudit(auditContext, error, "connection", {
+      cacheHit: false,
+      connectionType: "jira",
+      resource: config.resource,
+    });
+    throw error;
+  }
+}
+
+const actions = {
+  listProjects({ connection }) {
+    return jiraConnection.listProjects(connection);
+  },
+  listIssueTypes({ connection }) {
+    return jiraConnection.listIssueTypes(connection);
+  },
+  listStatuses({ connection }) {
+    return jiraConnection.listStatuses(connection);
+  },
+  listUsers({ connection, params }) {
+    return jiraConnection.listUsers(connection, params);
+  },
+  listBoards({ connection, params }) {
+    return jiraConnection.listBoards(connection, params);
+  },
+  listSprints({ connection, params }) {
+    return jiraConnection.listSprints(connection, params);
+  },
+  listVersions({ connection, params }) {
+    return jiraConnection.listVersions(connection, params);
+  },
+  listFields({ connection }) {
+    return jiraConnection.listFields(connection);
+  },
+  validateJql({ connection, params }) {
+    return jiraConnection.validateJql(connection, params);
+  },
+  previewJql({ connection, params }) {
+    return jiraConnection.previewJql(connection, params);
+  },
+  detectFieldMappings({ connection }) {
+    return jiraConnection.detectFieldMappings(connection);
+  },
+};
+
+module.exports = {
+  actions,
+  applyVariables,
+  assertValidConfiguration,
+  fetchJiraRows,
+  getBuilderMetadata,
+  getDefaultDataRequest,
+  getSchema,
+  normalizeIssue,
+  prepareConnectionData,
+  runDataRequest,
+  testConnection,
+  testUnsavedConnection,
+  transformRows,
+  validateConfiguration,
+};

--- a/server/sources/plugins/jira/jira.resources.js
+++ b/server/sources/plugins/jira/jira.resources.js
@@ -1,0 +1,61 @@
+const DEFAULT_FIELDS = [
+  "key",
+  "summary",
+  "status",
+  "assignee",
+  "reporter",
+  "priority",
+  "issuetype",
+  "created",
+  "updated",
+  "resolutiondate",
+  "project",
+  "parent",
+  "fixVersions",
+  "labels",
+];
+
+const JIRA_RESOURCES = {
+  issues: {
+    label: "Issues",
+    endpoint: "/rest/api/3/search/jql",
+    fields: DEFAULT_FIELDS,
+  },
+  boards: {
+    label: "Boards",
+    endpoint: "/rest/agile/1.0/board",
+  },
+  sprints: {
+    label: "Sprints",
+    endpoint: "/rest/agile/1.0/board/{boardId}/sprint",
+  },
+  sprint_issues: {
+    label: "Sprint issues",
+    endpoint: "/rest/agile/1.0/sprint/{sprintId}/issue",
+    fields: DEFAULT_FIELDS,
+  },
+  versions: {
+    label: "Versions",
+    endpoint: "/rest/api/3/project/{projectIdOrKey}/versions",
+  },
+  fields: {
+    label: "Fields",
+    endpoint: "/rest/api/3/field",
+  },
+  users: {
+    label: "Users",
+    endpoint: "/rest/api/3/user/search",
+  },
+};
+
+const FIELD_MAPPING_NAMES = {
+  storyPoints: ["story points", "story point estimate", "estimate"],
+  severity: ["severity"],
+  team: ["team"],
+};
+
+module.exports = {
+  DEFAULT_FIELDS,
+  FIELD_MAPPING_NAMES,
+  JIRA_RESOURCES,
+};

--- a/server/sources/plugins/jira/jira.resources.js
+++ b/server/sources/plugins/jira/jira.resources.js
@@ -15,36 +15,158 @@ const DEFAULT_FIELDS = [
   "labels",
 ];
 
+const ISSUE_METRICS = [
+  "count",
+  "storyPoints",
+];
+
+const SPRINT_METRICS = [
+  ...ISSUE_METRICS,
+  "completionRate",
+  "completedIssues",
+  "completedStoryPoints",
+];
+
+const ISSUE_DIMENSIONS = [
+  "status",
+  "statusCategory",
+  "assignee",
+  "reporter",
+  "priority",
+  "issueType",
+  "project",
+  "projectKey",
+  "fixVersion",
+  "label",
+  "epicKey",
+];
+
+const SPRINT_DIMENSIONS = [
+  ...ISSUE_DIMENSIONS,
+  "sprint",
+  "board",
+];
+
+const ISSUE_DATE_FIELDS = [
+  "createdAt",
+  "updatedAt",
+  "resolvedAt",
+  "doneAt",
+];
+
+const ISSUE_FILTERS = [
+  { field: "project", operators: ["in", "equals"] },
+  { field: "status", operators: ["in", "equals"] },
+  { field: "statusCategory", operators: ["in", "equals"] },
+  { field: "assignee", operators: ["in", "equals"] },
+  { field: "reporter", operators: ["in", "equals"] },
+  { field: "priority", operators: ["in", "equals"] },
+  { field: "issueType", operators: ["in", "equals"] },
+  { field: "fixVersion", operators: ["in", "equals"] },
+  { field: "label", operators: ["in", "equals"] },
+  { field: "createdAt", operators: ["between", "gte", "lte"] },
+  { field: "updatedAt", operators: ["between", "gte", "lte"] },
+  { field: "resolvedAt", operators: ["between", "gte", "lte"] },
+];
+
 const JIRA_RESOURCES = {
   issues: {
     label: "Issues",
     endpoint: "/rest/api/3/search/jql",
     fields: DEFAULT_FIELDS,
+    metrics: ISSUE_METRICS,
+    dimensions: ISSUE_DIMENSIONS,
+    filters: ISSUE_FILTERS,
+    transforms: ["raw", "grouped", "created_resolved_trend", "stale_table"],
+    dateFields: ISSUE_DATE_FIELDS,
+    requires: [],
+    canAutoResolve: ["project"],
   },
   boards: {
     label: "Boards",
     endpoint: "/rest/agile/1.0/board",
+    metrics: ["count"],
+    dimensions: ["type", "project"],
+    filters: [
+      { field: "project", operators: ["equals"] },
+      { field: "type", operators: ["equals"] },
+    ],
+    transforms: ["raw"],
+    dateFields: [],
+    requires: [],
+    canAutoResolve: ["project"],
   },
   sprints: {
     label: "Sprints",
     endpoint: "/rest/agile/1.0/board/{boardId}/sprint",
+    metrics: ["count"],
+    dimensions: ["state", "board"],
+    filters: [
+      { field: "board", operators: ["equals"] },
+      { field: "state", operators: ["equals"] },
+    ],
+    transforms: ["raw"],
+    dateFields: ["startDate", "endDate", "completeDate"],
+    requires: ["board"],
+    canAutoResolve: ["project", "board"],
   },
   sprint_issues: {
     label: "Sprint issues",
     endpoint: "/rest/agile/1.0/sprint/{sprintId}/issue",
     fields: DEFAULT_FIELDS,
+    metrics: SPRINT_METRICS,
+    dimensions: SPRINT_DIMENSIONS,
+    filters: [
+      ...ISSUE_FILTERS,
+      { field: "sprint", operators: ["equals"] },
+      { field: "board", operators: ["equals"] },
+    ],
+    transforms: ["raw", "grouped", "sprint_summary", "stale_table"],
+    dateFields: ISSUE_DATE_FIELDS,
+    requires: ["sprint"],
+    canAutoResolve: ["project", "board", "activeSprint"],
   },
   versions: {
     label: "Versions",
     endpoint: "/rest/api/3/project/{projectIdOrKey}/versions",
+    metrics: ["count"],
+    dimensions: ["released", "archived", "project"],
+    filters: [
+      { field: "project", operators: ["equals"] },
+      { field: "released", operators: ["equals"] },
+    ],
+    transforms: ["raw"],
+    dateFields: ["releaseDate"],
+    requires: ["project"],
+    canAutoResolve: ["project"],
   },
   fields: {
     label: "Fields",
     endpoint: "/rest/api/3/field",
+    metrics: ["count"],
+    dimensions: ["custom", "schema"],
+    filters: [
+      { field: "name", operators: ["contains", "equals"] },
+      { field: "custom", operators: ["equals"] },
+    ],
+    transforms: ["raw"],
+    dateFields: [],
+    requires: [],
+    canAutoResolve: [],
   },
   users: {
     label: "Users",
     endpoint: "/rest/api/3/user/search",
+    metrics: ["count"],
+    dimensions: ["active"],
+    filters: [
+      { field: "query", operators: ["contains"] },
+      { field: "active", operators: ["equals"] },
+    ],
+    transforms: ["raw"],
+    dateFields: [],
+    requires: [],
+    canAutoResolve: [],
   },
 };
 
@@ -57,5 +179,11 @@ const FIELD_MAPPING_NAMES = {
 module.exports = {
   DEFAULT_FIELDS,
   FIELD_MAPPING_NAMES,
+  ISSUE_DATE_FIELDS,
+  ISSUE_DIMENSIONS,
+  ISSUE_FILTERS,
+  ISSUE_METRICS,
   JIRA_RESOURCES,
+  SPRINT_DIMENSIONS,
+  SPRINT_METRICS,
 };

--- a/server/sources/plugins/jira/templates/bug-tracking.json
+++ b/server/sources/plugins/jira/templates/bug-tracking.json
@@ -1,0 +1,139 @@
+{
+  "id": "jira-bug-tracking",
+  "slug": "bug-tracking",
+  "version": 1,
+  "source": "jira",
+  "name": "Jira Bug Tracking",
+  "description": "Open bugs, priority breakdowns, oldest bugs, and bug trends.",
+  "requiredConnection": {
+    "type": "jira",
+    "subType": "jira"
+  },
+  "datasets": [
+    {
+      "id": "bugs_by_priority",
+      "name": "Jira open bugs by priority",
+      "description": "Open bug count grouped by priority.",
+      "icon": "Bug",
+      "fieldsSchema": {
+        "root[].priority": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND issuetype = Bug AND statusCategory != Done",
+          "transform": {
+            "type": "grouped",
+            "metric": "count",
+            "groupBy": "priority"
+          },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "bug_trend",
+      "name": "Jira bug trend",
+      "description": "Bugs created and resolved by day.",
+      "icon": "LineChart",
+      "fieldsSchema": {
+        "root[].period": "date",
+        "root[].created": "number",
+        "root[].resolved": "number",
+        "root[].open": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "includeDoneAt": true,
+          "jql": "project IN ({{projects}}) AND issuetype = Bug AND ((created >= {{start_date}} AND created <= {{end_date}}) OR (statusCategory = Done AND statusCategoryChangedDate >= {{start_date}} AND statusCategoryChangedDate <= {{end_date}})) ORDER BY updated ASC",
+          "transform": {
+            "type": "created_resolved_trend",
+            "interval": "day"
+          },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true },
+          { "name": "start_date", "type": "date", "default_value": "-30d", "required": false },
+          { "name": "end_date", "type": "date", "default_value": "now()", "required": false }
+        ]
+      }
+    },
+    {
+      "id": "oldest_open_bugs",
+      "name": "Jira oldest open bugs",
+      "description": "Oldest unresolved bugs.",
+      "icon": "Table",
+      "fieldsSchema": {
+        "root[].key": "string",
+        "root[].summary": "string",
+        "root[].priority": "string",
+        "root[].assignee": "string",
+        "root[].createdAt": "date"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND issuetype = Bug AND statusCategory != Done ORDER BY created ASC",
+          "transform": { "type": "raw" },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 500 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    }
+  ],
+  "charts": [
+    {
+      "id": "bugs-by-priority",
+      "name": "Bugs by priority",
+      "description": "Open bugs grouped by priority.",
+      "icon": "Bug",
+      "type": "bar",
+      "requiredDatasetIds": ["bugs_by_priority"],
+      "layoutIntent": { "kind": "comparison", "priority": 10 },
+      "cdc": { "datasetTemplateId": "bugs_by_priority", "xAxis": "root[].priority", "yAxis": "root[].issueCount", "legend": "Bugs", "datasetColor": "#EF4444", "fillColor": "rgba(239, 68, 68, 0.12)", "fill": true }
+    },
+    {
+      "id": "bug-trend",
+      "name": "Bug trend",
+      "description": "Bugs created and resolved over time.",
+      "icon": "LineChart",
+      "type": "line",
+      "requiredDatasetIds": ["bug_trend"],
+      "layoutIntent": { "kind": "trend", "priority": 20 },
+      "cdcs": [
+        { "datasetTemplateId": "bug_trend", "xAxis": "root[].period", "yAxis": "root[].created", "legend": "Created", "datasetColor": "#EF4444", "fillColor": "rgba(239, 68, 68, 0.12)", "fill": true },
+        { "datasetTemplateId": "bug_trend", "xAxis": "root[].period", "yAxis": "root[].resolved", "legend": "Resolved", "datasetColor": "#0FC457", "fillColor": "rgba(15, 196, 87, 0.12)", "fill": true }
+      ]
+    },
+    {
+      "id": "oldest-open-bugs",
+      "name": "Oldest open bugs",
+      "description": "Oldest unresolved bug issues.",
+      "icon": "Table",
+      "type": "table",
+      "requiredDatasetIds": ["oldest_open_bugs"],
+      "layoutIntent": { "kind": "table", "priority": 30 },
+      "cdc": {
+        "datasetTemplateId": "oldest_open_bugs",
+        "xAxis": "root[]",
+        "datasetColor": "#EF4444",
+        "columnsOrder": ["key", "summary", "priority", "assignee", "createdAt"]
+      }
+    }
+  ]
+}

--- a/server/sources/plugins/jira/templates/bug-tracking.json
+++ b/server/sources/plugins/jira/templates/bug-tracking.json
@@ -64,7 +64,7 @@
         },
         "variableBindings": [
           { "name": "projects", "type": "string", "default_value": "", "required": true },
-          { "name": "start_date", "type": "date", "default_value": "-30d", "required": false },
+          { "name": "start_date", "type": "date", "default_value": "-365d", "required": false },
           { "name": "end_date", "type": "date", "default_value": "now()", "required": false }
         ]
       }
@@ -105,7 +105,7 @@
       "type": "bar",
       "requiredDatasetIds": ["bugs_by_priority"],
       "layoutIntent": { "kind": "comparison", "priority": 10 },
-      "cdc": { "datasetTemplateId": "bugs_by_priority", "xAxis": "root[].priority", "yAxis": "root[].issueCount", "legend": "Bugs", "datasetColor": "#EF4444", "fillColor": "rgba(239, 68, 68, 0.12)", "fill": true }
+      "cdc": { "datasetTemplateId": "bugs_by_priority", "xAxis": "root[].priority", "yAxis": "root[].issueCount", "yAxisOperation": "none", "legend": "Bugs", "datasetColor": "#EF4444", "fillColor": "rgba(239, 68, 68, 0.12)", "fill": true }
     },
     {
       "id": "bug-trend",
@@ -116,8 +116,8 @@
       "requiredDatasetIds": ["bug_trend"],
       "layoutIntent": { "kind": "trend", "priority": 20 },
       "cdcs": [
-        { "datasetTemplateId": "bug_trend", "xAxis": "root[].period", "yAxis": "root[].created", "legend": "Created", "datasetColor": "#EF4444", "fillColor": "rgba(239, 68, 68, 0.12)", "fill": true },
-        { "datasetTemplateId": "bug_trend", "xAxis": "root[].period", "yAxis": "root[].resolved", "legend": "Resolved", "datasetColor": "#0FC457", "fillColor": "rgba(15, 196, 87, 0.12)", "fill": true }
+        { "datasetTemplateId": "bug_trend", "xAxis": "root[].period", "yAxis": "root[].created", "dateField": "root[].period", "yAxisOperation": "none", "legend": "Created", "datasetColor": "#EF4444", "fillColor": "rgba(239, 68, 68, 0.12)", "fill": true },
+        { "datasetTemplateId": "bug_trend", "xAxis": "root[].period", "yAxis": "root[].resolved", "dateField": "root[].period", "yAxisOperation": "none", "legend": "Resolved", "datasetColor": "#0FC457", "fillColor": "rgba(15, 196, 87, 0.12)", "fill": true }
       ]
     },
     {
@@ -131,6 +131,8 @@
       "cdc": {
         "datasetTemplateId": "oldest_open_bugs",
         "xAxis": "root[]",
+        "yAxis": "root[].key",
+        "yAxisOperation": "none",
         "datasetColor": "#EF4444",
         "columnsOrder": ["key", "summary", "priority", "assignee", "createdAt"]
       }

--- a/server/sources/plugins/jira/templates/project-overview.json
+++ b/server/sources/plugins/jira/templates/project-overview.json
@@ -40,7 +40,7 @@
         },
         "variableBindings": [
           { "name": "projects", "type": "string", "default_value": "", "required": true },
-          { "name": "start_date", "type": "date", "default_value": "-30d", "required": false },
+          { "name": "start_date", "type": "date", "default_value": "-365d", "required": false },
           { "name": "end_date", "type": "date", "default_value": "now()", "required": false }
         ]
       }
@@ -154,8 +154,8 @@
       "requiredDatasetIds": ["issues_created_resolved"],
       "layoutIntent": { "kind": "trend", "priority": 10 },
       "cdcs": [
-        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].created", "legend": "Created", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true },
-        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].resolved", "legend": "Resolved", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
+        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].created", "dateField": "root[].period", "yAxisOperation": "none", "legend": "Created", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true },
+        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].resolved", "dateField": "root[].period", "yAxisOperation": "none", "legend": "Resolved", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
       ]
     },
     {
@@ -166,7 +166,7 @@
       "type": "bar",
       "requiredDatasetIds": ["issues_by_status"],
       "layoutIntent": { "kind": "comparison", "priority": 20 },
-      "cdc": { "datasetTemplateId": "issues_by_status", "xAxis": "root[].status", "yAxis": "root[].issueCount", "legend": "Issues", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "issues_by_status", "xAxis": "root[].status", "yAxis": "root[].issueCount", "yAxisOperation": "none", "legend": "Issues", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
     },
     {
       "id": "issues-by-assignee",
@@ -176,7 +176,7 @@
       "type": "bar",
       "requiredDatasetIds": ["issues_by_assignee"],
       "layoutIntent": { "kind": "comparison", "priority": 30 },
-      "cdc": { "datasetTemplateId": "issues_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "legend": "Issues", "datasetColor": "rgba(255, 152, 0, 1)", "fillColor": "rgba(255, 152, 0, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "issues_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "yAxisOperation": "none", "legend": "Issues", "datasetColor": "rgba(255, 152, 0, 1)", "fillColor": "rgba(255, 152, 0, 0.14)", "fill": true }
     },
     {
       "id": "recent-completed-work",
@@ -189,6 +189,8 @@
       "cdc": {
         "datasetTemplateId": "recent_completed_work",
         "xAxis": "root[]",
+        "yAxis": "root[].key",
+        "yAxisOperation": "none",
         "datasetColor": "rgba(38, 166, 154, 1)",
         "columnsOrder": ["key", "summary", "assignee", "doneAt"]
       }

--- a/server/sources/plugins/jira/templates/project-overview.json
+++ b/server/sources/plugins/jira/templates/project-overview.json
@@ -1,0 +1,197 @@
+{
+  "id": "jira-project-overview",
+  "slug": "project-overview",
+  "version": 1,
+  "source": "jira",
+  "name": "Jira Project Overview",
+  "description": "Project-level Jira KPIs, issue trends, status breakdowns, and recent completed work.",
+  "requiredConnection": {
+    "type": "jira",
+    "subType": "jira"
+  },
+  "datasets": [
+    {
+      "id": "issues_created_resolved",
+      "name": "Jira issues created vs resolved",
+      "description": "Created and resolved issue counts grouped by day.",
+      "icon": "LineChart",
+      "fieldsSchema": {
+        "root[].period": "date",
+        "root[].created": "number",
+        "root[].resolved": "number",
+        "root[].open": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "includeDoneAt": true,
+          "jql": "project IN ({{projects}}) AND ((created >= {{start_date}} AND created <= {{end_date}}) OR (statusCategory = Done AND statusCategoryChangedDate >= {{start_date}} AND statusCategoryChangedDate <= {{end_date}})) ORDER BY updated ASC",
+          "transform": {
+            "type": "created_resolved_trend",
+            "interval": "day"
+          },
+          "pagination": {
+            "startAt": 0,
+            "maxResults": 100,
+            "maxRecords": 5000
+          }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true },
+          { "name": "start_date", "type": "date", "default_value": "-30d", "required": false },
+          { "name": "end_date", "type": "date", "default_value": "now()", "required": false }
+        ]
+      }
+    },
+    {
+      "id": "issues_by_status",
+      "name": "Jira issues by status",
+      "description": "Issue count and story points grouped by status.",
+      "icon": "BarChart3",
+      "fieldsSchema": {
+        "root[].status": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND statusCategory != Done",
+          "transform": {
+            "type": "grouped",
+            "metric": "count",
+            "groupBy": "status"
+          },
+          "pagination": {
+            "startAt": 0,
+            "maxResults": 100,
+            "maxRecords": 5000
+          }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "issues_by_assignee",
+      "name": "Jira open issues by assignee",
+      "description": "Open issue count and story points grouped by assignee.",
+      "icon": "Users",
+      "fieldsSchema": {
+        "root[].assignee": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND statusCategory != Done",
+          "transform": {
+            "type": "grouped",
+            "metric": "count",
+            "groupBy": "assignee"
+          },
+          "pagination": {
+            "startAt": 0,
+            "maxResults": 100,
+            "maxRecords": 5000
+          }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "recent_completed_work",
+      "name": "Jira recent completed work",
+      "description": "Recently completed issues for a project.",
+      "icon": "ListChecks",
+      "fieldsSchema": {
+        "root[].key": "string",
+        "root[].summary": "string",
+        "root[].assignee": "string",
+        "root[].doneAt": "date"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "includeDoneAt": true,
+          "jql": "project IN ({{projects}}) AND statusCategory = Done AND statusCategoryChangedDate >= {{start_date}} AND statusCategoryChangedDate <= {{end_date}} ORDER BY updated DESC",
+          "transform": {
+            "type": "raw"
+          },
+          "pagination": {
+            "startAt": 0,
+            "maxResults": 100,
+            "maxRecords": 500
+          }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true },
+          { "name": "start_date", "type": "date", "default_value": "-30d", "required": false },
+          { "name": "end_date", "type": "date", "default_value": "now()", "required": false }
+        ]
+      }
+    }
+  ],
+  "charts": [
+    {
+      "id": "created-vs-resolved",
+      "name": "Issues created vs resolved",
+      "description": "Created and resolved issues by day.",
+      "icon": "LineChart",
+      "type": "line",
+      "requiredDatasetIds": ["issues_created_resolved"],
+      "layoutIntent": { "kind": "trend", "priority": 10 },
+      "cdcs": [
+        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].created", "legend": "Created", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true },
+        { "datasetTemplateId": "issues_created_resolved", "xAxis": "root[].period", "yAxis": "root[].resolved", "legend": "Resolved", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
+      ]
+    },
+    {
+      "id": "issues-by-status",
+      "name": "Issues by status",
+      "description": "Open issue count grouped by Jira status.",
+      "icon": "BarChart3",
+      "type": "bar",
+      "requiredDatasetIds": ["issues_by_status"],
+      "layoutIntent": { "kind": "comparison", "priority": 20 },
+      "cdc": { "datasetTemplateId": "issues_by_status", "xAxis": "root[].status", "yAxis": "root[].issueCount", "legend": "Issues", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+    },
+    {
+      "id": "issues-by-assignee",
+      "name": "Open issues by assignee",
+      "description": "Open issue count grouped by assignee.",
+      "icon": "Users",
+      "type": "bar",
+      "requiredDatasetIds": ["issues_by_assignee"],
+      "layoutIntent": { "kind": "comparison", "priority": 30 },
+      "cdc": { "datasetTemplateId": "issues_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "legend": "Issues", "datasetColor": "rgba(255, 152, 0, 1)", "fillColor": "rgba(255, 152, 0, 0.14)", "fill": true }
+    },
+    {
+      "id": "recent-completed-work",
+      "name": "Recent completed work",
+      "description": "Recently completed Jira issues.",
+      "icon": "Table",
+      "type": "table",
+      "requiredDatasetIds": ["recent_completed_work"],
+      "layoutIntent": { "kind": "table", "priority": 40 },
+      "cdc": {
+        "datasetTemplateId": "recent_completed_work",
+        "xAxis": "root[]",
+        "datasetColor": "rgba(38, 166, 154, 1)",
+        "columnsOrder": ["key", "summary", "assignee", "doneAt"]
+      }
+    }
+  ]
+}

--- a/server/sources/plugins/jira/templates/sprint-health.json
+++ b/server/sources/plugins/jira/templates/sprint-health.json
@@ -132,7 +132,7 @@
       "type": "gauge",
       "requiredDatasetIds": ["sprint_summary"],
       "layoutIntent": { "kind": "kpi", "priority": 10 },
-      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completionRate", "yAxis": "root[].completionRate", "yAxisOperation": "none", "legend": "Completion rate", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completionRate", "yAxis": "root[].completionRate", "yAxisOperation": "none", "legend": "Completion rate", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true, "formula": "{val * 100}%" }
     },
     {
       "id": "story-points-completed",

--- a/server/sources/plugins/jira/templates/sprint-health.json
+++ b/server/sources/plugins/jira/templates/sprint-health.json
@@ -1,0 +1,183 @@
+{
+  "id": "jira-sprint-health",
+  "slug": "sprint-health",
+  "version": 1,
+  "source": "jira",
+  "name": "Jira Sprint Health",
+  "description": "Sprint completion, story points, carryover, workload, and status breakdowns.",
+  "requiredConnection": {
+    "type": "jira",
+    "subType": "jira"
+  },
+  "datasets": [
+    {
+      "id": "sprint_summary",
+      "name": "Jira sprint summary",
+      "description": "Sprint completion and story point totals.",
+      "icon": "Gauge",
+      "fieldsSchema": {
+        "root[].committedIssues": "number",
+        "root[].completedIssues": "number",
+        "root[].completionRate": "number",
+        "root[].committedStoryPoints": "number",
+        "root[].completedStoryPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "sprint_issues",
+          "mode": "visual",
+          "sprintId": "{{sprint_id}}",
+          "jql": "",
+          "transform": { "type": "sprint_summary" },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "sprint_id", "type": "number", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "sprint_by_assignee",
+      "name": "Jira sprint work by assignee",
+      "description": "Sprint issue count and story points by assignee.",
+      "icon": "Users",
+      "fieldsSchema": {
+        "root[].assignee": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "sprint_issues",
+          "mode": "visual",
+          "sprintId": "{{sprint_id}}",
+          "jql": "",
+          "transform": {
+            "type": "grouped",
+            "metric": "storyPoints",
+            "groupBy": "assignee"
+          },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "sprint_id", "type": "number", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "sprint_by_status",
+      "name": "Jira sprint issue status",
+      "description": "Sprint issue count by status category.",
+      "icon": "PieChart",
+      "fieldsSchema": {
+        "root[].statusCategory": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "sprint_issues",
+          "mode": "visual",
+          "sprintId": "{{sprint_id}}",
+          "jql": "",
+          "transform": {
+            "type": "grouped",
+            "metric": "count",
+            "groupBy": "statusCategory"
+          },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "sprint_id", "type": "number", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "sprint_carryover",
+      "name": "Jira sprint carryover issues",
+      "description": "Sprint issues that are not done.",
+      "icon": "Table",
+      "fieldsSchema": {
+        "root[].key": "string",
+        "root[].summary": "string",
+        "root[].assignee": "string",
+        "root[].status": "string",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "sprint_issues",
+          "mode": "visual",
+          "sprintId": "{{sprint_id}}",
+          "jql": "statusCategory != Done",
+          "transform": { "type": "raw" },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 1000 }
+        },
+        "variableBindings": [
+          { "name": "sprint_id", "type": "number", "default_value": "", "required": true }
+        ]
+      }
+    }
+  ],
+  "charts": [
+    {
+      "id": "sprint-completion",
+      "name": "Sprint completion",
+      "description": "Completed issues divided by committed issues.",
+      "icon": "Gauge",
+      "type": "gauge",
+      "requiredDatasetIds": ["sprint_summary"],
+      "layoutIntent": { "kind": "kpi", "priority": 10 },
+      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completionRate", "yAxis": "root[].completionRate", "legend": "Completion rate", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
+    },
+    {
+      "id": "story-points-completed",
+      "name": "Story points completed",
+      "description": "Completed story points for the selected sprint.",
+      "icon": "BadgeCheck",
+      "type": "kpi",
+      "requiredDatasetIds": ["sprint_summary"],
+      "layoutIntent": { "kind": "kpi", "priority": 20 },
+      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completedStoryPoints", "yAxis": "root[].completedStoryPoints", "legend": "Story points", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+    },
+    {
+      "id": "sprint-work-by-assignee",
+      "name": "Sprint work by assignee",
+      "description": "Sprint story points grouped by assignee.",
+      "icon": "Users",
+      "type": "bar",
+      "requiredDatasetIds": ["sprint_by_assignee"],
+      "layoutIntent": { "kind": "comparison", "priority": 30 },
+      "cdc": { "datasetTemplateId": "sprint_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].storyPoints", "legend": "Story points", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+    },
+    {
+      "id": "sprint-status-breakdown",
+      "name": "Sprint status breakdown",
+      "description": "Sprint issues grouped by status category.",
+      "icon": "PieChart",
+      "type": "doughnut",
+      "requiredDatasetIds": ["sprint_by_status"],
+      "layoutIntent": { "kind": "comparison", "priority": 40 },
+      "cdc": { "datasetTemplateId": "sprint_by_status", "xAxis": "root[].statusCategory", "yAxis": "root[].issueCount", "legend": "Issues", "datasetColor": "rgba(255, 255, 255, 1)", "fillColor": ["rgba(66, 133, 244, 1)", "rgba(255, 152, 0, 1)", "rgba(38, 166, 154, 1)"], "multiFill": true }
+    },
+    {
+      "id": "carryover-issues",
+      "name": "Carryover issues",
+      "description": "Sprint issues that are not done.",
+      "icon": "Table",
+      "type": "table",
+      "requiredDatasetIds": ["sprint_carryover"],
+      "layoutIntent": { "kind": "table", "priority": 50 },
+      "cdc": {
+        "datasetTemplateId": "sprint_carryover",
+        "xAxis": "root[]",
+        "datasetColor": "rgba(255, 152, 0, 1)",
+        "columnsOrder": ["key", "summary", "assignee", "status", "storyPoints"]
+      }
+    }
+  ]
+}

--- a/server/sources/plugins/jira/templates/sprint-health.json
+++ b/server/sources/plugins/jira/templates/sprint-health.json
@@ -132,7 +132,7 @@
       "type": "gauge",
       "requiredDatasetIds": ["sprint_summary"],
       "layoutIntent": { "kind": "kpi", "priority": 10 },
-      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completionRate", "yAxis": "root[].completionRate", "legend": "Completion rate", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completionRate", "yAxis": "root[].completionRate", "yAxisOperation": "none", "legend": "Completion rate", "datasetColor": "rgba(38, 166, 154, 1)", "fillColor": "rgba(38, 166, 154, 0.14)", "fill": true }
     },
     {
       "id": "story-points-completed",
@@ -142,7 +142,7 @@
       "type": "kpi",
       "requiredDatasetIds": ["sprint_summary"],
       "layoutIntent": { "kind": "kpi", "priority": 20 },
-      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completedStoryPoints", "yAxis": "root[].completedStoryPoints", "legend": "Story points", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "sprint_summary", "xAxis": "root[].completedStoryPoints", "yAxis": "root[].completedStoryPoints", "yAxisOperation": "none", "legend": "Story points", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
     },
     {
       "id": "sprint-work-by-assignee",
@@ -152,7 +152,7 @@
       "type": "bar",
       "requiredDatasetIds": ["sprint_by_assignee"],
       "layoutIntent": { "kind": "comparison", "priority": 30 },
-      "cdc": { "datasetTemplateId": "sprint_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].storyPoints", "legend": "Story points", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "sprint_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].storyPoints", "yAxisOperation": "none", "legend": "Story points", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
     },
     {
       "id": "sprint-status-breakdown",
@@ -162,7 +162,7 @@
       "type": "doughnut",
       "requiredDatasetIds": ["sprint_by_status"],
       "layoutIntent": { "kind": "comparison", "priority": 40 },
-      "cdc": { "datasetTemplateId": "sprint_by_status", "xAxis": "root[].statusCategory", "yAxis": "root[].issueCount", "legend": "Issues", "datasetColor": "rgba(255, 255, 255, 1)", "fillColor": ["rgba(66, 133, 244, 1)", "rgba(255, 152, 0, 1)", "rgba(38, 166, 154, 1)"], "multiFill": true }
+      "cdc": { "datasetTemplateId": "sprint_by_status", "xAxis": "root[].statusCategory", "yAxis": "root[].issueCount", "yAxisOperation": "none", "legend": "Issues", "datasetColor": "rgba(255, 255, 255, 1)", "fillColor": ["rgba(66, 133, 244, 1)", "rgba(255, 152, 0, 1)", "rgba(38, 166, 154, 1)"], "multiFill": true }
     },
     {
       "id": "carryover-issues",
@@ -175,6 +175,8 @@
       "cdc": {
         "datasetTemplateId": "sprint_carryover",
         "xAxis": "root[]",
+        "yAxis": "root[].key",
+        "yAxisOperation": "none",
         "datasetColor": "rgba(255, 152, 0, 1)",
         "columnsOrder": ["key", "summary", "assignee", "status", "storyPoints"]
       }

--- a/server/sources/plugins/jira/templates/team-workload.json
+++ b/server/sources/plugins/jira/templates/team-workload.json
@@ -102,7 +102,7 @@
       "type": "bar",
       "requiredDatasetIds": ["open_by_assignee"],
       "layoutIntent": { "kind": "comparison", "priority": 10 },
-      "cdc": { "datasetTemplateId": "open_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "legend": "Open issues", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "open_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "yAxisOperation": "none", "legend": "Open issues", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
     },
     {
       "id": "wip-by-assignee",
@@ -112,7 +112,7 @@
       "type": "bar",
       "requiredDatasetIds": ["wip_by_assignee"],
       "layoutIntent": { "kind": "comparison", "priority": 20 },
-      "cdc": { "datasetTemplateId": "wip_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "legend": "WIP issues", "datasetColor": "rgba(255, 152, 0, 1)", "fillColor": "rgba(255, 152, 0, 0.14)", "fill": true }
+      "cdc": { "datasetTemplateId": "wip_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "yAxisOperation": "none", "legend": "WIP issues", "datasetColor": "rgba(255, 152, 0, 1)", "fillColor": "rgba(255, 152, 0, 0.14)", "fill": true }
     },
     {
       "id": "stale-issues",
@@ -125,6 +125,8 @@
       "cdc": {
         "datasetTemplateId": "stale_issues",
         "xAxis": "root[]",
+        "yAxis": "root[].key",
+        "yAxisOperation": "none",
         "datasetColor": "rgba(255, 152, 0, 1)",
         "columnsOrder": ["key", "summary", "assignee", "status", "updatedAt"]
       }

--- a/server/sources/plugins/jira/templates/team-workload.json
+++ b/server/sources/plugins/jira/templates/team-workload.json
@@ -1,0 +1,133 @@
+{
+  "id": "jira-team-workload",
+  "slug": "team-workload",
+  "version": 1,
+  "source": "jira",
+  "name": "Jira Team Workload",
+  "description": "Open work, work in progress, and stale issues by assignee.",
+  "requiredConnection": {
+    "type": "jira",
+    "subType": "jira"
+  },
+  "datasets": [
+    {
+      "id": "open_by_assignee",
+      "name": "Jira open issues by assignee",
+      "description": "Open issue count grouped by assignee.",
+      "icon": "Users",
+      "fieldsSchema": {
+        "root[].assignee": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND statusCategory != Done",
+          "transform": {
+            "type": "grouped",
+            "metric": "count",
+            "groupBy": "assignee"
+          },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "wip_by_assignee",
+      "name": "Jira work in progress by assignee",
+      "description": "In-progress issue count grouped by assignee.",
+      "icon": "Activity",
+      "fieldsSchema": {
+        "root[].assignee": "string",
+        "root[].issueCount": "number",
+        "root[].storyPoints": "number"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND statusCategory = \"In Progress\"",
+          "transform": {
+            "type": "grouped",
+            "metric": "count",
+            "groupBy": "assignee"
+          },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 5000 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "stale_issues",
+      "name": "Jira stale issues",
+      "description": "Open issues not updated recently.",
+      "icon": "Clock",
+      "fieldsSchema": {
+        "root[].key": "string",
+        "root[].summary": "string",
+        "root[].assignee": "string",
+        "root[].status": "string",
+        "root[].updatedAt": "date"
+      },
+      "dataRequest": {
+        "configuration": {
+          "source": "jira",
+          "resource": "issues",
+          "mode": "visual",
+          "jql": "project IN ({{projects}}) AND statusCategory != Done AND updated <= -14d ORDER BY updated ASC",
+          "transform": { "type": "stale_table" },
+          "pagination": { "startAt": 0, "maxResults": 100, "maxRecords": 500 }
+        },
+        "variableBindings": [
+          { "name": "projects", "type": "string", "default_value": "", "required": true }
+        ]
+      }
+    }
+  ],
+  "charts": [
+    {
+      "id": "open-issues-by-assignee",
+      "name": "Open issues by assignee",
+      "description": "Open issues grouped by assignee.",
+      "icon": "Users",
+      "type": "bar",
+      "requiredDatasetIds": ["open_by_assignee"],
+      "layoutIntent": { "kind": "comparison", "priority": 10 },
+      "cdc": { "datasetTemplateId": "open_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "legend": "Open issues", "datasetColor": "rgba(66, 133, 244, 1)", "fillColor": "rgba(66, 133, 244, 0.14)", "fill": true }
+    },
+    {
+      "id": "wip-by-assignee",
+      "name": "Work in progress by assignee",
+      "description": "In-progress issues grouped by assignee.",
+      "icon": "Activity",
+      "type": "bar",
+      "requiredDatasetIds": ["wip_by_assignee"],
+      "layoutIntent": { "kind": "comparison", "priority": 20 },
+      "cdc": { "datasetTemplateId": "wip_by_assignee", "xAxis": "root[].assignee", "yAxis": "root[].issueCount", "legend": "WIP issues", "datasetColor": "rgba(255, 152, 0, 1)", "fillColor": "rgba(255, 152, 0, 0.14)", "fill": true }
+    },
+    {
+      "id": "stale-issues",
+      "name": "Stale issues",
+      "description": "Open issues that have not been updated recently.",
+      "icon": "Table",
+      "type": "table",
+      "requiredDatasetIds": ["stale_issues"],
+      "layoutIntent": { "kind": "table", "priority": 30 },
+      "cdc": {
+        "datasetTemplateId": "stale_issues",
+        "xAxis": "root[]",
+        "datasetColor": "rgba(255, 152, 0, 1)",
+        "columnsOrder": ["key", "summary", "assignee", "status", "updatedAt"]
+      }
+    }
+  ]
+}

--- a/server/tests/integration/chartTemplateRoute.test.js
+++ b/server/tests/integration/chartTemplateRoute.test.js
@@ -252,6 +252,38 @@ describe("ChartTemplateRoute", () => {
     expect(projectBinding.required).toBe(true);
   });
 
+  it("creates Jira template charts with complete dataset config fields", async () => {
+    const seeded = await seedJiraTemplateSetup(models);
+
+    const response = await request(app)
+      .post(`/team/${seeded.team.id}/chart-templates/jira/project-overview/create`)
+      .set("Authorization", `Bearer ${seeded.token}`)
+      .send({
+        connection_id: seeded.connection.id,
+        dashboard: { type: "existing", project_id: seeded.project.id },
+        dataset_template_ids: ["issues_by_status"],
+        chart_template_ids: ["issues-by-status"],
+        variable_defaults: {
+          projects: "CHART",
+        },
+      })
+      .expect(200);
+
+    const chart = await models.Chart.findByPk(response.body.charts[0].id, {
+      include: [{ model: models.ChartDatasetConfig }],
+    });
+    const dataset = await models.Dataset.findByPk(response.body.datasets[0].id);
+    const [cdc] = chart.ChartDatasetConfigs;
+
+    expect(cdc.xAxis).toBe("root[].status");
+    expect(cdc.yAxis).toBe("root[].issueCount");
+    expect(cdc.yAxisOperation).toBe("none");
+    expect(dataset.fieldsSchema).toEqual(expect.objectContaining({
+      "root[].status": "string",
+      "root[].issueCount": "number",
+    }));
+  });
+
   it("rejects cross-team connections", async () => {
     const seeded = await seedStripeTemplateSetup(models);
     const otherTeam = await models.Team.create(teamFactory.build());

--- a/server/tests/integration/chartTemplateRoute.test.js
+++ b/server/tests/integration/chartTemplateRoute.test.js
@@ -59,6 +59,32 @@ async function seedStripeTemplateSetup(models) {
   };
 }
 
+async function seedJiraTemplateSetup(models) {
+  const seeded = await seedStripeTemplateSetup(models);
+  const connection = await models.Connection.create(connectionFactory.build({
+    team_id: seeded.team.id,
+    project_ids: [],
+    type: "jira",
+    subType: "jira",
+    host: "https://chartbrew.atlassian.net",
+    authentication: {
+      type: "api_token",
+      email: "raz@example.com",
+      apiToken: "token",
+    },
+    options: {
+      jira: {
+        siteUrl: "https://chartbrew.atlassian.net",
+      },
+    },
+  }));
+
+  return {
+    ...seeded,
+    connection,
+  };
+}
+
 describe("ChartTemplateRoute", () => {
   let app;
   let models;
@@ -192,6 +218,38 @@ describe("ChartTemplateRoute", () => {
     expect(datasets).toHaveLength(2);
     expect(datasets[0].DataRequests[0].template).toBe("stripe");
     expect(charts).toHaveLength(0);
+  });
+
+  it("applies template variable defaults when creating Jira datasets", async () => {
+    const seeded = await seedJiraTemplateSetup(models);
+
+    const response = await request(app)
+      .post(`/team/${seeded.team.id}/chart-templates/jira/project-overview/create`)
+      .set("Authorization", `Bearer ${seeded.token}`)
+      .send({
+        connection_id: seeded.connection.id,
+        dashboard: { type: "existing", project_id: seeded.project.id },
+        dataset_template_ids: ["issues_by_status"],
+        chart_template_ids: [],
+        variable_defaults: {
+          projects: "CHART",
+        },
+      })
+      .expect(200);
+
+    const dataRequest = await models.DataRequest.findOne({
+      where: { dataset_id: response.body.datasets[0].id },
+    });
+    const projectBinding = await models.VariableBinding.findOne({
+      where: {
+        entity_type: "DataRequest",
+        entity_id: `${dataRequest.id}`,
+        name: "projects",
+      },
+    });
+
+    expect(projectBinding.default_value).toBe("CHART");
+    expect(projectBinding.required).toBe(true);
   });
 
   it("rejects cross-team connections", async () => {

--- a/server/tests/integration/connectionRoute.security.test.js
+++ b/server/tests/integration/connectionRoute.security.test.js
@@ -89,6 +89,19 @@ async function seedProjectScopedAccess(models) {
     connectionString: "mongodb://user:pass@mongo.example.com:27017/app",
   }));
 
+  const allowedJiraConnection = await models.Connection.create(connectionFactory.build({
+    team_id: team.id,
+    project_ids: [allowedProject.id],
+    type: "jira",
+    subType: "jira",
+    host: "https://chartbrew.atlassian.net",
+    authentication: JSON.stringify({
+      type: "api_token",
+      email: "raz@example.com",
+      apiToken: "jira-token",
+    }),
+  }));
+
   const restrictedApiConnection = await models.Connection.create(connectionFactory.build({
     team_id: team.id,
     project_ids: [restrictedProject.id],
@@ -113,6 +126,7 @@ async function seedProjectScopedAccess(models) {
       allowedStripeConnection,
       allowedStrapiConnection,
       allowedMongoConnection,
+      allowedJiraConnection,
       restrictedApiConnection,
     },
   };
@@ -170,6 +184,28 @@ describe("ConnectionRoute project scoping", () => {
 
     expect(response.body).toEqual({ error: "Unsupported source action" });
     expect(internalSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows Jira source actions for connections assigned to the caller's project", async () => {
+    const seeded = await seedProjectScopedAccess(models);
+    const jiraSource = getSourceById("jira");
+    const actionSpy = vi.spyOn(jiraSource.backend.actions, "listProjects")
+      .mockResolvedValue([{ id: "10000", key: "CHART", name: "Chartbrew" }]);
+
+    const response = await request(app)
+      .post(`/team/${seeded.team.id}/connections/${seeded.connections.allowedJiraConnection.id}/source-action`)
+      .set("Authorization", `Bearer ${seeded.token}`)
+      .send({ action: "listProjects" })
+      .expect(200);
+
+    expect(response.body).toEqual([{ id: "10000", key: "CHART", name: "Chartbrew" }]);
+    expect(actionSpy).toHaveBeenCalledWith(expect.objectContaining({
+      connection: expect.objectContaining({
+        id: seeded.connections.allowedJiraConnection.id,
+        type: "jira",
+      }),
+      params: {},
+    }));
   });
 
   it("rejects source actions for same-team connections outside the caller's projects", async () => {

--- a/server/tests/unit/axisChartRuntime.test.js
+++ b/server/tests/unit/axisChartRuntime.test.js
@@ -103,4 +103,44 @@ describe("AxisChart runtime date handling", () => {
     expect(result.configuration.data.datasets[0].label).toBe("Dataset 1");
     expect(result.configuration.data.datasets[1].label).toBe("Dataset 2");
   });
+
+  it("sums numeric rows in the same date bucket when no y-axis operation is selected", async () => {
+    const chart = {
+      id: 1492,
+      type: "line",
+      timeInterval: "month",
+      includeZeros: false,
+      displayLegend: true,
+      ChartDatasetConfigs: [{
+        id: "cdc-1",
+        legend: "Created",
+      }],
+    };
+
+    const datasets = [{
+      options: {
+        id: "cdc-1",
+        dateField: "root[].period",
+        xAxis: "root[].period",
+        yAxis: "root[].created",
+        yAxisOperation: "none",
+        legend: "Created",
+        fieldsSchema: {
+          "root[].period": "date",
+          "root[].created": "number",
+        },
+      },
+      data: [
+        { period: "2026-04-02T00:00:00.000Z", created: 1 },
+        { period: "2026-04-14T00:00:00.000Z", created: 3 },
+        { period: "2026-05-01T00:00:00.000Z", created: 2 },
+      ],
+    }];
+
+    const axisChart = new AxisChart({ chart, datasets }, "UTC");
+    const result = await axisChart.plot(false, [], {});
+
+    expect(result.configuration.data.labels).toEqual(["Apr", "May"]);
+    expect(result.configuration.data.datasets[0].data).toEqual([4, 2]);
+  });
 });

--- a/server/tests/unit/jiraAi.test.js
+++ b/server/tests/unit/jiraAi.test.js
@@ -9,11 +9,53 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 const jiraAi = require("../../sources/plugins/jira/ai/jira.ai");
+const jiraProtocol = require("../../sources/plugins/jira/jira.protocol");
+const jiraResolver = require("../../sources/plugins/jira/ai/jira.resolver");
 const jiraConnection = require("../../sources/plugins/jira/jira.connection");
 
 describe("Jira AI planner", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("exposes Jira semantic capabilities and resource planning metadata", () => {
+    const capabilities = jiraAi.getCapabilities();
+    const resources = jiraAi.listResources();
+    const sprintIssues = resources.resources.find((resource) => resource.id === "sprint_issues");
+    const issues = resources.resources.find((resource) => resource.id === "issues");
+
+    expect(capabilities.supports.discovery).toEqual(expect.arrayContaining([
+      "projects",
+      "boards",
+      "sprints",
+      "versions",
+      "users",
+      "fields",
+    ]));
+    expect(capabilities.supports.semanticIntents).toEqual(expect.arrayContaining([
+      "sprint_status",
+      "sprint_summary",
+      "bug_breakdown",
+      "release_progress",
+    ]));
+    expect(capabilities.supports.riskPolicy).toMatchObject({
+      preview: "best_match",
+      persist: "disambiguate_meaningful_uncertainty",
+    });
+    expect(sprintIssues).toMatchObject({
+      id: "sprint_issues",
+      requires: ["sprint"],
+      canAutoResolve: ["project", "board", "activeSprint"],
+      metrics: expect.arrayContaining(["count", "storyPoints", "completionRate"]),
+      dimensions: expect.arrayContaining(["status", "statusCategory", "assignee", "priority", "issueType"]),
+      transforms: expect.arrayContaining(["raw", "grouped", "sprint_summary", "stale_table"]),
+      dateFields: expect.arrayContaining(["createdAt", "updatedAt", "resolvedAt", "doneAt"]),
+    });
+    expect(issues.filters).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: "statusCategory" }),
+      expect.objectContaining({ field: "assignee" }),
+      expect.objectContaining({ field: "fixVersion" }),
+    ]));
   });
 
   it("resolves an active sprint from a project key before planning sprint status", async () => {
@@ -60,7 +102,373 @@ describe("Jira AI planner", () => {
     });
   });
 
-  it("asks for a useful choice when no active sprint can be resolved", async () => {
+  it("returns resolution and correction actions for active sprint status", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "D2371 Sprint 14",
+      state: "active",
+    }]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show me the active sprint status for D2371",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.rationale.intent).toBe("sprint_status");
+    expect(plan.resolution.project).toMatchObject({ key: "D2371" });
+    expect(plan.resolution.board).toMatchObject({ id: "77" });
+    expect(plan.resolution.sprint).toMatchObject({ id: "123" });
+    expect(plan.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ value: "change_sprint" }),
+      expect.objectContaining({ value: "group_by_assignee" }),
+    ]));
+  });
+
+  it("plans a sprint summary from follow-up overrides", async () => {
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show me a simple sprint summary",
+      overrides: {
+        project: "D2371",
+        boardId: "77",
+        sprintId: "123",
+      },
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.rationale.intent).toBe("sprint_summary");
+    expect(plan.configuration).toMatchObject({
+      resource: "sprint_issues",
+      sprintId: "123",
+      boardId: "77",
+      transform: { type: "sprint_summary" },
+    });
+    expect(plan.chartSpec.type).toBe("gauge");
+  });
+
+  it("falls back to project status breakdown when active sprint cannot be resolved", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show me the active sprint status for D2371",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("fallback");
+    expect(plan.message).toContain("project status breakdown");
+    expect(plan.configuration).toMatchObject({
+      resource: "issues",
+      transform: {
+        type: "grouped",
+        groupBy: "status",
+        metric: "count",
+      },
+    });
+    expect(plan.configuration.jql).toContain("project IN (\"D2371\")");
+    expect(plan.configuration.jql).not.toContain("created >=");
+  });
+
+  it("plans Jira release progress from a version name", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([{
+      id: "20001",
+      name: "v5.2.0",
+      released: false,
+    }]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show release readiness for D2371 v5.2.0",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.rationale.intent).toBe("release_progress");
+    expect(plan.configuration.jql).toContain("fixVersion IN (\"v5.2.0\")");
+    expect(plan.configuration.jql).not.toContain("created >=");
+    expect(plan.resolution.version).toMatchObject({
+      name: "v5.2.0",
+    });
+  });
+
+  it.each([
+    ["empty version discovery", []],
+    ["failed version discovery", new Error("Jira versions unavailable")],
+  ])("keeps release version token when %s", async (name, versionsResult) => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    const versionsSpy = vi.spyOn(jiraConnection, "listVersions");
+    if (versionsResult instanceof Error) {
+      versionsSpy.mockRejectedValue(versionsResult);
+    } else {
+      versionsSpy.mockResolvedValue(versionsResult);
+    }
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show release readiness for D2371 v5.2.0",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.rationale.intent).toBe("release_progress");
+    expect(plan.configuration.jql).toContain("fixVersion IN (\"v5.2.0\")");
+    expect(plan.configuration.jql).not.toContain("created >=");
+  });
+
+  it("applies resolved Jira users to planned workload JQL", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
+      accountId: "abc",
+      displayName: "Jane Product",
+    }]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show workload for D2371 assigned to Jane",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.rationale.intent).toBe("team_workload");
+    expect(plan.configuration.jql).toContain("assignee IN (\"abc\")");
+    expect(plan.configuration.transform).toMatchObject({
+      type: "grouped",
+      groupBy: "assignee",
+    });
+  });
+
+  it("plans current work by assignee without requiring a project", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([]);
+    vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
+      accountId: "raz-account",
+      displayName: "Razvan Ilin",
+    }]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "what tasks is Razvan working on currently?",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.configuration.jql).not.toContain("project IN ()");
+    expect(plan.configuration.jql).not.toContain("{{projects}}");
+    expect(plan.configuration.jql).not.toContain("created >=");
+    expect(plan.configuration.jql).toContain("assignee IN (\"raz-account\")");
+    expect(plan.configuration.jql).toContain("statusCategory != Done");
+    expect(plan.chartSpec.type).toBe("table");
+  });
+
+  it("plans created resolved trend from explicit intent overrides", async () => {
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42 },
+      question: "show project movement",
+      overrides: {
+        intent: "created_resolved_trend",
+        project: "D2371",
+      },
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.rationale.intent).toBe("created_resolved_trend");
+    expect(plan.configuration).toMatchObject({
+      resource: "issues",
+      transform: {
+        type: "created_resolved_trend",
+      },
+      includeDoneAt: true,
+    });
+    expect(plan.chartSpec.type).toBe("line");
+  });
+
+  it("normalizes preview issues with doneAt when requested", async () => {
+    vi.spyOn(jiraProtocol, "fetchJiraRows").mockResolvedValue([{
+      key: "D2371-1",
+      fields: {
+        summary: "Ship release checklist",
+        project: { key: "D2371" },
+        status: {
+          name: "Done",
+          statusCategory: {
+            key: "done",
+            name: "Done",
+          },
+        },
+        created: "2026-01-01T00:00:00.000Z",
+        updated: "2026-01-04T00:00:00.000Z",
+        resolutiondate: null,
+      },
+      changelog: {
+        histories: [{
+          created: "2026-01-03T12:00:00.000Z",
+          items: [{
+            field: "status",
+            toString: "Done",
+          }],
+        }],
+      },
+    }]);
+
+    const preview = await jiraAi.previewConfiguration({
+      connection: { id: 42 },
+      configuration: {
+        source: "jira",
+        resource: "issues",
+        mode: "jql",
+        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        includeDoneAt: true,
+        transform: { type: "raw" },
+      },
+      rowLimit: 5,
+    });
+
+    expect(preview.status).toBe("ok");
+    expect(preview.rows[0].doneAt).toBe("2026-01-03T12:00:00.000Z");
+  });
+
+  it("falls back to project status when sprint issue preview fails", async () => {
+    const jiraProtocol = require("../../sources/plugins/jira/jira.protocol");
+    const fetchSpy = vi.spyOn(jiraProtocol, "fetchJiraRows");
+    fetchSpy
+      .mockRejectedValueOnce(new Error("400 - The sprint field is invalid"))
+      .mockResolvedValueOnce([{
+        key: "D2371-1",
+        fields: {
+          summary: "Fallback issue",
+          project: { key: "D2371" },
+          issuetype: { name: "Story" },
+          status: { name: "In Progress", statusCategory: { name: "In Progress", key: "indeterminate" } },
+          created: "2026-05-01T00:00:00.000Z",
+          updated: "2026-05-02T00:00:00.000Z",
+        },
+      }]);
+
+    const preview = await jiraAi.previewConfiguration({
+      connection: { id: 42 },
+      rowLimit: 5,
+      configuration: {
+        source: "jira",
+        resource: "sprint_issues",
+        mode: "visual",
+        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
+        sprintId: "123",
+        boardId: "77",
+        projectIdOrKey: "D2371",
+        transform: { type: "grouped", groupBy: "status", metric: "count" },
+        pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
+      },
+    });
+
+    expect(preview.status).toBe("fallback");
+    expect(preview.message).toContain("project status breakdown");
+    expect(preview.message).toContain("400 - The sprint field is invalid");
+    expect(preview.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining("400 - The sprint field is invalid"),
+    ]));
+    expect(preview.rows).toEqual([{ status: "In Progress", issueCount: 1, storyPoints: 0 }]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({
+      resource: "issues",
+      sprintId: undefined,
+      boardId: undefined,
+      projectIdOrKey: "D2371",
+      transform: { type: "grouped", groupBy: "status", metric: "count" },
+      includeDoneAt: false,
+    });
+    expect(fetchSpy.mock.calls[1][1].jql).toContain("project IN (\"D2371\")");
+    expect(fetchSpy.mock.calls[1][1].jql).toContain("statusCategory != Done");
+    expect(fetchSpy.mock.calls[1][1].jql).not.toContain("created >=");
+  });
+
+  it("does not fallback for generic missing resource preview errors", async () => {
+    const jiraProtocol = require("../../sources/plugins/jira/jira.protocol");
+    const fetchSpy = vi.spyOn(jiraProtocol, "fetchJiraRows")
+      .mockRejectedValueOnce(new Error("404 - Project does not exist"));
+
+    await expect(jiraAi.previewConfiguration({
+      connection: { id: 42 },
+      rowLimit: 5,
+      configuration: {
+        source: "jira",
+        resource: "sprint_issues",
+        mode: "visual",
+        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
+        sprintId: "123",
+        boardId: "77",
+        projectIdOrKey: "D2371",
+        transform: { type: "grouped", groupBy: "status", metric: "count" },
+        pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
+      },
+    })).rejects.toThrow("404 - Project does not exist");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fallback for generic missing field preview errors", async () => {
+    const jiraProtocol = require("../../sources/plugins/jira/jira.protocol");
+    const fetchSpy = vi.spyOn(jiraProtocol, "fetchJiraRows")
+      .mockRejectedValueOnce(new Error("400 - Field not found"));
+
+    await expect(jiraAi.previewConfiguration({
+      connection: { id: 42 },
+      rowLimit: 5,
+      configuration: {
+        source: "jira",
+        resource: "sprint_issues",
+        mode: "visual",
+        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
+        sprintId: "123",
+        boardId: "77",
+        projectIdOrKey: "D2371",
+        transform: { type: "grouped", groupBy: "status", metric: "count" },
+        pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
+      },
+    })).rejects.toThrow("400 - Field not found");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a useful fallback when no active sprint can be resolved", async () => {
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
       name: "D2371 Scrum Board",
@@ -73,11 +481,241 @@ describe("Jira AI planner", () => {
       question: "show me the active sprint status for D2371",
     });
 
-    expect(plan.status).toBe("needs_disambiguation");
+    expect(plan.status).toBe("fallback");
     expect(plan.message).toContain("active sprint");
-    expect(plan.options).toEqual(expect.arrayContaining([
+    expect(plan.actions).toEqual(expect.arrayContaining([
       expect.objectContaining({ value: "status_breakdown" }),
-      expect.objectContaining({ value: "pick_board" }),
+      expect.objectContaining({ value: "show_table" }),
     ]));
+  });
+
+  it("resolves exact project, single scrum board, and active sprint context", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "Sprint 14",
+      state: "active",
+    }]);
+
+    const context = await jiraResolver.resolveContext({
+      connection: { id: 42 },
+      question: "show active sprint status for D2371",
+      intent: { id: "sprint_status", resource: "sprint_issues" },
+      mode: "preview",
+    });
+
+    expect(context.needsDisambiguation).toBe(false);
+    expect(context.entities.project).toMatchObject({
+      id: "10001",
+      key: "D2371",
+      confidence: 0.98,
+    });
+    expect(context.entities.board).toMatchObject({
+      id: "77",
+      confidence: 0.9,
+    });
+    expect(context.entities.sprint).toMatchObject({
+      id: "123",
+      state: "active",
+      confidence: 0.95,
+    });
+  });
+
+  it("resolves an active sprint from the second matching board", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }, {
+      id: 88,
+      name: "D2371 Delivery Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockImplementation((connection, params) => {
+      if (params.boardId === 88) {
+        return Promise.resolve([{
+          id: 456,
+          name: "Sprint 22",
+          state: "active",
+        }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const context = await jiraResolver.resolveContext({
+      connection: { id: 42 },
+      question: "show active sprint status for D2371",
+      intent: { id: "sprint_status", resource: "sprint_issues" },
+      mode: "preview",
+    });
+
+    expect(context.needsDisambiguation).toBe(false);
+    expect(context.entities.board).toMatchObject({
+      id: "88",
+      name: "D2371 Delivery Board",
+      confidence: 0.9,
+    });
+    expect(context.entities.sprint).toMatchObject({
+      id: "456",
+      name: "Sprint 22",
+      state: "active",
+      confidence: 0.95,
+    });
+    expect(jiraConnection.listSprints).toHaveBeenCalledWith(expect.any(Object), {
+      boardId: 77,
+      maxResults: 50,
+      state: "active",
+    });
+    expect(jiraConnection.listSprints).toHaveBeenCalledWith(expect.any(Object), {
+      boardId: 88,
+      maxResults: 50,
+      state: "active",
+    });
+  });
+
+  it("asks for sprint disambiguation in persist mode when multiple active sprints exist", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "Sprint 14",
+      state: "active",
+    }, {
+      id: 124,
+      name: "Sprint 15",
+      state: "active",
+    }]);
+
+    const context = await jiraResolver.resolveContext({
+      connection: { id: 42 },
+      question: "show active sprint status for D2371",
+      intent: { id: "sprint_status", resource: "sprint_issues" },
+      mode: "persist",
+    });
+
+    expect(context.needsDisambiguation).toBe(true);
+    expect(context.entities.sprint).toBeUndefined();
+    expect(context.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({ value: "sprint:123" }),
+      expect.objectContaining({ value: "sprint:124" }),
+    ]));
+  });
+
+  it("resolves users and versions only when requested by intent", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
+      accountId: "abc",
+      displayName: "Jane Doe",
+    }]);
+    vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([{
+      id: "20001",
+      name: "v5.2.0",
+    }]);
+
+    const context = await jiraResolver.resolveContext({
+      connection: { id: 42 },
+      question: "show release readiness for D2371 v5.2.0 assigned to Jane",
+      intent: {
+        id: "release_progress",
+        resource: "issues",
+        needsVersion: true,
+        needsUser: true,
+      },
+      mode: "preview",
+    });
+
+    expect(jiraConnection.listUsers).toHaveBeenCalledWith(expect.any(Object), {
+      query: "Jane",
+      maxResults: 20,
+    });
+    expect(jiraConnection.listVersions).toHaveBeenCalledWith(expect.any(Object), {
+      projectIdOrKey: "D2371",
+    });
+    expect(context.entities.user).toMatchObject({
+      accountId: "abc",
+      confidence: 0.8,
+    });
+    expect(context.entities.version).toMatchObject({
+      id: "20001",
+      name: "v5.2.0",
+      confidence: 0.95,
+    });
+  });
+
+  it("adds warnings when user and version discovery fail", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listUsers").mockRejectedValue(new Error("Jira users unavailable"));
+    vi.spyOn(jiraConnection, "listVersions").mockRejectedValue(new Error("Jira versions unavailable"));
+
+    const context = await jiraResolver.resolveContext({
+      connection: { id: 42 },
+      question: "show release readiness for D2371 v5.2.0 assigned to Jane",
+      intent: {
+        id: "release_progress",
+        resource: "issues",
+        needsVersion: true,
+        needsUser: true,
+      },
+      mode: "preview",
+    });
+
+    expect(context.entities.user).toBeNull();
+    expect(context.entities.version).toBeNull();
+    expect(context.warnings).toEqual(expect.arrayContaining([
+      "Could not resolve Jira user.",
+      "Could not resolve Jira version.",
+    ]));
+  });
+
+  it("skips user and version discovery when the intent does not need them", async () => {
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    const listUsersSpy = vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([]);
+    const listVersionsSpy = vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([]);
+
+    const resolution = await jiraResolver.resolveContext({
+      connection: { id: 42 },
+      question: "show issue status for D2371",
+      intent: { id: "issue_breakdown", resource: "issues" },
+      mode: "preview",
+    });
+
+    expect(resolution.entities.user).toBeUndefined();
+    expect(resolution.entities.version).toBeUndefined();
+    expect(listUsersSpy).not.toHaveBeenCalled();
+    expect(listVersionsSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/tests/unit/jiraAi.test.js
+++ b/server/tests/unit/jiraAi.test.js
@@ -61,18 +61,18 @@ describe("Jira AI planner", () => {
   it("resolves an active sprint from a project key before planning sprint status", async () => {
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
       id: 123,
-      name: "D2371 Sprint 14",
+      name: "A4321 Sprint 14",
       state: "active",
     }]);
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42, type: "jira", subType: "jira" },
-      question: "can you show me the status of the active sprint I have for D2371 in Jira?",
+      question: "can you show me the status of the active sprint I have for A4321 in Jira?",
     });
 
     expect(plan.status).toBe("ok");
@@ -85,14 +85,14 @@ describe("Jira AI planner", () => {
         groupBy: "status",
       },
     });
-    expect(plan.configuration.jql).toBe("project IN (\"D2371\") ORDER BY updated DESC");
+    expect(plan.configuration.jql).toBe("project IN (\"A4321\") ORDER BY updated DESC");
     expect(plan.chartSpec).toMatchObject({
       type: "bar",
       xAxis: "root[].status",
       yAxis: "root[].issueCount",
     });
     expect(jiraConnection.listBoards).toHaveBeenCalledWith(expect.any(Object), {
-      projectKeyOrId: "D2371",
+      projectKeyOrId: "A4321",
       maxResults: 50,
     });
     expect(jiraConnection.listSprints).toHaveBeenCalledWith(expect.any(Object), {
@@ -105,29 +105,29 @@ describe("Jira AI planner", () => {
   it("returns resolution and correction actions for active sprint status", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
       id: 123,
-      name: "D2371 Sprint 14",
+      name: "A4321 Sprint 14",
       state: "active",
     }]);
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42 },
-      question: "show me the active sprint status for D2371",
+      question: "show me the active sprint status for A4321",
       mode: "preview",
     });
 
     expect(plan.status).toBe("ok");
     expect(plan.rationale.intent).toBe("sprint_status");
-    expect(plan.resolution.project).toMatchObject({ key: "D2371" });
+    expect(plan.resolution.project).toMatchObject({ key: "A4321" });
     expect(plan.resolution.board).toMatchObject({ id: "77" });
     expect(plan.resolution.sprint).toMatchObject({ id: "123" });
     expect(plan.actions).toEqual(expect.arrayContaining([
@@ -141,7 +141,7 @@ describe("Jira AI planner", () => {
       connection: { id: 42 },
       question: "show me a simple sprint summary",
       overrides: {
-        project: "D2371",
+        project: "A4321",
         boardId: "77",
         sprintId: "123",
       },
@@ -162,19 +162,19 @@ describe("Jira AI planner", () => {
   it("falls back to project status breakdown when active sprint cannot be resolved", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42 },
-      question: "show me the active sprint status for D2371",
+      question: "show me the active sprint status for A4321",
       mode: "preview",
     });
 
@@ -188,15 +188,15 @@ describe("Jira AI planner", () => {
         metric: "count",
       },
     });
-    expect(plan.configuration.jql).toContain("project IN (\"D2371\")");
+    expect(plan.configuration.jql).toContain("project IN (\"A4321\")");
     expect(plan.configuration.jql).not.toContain("created >=");
   });
 
   it("plans Jira release progress from a version name", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([{
       id: "20001",
@@ -206,7 +206,7 @@ describe("Jira AI planner", () => {
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42 },
-      question: "show release readiness for D2371 v5.2.0",
+      question: "show release readiness for A4321 v5.2.0",
       mode: "preview",
     });
 
@@ -225,8 +225,8 @@ describe("Jira AI planner", () => {
   ])("keeps release version token when %s", async (name, versionsResult) => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     const versionsSpy = vi.spyOn(jiraConnection, "listVersions");
     if (versionsResult instanceof Error) {
@@ -237,7 +237,7 @@ describe("Jira AI planner", () => {
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42 },
-      question: "show release readiness for D2371 v5.2.0",
+      question: "show release readiness for A4321 v5.2.0",
       mode: "preview",
     });
 
@@ -250,8 +250,8 @@ describe("Jira AI planner", () => {
   it("applies resolved Jira users to planned workload JQL", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
       accountId: "abc",
@@ -260,7 +260,7 @@ describe("Jira AI planner", () => {
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42 },
-      question: "show workload for D2371 assigned to Jane",
+      question: "show workload for A4321 assigned to Jane",
       mode: "preview",
     });
 
@@ -301,7 +301,7 @@ describe("Jira AI planner", () => {
       question: "show project movement",
       overrides: {
         intent: "created_resolved_trend",
-        project: "D2371",
+        project: "A4321",
       },
       mode: "preview",
     });
@@ -320,10 +320,10 @@ describe("Jira AI planner", () => {
 
   it("normalizes preview issues with doneAt when requested", async () => {
     vi.spyOn(jiraProtocol, "fetchJiraRows").mockResolvedValue([{
-      key: "D2371-1",
+      key: "A4321-1",
       fields: {
         summary: "Ship release checklist",
-        project: { key: "D2371" },
+        project: { key: "A4321" },
         status: {
           name: "Done",
           statusCategory: {
@@ -352,7 +352,7 @@ describe("Jira AI planner", () => {
         source: "jira",
         resource: "issues",
         mode: "jql",
-        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        jql: "project IN (\"A4321\") ORDER BY updated DESC",
         includeDoneAt: true,
         transform: { type: "raw" },
       },
@@ -369,10 +369,10 @@ describe("Jira AI planner", () => {
     fetchSpy
       .mockRejectedValueOnce(new Error("400 - The sprint field is invalid"))
       .mockResolvedValueOnce([{
-        key: "D2371-1",
+        key: "A4321-1",
         fields: {
           summary: "Fallback issue",
-          project: { key: "D2371" },
+          project: { key: "A4321" },
           issuetype: { name: "Story" },
           status: { name: "In Progress", statusCategory: { name: "In Progress", key: "indeterminate" } },
           created: "2026-05-01T00:00:00.000Z",
@@ -387,11 +387,11 @@ describe("Jira AI planner", () => {
         source: "jira",
         resource: "sprint_issues",
         mode: "visual",
-        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        jql: "project IN (\"A4321\") ORDER BY updated DESC",
         fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
         sprintId: "123",
         boardId: "77",
-        projectIdOrKey: "D2371",
+        projectIdOrKey: "A4321",
         transform: { type: "grouped", groupBy: "status", metric: "count" },
         pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
       },
@@ -409,11 +409,11 @@ describe("Jira AI planner", () => {
       resource: "issues",
       sprintId: undefined,
       boardId: undefined,
-      projectIdOrKey: "D2371",
+      projectIdOrKey: "A4321",
       transform: { type: "grouped", groupBy: "status", metric: "count" },
       includeDoneAt: false,
     });
-    expect(fetchSpy.mock.calls[1][1].jql).toContain("project IN (\"D2371\")");
+    expect(fetchSpy.mock.calls[1][1].jql).toContain("project IN (\"A4321\")");
     expect(fetchSpy.mock.calls[1][1].jql).toContain("statusCategory != Done");
     expect(fetchSpy.mock.calls[1][1].jql).not.toContain("created >=");
   });
@@ -430,11 +430,11 @@ describe("Jira AI planner", () => {
         source: "jira",
         resource: "sprint_issues",
         mode: "visual",
-        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        jql: "project IN (\"A4321\") ORDER BY updated DESC",
         fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
         sprintId: "123",
         boardId: "77",
-        projectIdOrKey: "D2371",
+        projectIdOrKey: "A4321",
         transform: { type: "grouped", groupBy: "status", metric: "count" },
         pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
       },
@@ -455,11 +455,11 @@ describe("Jira AI planner", () => {
         source: "jira",
         resource: "sprint_issues",
         mode: "visual",
-        jql: "project IN (\"D2371\") ORDER BY updated DESC",
+        jql: "project IN (\"A4321\") ORDER BY updated DESC",
         fields: ["key", "summary", "status", "project", "issuetype", "created", "updated"],
         sprintId: "123",
         boardId: "77",
-        projectIdOrKey: "D2371",
+        projectIdOrKey: "A4321",
         transform: { type: "grouped", groupBy: "status", metric: "count" },
         pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
       },
@@ -471,14 +471,14 @@ describe("Jira AI planner", () => {
   it("returns a useful fallback when no active sprint can be resolved", async () => {
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
 
     const plan = await jiraAi.planDataset({
       connection: { id: 42, type: "jira", subType: "jira" },
-      question: "show me the active sprint status for D2371",
+      question: "show me the active sprint status for A4321",
     });
 
     expect(plan.status).toBe("fallback");
@@ -492,12 +492,12 @@ describe("Jira AI planner", () => {
   it("resolves exact project, single scrum board, and active sprint context", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -508,7 +508,7 @@ describe("Jira AI planner", () => {
 
     const context = await jiraResolver.resolveContext({
       connection: { id: 42 },
-      question: "show active sprint status for D2371",
+      question: "show active sprint status for A4321",
       intent: { id: "sprint_status", resource: "sprint_issues" },
       mode: "preview",
     });
@@ -516,7 +516,7 @@ describe("Jira AI planner", () => {
     expect(context.needsDisambiguation).toBe(false);
     expect(context.entities.project).toMatchObject({
       id: "10001",
-      key: "D2371",
+      key: "A4321",
       confidence: 0.98,
     });
     expect(context.entities.board).toMatchObject({
@@ -533,16 +533,16 @@ describe("Jira AI planner", () => {
   it("resolves an active sprint from the second matching board", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }, {
       id: 88,
-      name: "D2371 Delivery Board",
+      name: "A4321 Delivery Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockImplementation((connection, params) => {
@@ -558,7 +558,7 @@ describe("Jira AI planner", () => {
 
     const context = await jiraResolver.resolveContext({
       connection: { id: 42 },
-      question: "show active sprint status for D2371",
+      question: "show active sprint status for A4321",
       intent: { id: "sprint_status", resource: "sprint_issues" },
       mode: "preview",
     });
@@ -566,7 +566,7 @@ describe("Jira AI planner", () => {
     expect(context.needsDisambiguation).toBe(false);
     expect(context.entities.board).toMatchObject({
       id: "88",
-      name: "D2371 Delivery Board",
+      name: "A4321 Delivery Board",
       confidence: 0.9,
     });
     expect(context.entities.sprint).toMatchObject({
@@ -590,12 +590,12 @@ describe("Jira AI planner", () => {
   it("asks for sprint disambiguation in persist mode when multiple active sprints exist", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -610,7 +610,7 @@ describe("Jira AI planner", () => {
 
     const context = await jiraResolver.resolveContext({
       connection: { id: 42 },
-      question: "show active sprint status for D2371",
+      question: "show active sprint status for A4321",
       intent: { id: "sprint_status", resource: "sprint_issues" },
       mode: "persist",
     });
@@ -626,8 +626,8 @@ describe("Jira AI planner", () => {
   it("resolves users and versions only when requested by intent", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
       accountId: "abc",
@@ -640,7 +640,7 @@ describe("Jira AI planner", () => {
 
     const context = await jiraResolver.resolveContext({
       connection: { id: 42 },
-      question: "show release readiness for D2371 v5.2.0 assigned to Jane",
+      question: "show release readiness for A4321 v5.2.0 assigned to Jane",
       intent: {
         id: "release_progress",
         resource: "issues",
@@ -655,7 +655,7 @@ describe("Jira AI planner", () => {
       maxResults: 20,
     });
     expect(jiraConnection.listVersions).toHaveBeenCalledWith(expect.any(Object), {
-      projectIdOrKey: "D2371",
+      projectIdOrKey: "A4321",
     });
     expect(context.entities.user).toMatchObject({
       accountId: "abc",
@@ -671,15 +671,15 @@ describe("Jira AI planner", () => {
   it("adds warnings when user and version discovery fail", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listUsers").mockRejectedValue(new Error("Jira users unavailable"));
     vi.spyOn(jiraConnection, "listVersions").mockRejectedValue(new Error("Jira versions unavailable"));
 
     const context = await jiraResolver.resolveContext({
       connection: { id: 42 },
-      question: "show release readiness for D2371 v5.2.0 assigned to Jane",
+      question: "show release readiness for A4321 v5.2.0 assigned to Jane",
       intent: {
         id: "release_progress",
         resource: "issues",
@@ -700,15 +700,15 @@ describe("Jira AI planner", () => {
   it("skips user and version discovery when the intent does not need them", async () => {
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     const listUsersSpy = vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([]);
     const listVersionsSpy = vi.spyOn(jiraConnection, "listVersions").mockResolvedValue([]);
 
     const resolution = await jiraResolver.resolveContext({
       connection: { id: 42 },
-      question: "show issue status for D2371",
+      question: "show issue status for A4321",
       intent: { id: "issue_breakdown", resource: "issues" },
       mode: "preview",
     });

--- a/server/tests/unit/jiraAi.test.js
+++ b/server/tests/unit/jiraAi.test.js
@@ -1,0 +1,83 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const jiraAi = require("../../sources/plugins/jira/ai/jira.ai");
+const jiraConnection = require("../../sources/plugins/jira/jira.connection");
+
+describe("Jira AI planner", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves an active sprint from a project key before planning sprint status", async () => {
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "D2371 Sprint 14",
+      state: "active",
+    }]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42, type: "jira", subType: "jira" },
+      question: "can you show me the status of the active sprint I have for D2371 in Jira?",
+    });
+
+    expect(plan.status).toBe("ok");
+    expect(plan.configuration).toMatchObject({
+      resource: "sprint_issues",
+      sprintId: "123",
+      boardId: "77",
+      transform: {
+        type: "grouped",
+        groupBy: "status",
+      },
+    });
+    expect(plan.configuration.jql).toBe("project IN (\"D2371\") ORDER BY updated DESC");
+    expect(plan.chartSpec).toMatchObject({
+      type: "bar",
+      xAxis: "root[].status",
+      yAxis: "root[].issueCount",
+    });
+    expect(jiraConnection.listBoards).toHaveBeenCalledWith(expect.any(Object), {
+      projectKeyOrId: "D2371",
+      maxResults: 50,
+    });
+    expect(jiraConnection.listSprints).toHaveBeenCalledWith(expect.any(Object), {
+      boardId: 77,
+      maxResults: 50,
+      state: "active",
+    });
+  });
+
+  it("asks for a useful choice when no active sprint can be resolved", async () => {
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
+
+    const plan = await jiraAi.planDataset({
+      connection: { id: 42, type: "jira", subType: "jira" },
+      question: "show me the active sprint status for D2371",
+    });
+
+    expect(plan.status).toBe("needs_disambiguation");
+    expect(plan.message).toContain("active sprint");
+    expect(plan.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({ value: "status_breakdown" }),
+      expect.objectContaining({ value: "pick_board" }),
+    ]));
+  });
+});

--- a/server/tests/unit/jiraProtocol.test.js
+++ b/server/tests/unit/jiraProtocol.test.js
@@ -1,0 +1,355 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const drCacheController = require("../../controllers/DataRequestCacheController");
+const jiraConnection = require("../../sources/plugins/jira/jira.connection");
+const jiraProtocol = require("../../sources/plugins/jira/jira.protocol");
+
+describe("Jira protocol", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes source actions for Jira metadata", async () => {
+    vi.spyOn(jiraConnection, "listProjects")
+      .mockResolvedValue([{ id: "10000", key: "CHART", name: "Chartbrew" }]);
+    vi.spyOn(jiraConnection, "listBoards")
+      .mockResolvedValue([{ id: 12, name: "CHART board", type: "scrum" }]);
+    vi.spyOn(jiraConnection, "detectFieldMappings")
+      .mockResolvedValue({
+        fieldMappings: { storyPoints: "customfield_10016" },
+        candidates: { storyPoints: [{ id: "customfield_10016", name: "Story Points" }] },
+      });
+
+    const connection = { type: "jira", subType: "jira" };
+
+    await expect(jiraProtocol.actions.listProjects({ connection }))
+      .resolves.toEqual([{ id: "10000", key: "CHART", name: "Chartbrew" }]);
+    await expect(jiraProtocol.actions.listBoards({ connection, params: { projectKeyOrId: "CHART" } }))
+      .resolves.toEqual([{ id: 12, name: "CHART board", type: "scrum" }]);
+    await expect(jiraProtocol.actions.detectFieldMappings({ connection }))
+      .resolves.toEqual({
+        fieldMappings: { storyPoints: "customfield_10016" },
+        candidates: { storyPoints: [{ id: "customfield_10016", name: "Story Points" }] },
+      });
+  });
+
+  it("applies variables inside Jira configuration", () => {
+    const dataRequest = {
+      id: 42,
+      configuration: {
+        source: "jira",
+        resource: "issues",
+        jql: "project IN ({{projects}}) AND created >= {{start_date}} AND created <= {{end_date}}",
+      },
+      VariableBindings: [
+        { name: "projects", type: "string", default_value: "CHART", required: true },
+        { name: "start_date", type: "date", default_value: "2026-05-01", required: false },
+        { name: "end_date", type: "date", default_value: "2026-05-31", required: false },
+      ],
+    };
+
+    const result = jiraProtocol.applyVariables({
+      dataRequest,
+      variables: {
+        end_date: "2026-06-01",
+      },
+    });
+
+    expect(result.processedDataRequest.configuration.jql)
+      .toBe("project IN (CHART) AND created >= 2026-05-01 AND created <= 2026-06-01");
+  });
+
+  it("normalizes Jira issues using field mappings", () => {
+    const issue = {
+      key: "CHART-123",
+      fields: {
+        summary: "Add Jira dashboard template",
+        project: { key: "CHART" },
+        issuetype: { name: "Story" },
+        status: { name: "In Progress", statusCategory: { name: "In Progress" } },
+        assignee: { displayName: "Raz" },
+        reporter: { displayName: "Jane" },
+        priority: { name: "High" },
+        created: "2026-05-01T10:00:00.000Z",
+        updated: "2026-05-03T12:00:00.000Z",
+        resolutiondate: null,
+        customfield_10016: 5,
+        labels: ["dashboard", "jira"],
+        fixVersions: [{ name: "v5.2.0" }],
+        parent: { key: "CHART-100" },
+      },
+    };
+
+    expect(jiraProtocol.normalizeIssue(issue, { storyPoints: "customfield_10016" }))
+      .toEqual({
+        key: "CHART-123",
+        summary: "Add Jira dashboard template",
+        projectKey: "CHART",
+        issueType: "Story",
+        status: "In Progress",
+        statusCategory: "In Progress",
+        assignee: "Raz",
+        reporter: "Jane",
+        priority: "High",
+        createdAt: "2026-05-01T10:00:00.000Z",
+        updatedAt: "2026-05-03T12:00:00.000Z",
+        resolvedAt: null,
+        doneAt: null,
+        isDone: false,
+        storyPoints: 5,
+        severity: null,
+        team: null,
+        labels: ["dashboard", "jira"],
+        fixVersions: ["v5.2.0"],
+        epicKey: "CHART-100",
+      });
+  });
+
+  it("derives doneAt from Jira status changelog when resolutiondate is empty", () => {
+    const issue = {
+      key: "CHART-124",
+      fields: {
+        summary: "Complete sprint issue",
+        status: { name: "Closed", statusCategory: { name: "Done", key: "done" } },
+        resolutiondate: null,
+      },
+      changelog: {
+        histories: [{
+          created: "2026-05-04T09:30:00.000Z",
+          items: [{
+            field: "status",
+            to: "10002",
+            toString: "Closed",
+          }],
+        }],
+      },
+    };
+
+    expect(jiraProtocol.normalizeIssue(issue, {}, {
+      includeDoneAt: true,
+      doneStatusLookup: {
+        ids: new Set(["10002"]),
+        names: new Set(["closed"]),
+      },
+    })).toEqual(expect.objectContaining({
+      resolvedAt: null,
+      doneAt: "2026-05-04T09:30:00.000Z",
+      isDone: true,
+    }));
+  });
+
+  it("groups normalized rows for chart-ready breakdowns", () => {
+    const rows = [
+      { status: "Done", storyPoints: 3 },
+      { status: "Done", storyPoints: 5 },
+      { status: "In Progress", storyPoints: 2 },
+    ];
+
+    expect(jiraProtocol.transformRows(rows, {
+      transform: {
+        type: "grouped",
+        metric: "storyPoints",
+        groupBy: "status",
+      },
+    })).toEqual([
+      { status: "Done", issueCount: 2, storyPoints: 8 },
+      { status: "In Progress", issueCount: 1, storyPoints: 2 },
+    ]);
+  });
+
+  it("uses doneAt for created vs resolved trend transforms", () => {
+    expect(jiraProtocol.transformRows([{
+      createdAt: "2026-05-01T10:00:00.000Z",
+      doneAt: "2026-05-03T12:00:00.000Z",
+      resolvedAt: null,
+    }], {
+      transform: {
+        type: "created_resolved_trend",
+        interval: "day",
+      },
+    })).toEqual([
+      { period: "2026-05-01", created: 1, resolved: 0, open: 1 },
+      { period: "2026-05-03", created: 0, resolved: 1, open: 0 },
+    ]);
+  });
+
+  it("runs issue searches and caches normalized response data", async () => {
+    vi.spyOn(jiraConnection, "jiraRequest")
+      .mockResolvedValueOnce({
+        issues: [{
+          key: "CHART-1",
+          fields: {
+            summary: "Open issue",
+            status: { name: "To Do", statusCategory: { name: "To Do" } },
+            issuetype: { name: "Task" },
+            created: "2026-05-01T00:00:00.000Z",
+            updated: "2026-05-02T00:00:00.000Z",
+          },
+        }],
+        maxResults: 100,
+      });
+    const cacheSpy = vi.spyOn(drCacheController, "create")
+      .mockResolvedValue({});
+
+    const response = await jiraProtocol.runDataRequest({
+      connection: {
+        id: 7,
+        type: "jira",
+        subType: "jira",
+        host: "https://chartbrew.atlassian.net",
+        authentication: {
+          email: "raz@example.com",
+          apiToken: "token",
+        },
+        options: {
+          jira: {
+            fieldMappings: {},
+          },
+        },
+      },
+      dataRequest: {
+        id: 9,
+        configuration: {
+          source: "jira",
+          resource: "issues",
+          mode: "jql",
+          jql: "project = CHART",
+          transform: { type: "raw" },
+          pagination: { startAt: 0, maxResults: 100, maxRecords: 100 },
+        },
+      },
+      getCache: false,
+    });
+
+    expect(response.responseData.data).toEqual([expect.objectContaining({
+      key: "CHART-1",
+      summary: "Open issue",
+      status: "To Do",
+    })]);
+    expect(jiraConnection.jiraRequest).toHaveBeenCalledWith(expect.any(Object), "/rest/api/3/search/jql", {
+      method: "POST",
+      body: {
+        jql: "project = CHART",
+        fields: expect.any(Array),
+        maxResults: 100,
+      },
+    });
+    expect(cacheSpy).toHaveBeenCalledWith(9, expect.objectContaining({
+      responseData: {
+        data: [expect.objectContaining({ key: "CHART-1" })],
+      },
+    }));
+  });
+
+  it("paginates issue searches with nextPageToken", async () => {
+    vi.spyOn(jiraConnection, "jiraRequest")
+      .mockResolvedValueOnce({
+        issues: [{
+          key: "CHART-1",
+          fields: {
+            summary: "First issue",
+            status: { name: "To Do", statusCategory: { name: "To Do" } },
+          },
+        }],
+        nextPageToken: "next-page",
+      })
+      .mockResolvedValueOnce({
+        issues: [{
+          key: "CHART-2",
+          fields: {
+            summary: "Second issue",
+            status: { name: "Done", statusCategory: { name: "Done" } },
+          },
+        }],
+      });
+    vi.spyOn(drCacheController, "create").mockResolvedValue({});
+
+    const response = await jiraProtocol.runDataRequest({
+      connection: {
+        id: 7,
+        type: "jira",
+        subType: "jira",
+        host: "https://chartbrew.atlassian.net",
+        authentication: {
+          email: "raz@example.com",
+          apiToken: "token",
+        },
+      },
+      dataRequest: {
+        id: 11,
+        configuration: {
+          source: "jira",
+          resource: "issues",
+          mode: "jql",
+          jql: "project = CHART",
+          transform: { type: "raw" },
+          pagination: { maxResults: 100, maxRecords: 100 },
+        },
+      },
+      getCache: false,
+    });
+
+    expect(response.responseData.data.map((row) => row.key)).toEqual(["CHART-1", "CHART-2"]);
+    expect(jiraConnection.jiraRequest).toHaveBeenNthCalledWith(2, expect.any(Object), "/rest/api/3/search/jql", {
+      method: "POST",
+      body: {
+        jql: "project = CHART",
+        fields: expect.any(Array),
+        maxResults: 100,
+        nextPageToken: "next-page",
+      },
+    });
+  });
+
+  it("runs Agile board resources through Jira source actions", async () => {
+    vi.spyOn(jiraConnection, "listBoards")
+      .mockResolvedValue([{ id: 12, name: "CHART board", type: "scrum" }]);
+    const cacheSpy = vi.spyOn(drCacheController, "create")
+      .mockResolvedValue({});
+
+    const response = await jiraProtocol.runDataRequest({
+      connection: {
+        id: 7,
+        type: "jira",
+        subType: "jira",
+        host: "https://chartbrew.atlassian.net",
+        authentication: {
+          email: "raz@example.com",
+          apiToken: "token",
+        },
+      },
+      dataRequest: {
+        id: 10,
+        configuration: {
+          source: "jira",
+          resource: "boards",
+          mode: "advanced",
+          projectIdOrKey: "CHART",
+          transform: { type: "raw" },
+          pagination: { startAt: 0, maxResults: 100, maxRecords: 50 },
+        },
+      },
+      getCache: false,
+    });
+
+    expect(jiraConnection.listBoards).toHaveBeenCalledWith(expect.any(Object), {
+      maxResults: 50,
+      projectKeyOrId: "CHART",
+      type: undefined,
+    });
+    expect(response.responseData.data).toEqual([{ id: 12, name: "CHART board", type: "scrum" }]);
+    expect(cacheSpy).toHaveBeenCalledWith(10, expect.objectContaining({
+      responseData: {
+        data: [{ id: 12, name: "CHART board", type: "scrum" }],
+      },
+    }));
+  });
+});

--- a/server/tests/unit/jiraProtocol.test.js
+++ b/server/tests/unit/jiraProtocol.test.js
@@ -181,6 +181,89 @@ describe("Jira protocol", () => {
     ]);
   });
 
+  it("runs separate created and resolved searches for Jira trend templates", async () => {
+    vi.spyOn(jiraConnection, "jiraRequest")
+      .mockResolvedValueOnce({
+        issues: [{
+          key: "CHART-1",
+          fields: {
+            summary: "Created in range",
+            status: { name: "In Progress", statusCategory: { name: "In Progress" } },
+            created: "2026-05-01T10:00:00.000Z",
+            updated: "2026-05-01T10:30:00.000Z",
+            resolutiondate: null,
+          },
+        }],
+      })
+      .mockResolvedValueOnce({
+        issues: [{
+          key: "CHART-2",
+          fields: {
+            summary: "Resolved in range",
+            status: { name: "Done", statusCategory: { name: "Done", key: "done" } },
+            created: "2025-07-10T10:00:00.000Z",
+            updated: "2026-05-03T12:00:00.000Z",
+            resolutiondate: null,
+          },
+          changelog: {
+            histories: [{
+              created: "2026-05-03T12:00:00.000Z",
+              items: [{ field: "status", toString: "Done" }],
+            }],
+          },
+        }],
+      });
+    vi.spyOn(jiraConnection, "listStatuses")
+      .mockResolvedValue([{ id: "10002", name: "Done", statusCategory: "Done", statusCategoryKey: "done" }]);
+    vi.spyOn(drCacheController, "create").mockResolvedValue({});
+
+    const response = await jiraProtocol.runDataRequest({
+      connection: {
+        id: 7,
+        type: "jira",
+        subType: "jira",
+        host: "https://chartbrew.atlassian.net",
+        authentication: {
+          email: "raz@example.com",
+          apiToken: "token",
+        },
+      },
+      dataRequest: {
+        id: 12,
+        configuration: {
+          source: "jira",
+          resource: "issues",
+          mode: "visual",
+          includeDoneAt: true,
+          jql: "project IN (CHART) AND ((created >= 2026-05-01 AND created <= 2026-05-31) OR (statusCategory = Done AND statusCategoryChangedDate >= 2026-05-01 AND statusCategoryChangedDate <= 2026-05-31)) ORDER BY updated ASC",
+          transform: { type: "created_resolved_trend", interval: "day" },
+          pagination: { maxResults: 100, maxRecords: 1000 },
+        },
+      },
+      getCache: false,
+    });
+
+    expect(response.responseData.data).toEqual([
+      { period: "2026-05-01", created: 1, resolved: 0, open: 1 },
+      { period: "2026-05-03", created: 0, resolved: 1, open: 0 },
+    ]);
+    expect(response.responseData.data.some((row) => row.period === "2025-07-10")).toBe(false);
+    expect(jiraConnection.jiraRequest).toHaveBeenNthCalledWith(1, expect.any(Object), "/rest/api/3/search/jql", {
+      method: "POST",
+      body: expect.objectContaining({
+        jql: "project IN (CHART) AND created >= 2026-05-01 AND created <= 2026-05-31 ORDER BY created ASC",
+        expand: "changelog",
+      }),
+    });
+    expect(jiraConnection.jiraRequest).toHaveBeenNthCalledWith(2, expect.any(Object), "/rest/api/3/search/jql", {
+      method: "POST",
+      body: expect.objectContaining({
+        jql: "project IN (CHART) AND statusCategory = Done AND statusCategoryChangedDate >= 2026-05-01 AND statusCategoryChangedDate <= 2026-05-31 ORDER BY updated ASC",
+        expand: "changelog",
+      }),
+    });
+  });
+
   it("runs issue searches and caches normalized response data", async () => {
     vi.spyOn(jiraConnection, "jiraRequest")
       .mockResolvedValueOnce({
@@ -305,6 +388,49 @@ describe("Jira protocol", () => {
         fields: expect.any(Array),
         maxResults: 100,
         nextPageToken: "next-page",
+      },
+    });
+  });
+
+  it("omits unresolved variable JQL from sprint issue requests", async () => {
+    vi.spyOn(jiraConnection, "jiraRequest")
+      .mockResolvedValueOnce({
+        issues: [{
+          key: "CHART-1",
+          fields: {
+            summary: "Sprint issue",
+            status: { name: "Done", statusCategory: { name: "Done" } },
+            issuetype: { name: "Story" },
+          },
+        }],
+        total: 1,
+      });
+
+    const rows = await jiraProtocol.fetchJiraRows({
+      id: 7,
+      type: "jira",
+      subType: "jira",
+      host: "https://chartbrew.atlassian.net",
+      authentication: {
+        email: "raz@example.com",
+        apiToken: "token",
+      },
+    }, {
+      source: "jira",
+      resource: "sprint_issues",
+      mode: "visual",
+      sprintId: "123",
+      jql: "project IN ({{projects}}) ORDER BY updated DESC",
+      fields: ["key", "summary", "status", "issuetype"],
+      pagination: { startAt: 0, maxResults: 100, maxRecords: 100 },
+    });
+
+    expect(rows.map((row) => row.key)).toEqual(["CHART-1"]);
+    expect(jiraConnection.jiraRequest).toHaveBeenCalledWith(expect.any(Object), "/rest/agile/1.0/sprint/123/issue", {
+      qs: {
+        fields: "key,summary,status,issuetype",
+        startAt: 0,
+        maxResults: 100,
       },
     });
   });

--- a/server/tests/unit/jiraTemplates.test.js
+++ b/server/tests/unit/jiraTemplates.test.js
@@ -63,6 +63,63 @@ describe("Jira chart templates", () => {
     });
   });
 
+  it("sets complete chart dataset config fields for the editor", () => {
+    TEMPLATE_SLUGS.forEach((slug) => {
+      const template = loadTemplate("jira", slug);
+      const datasetsById = new Map(template.datasets.map((dataset) => [dataset.id, dataset]));
+
+      template.charts.forEach((chart) => {
+        getChartDatasetConfigs(chart).forEach((cdc) => {
+          const dataset = datasetsById.get(cdc.datasetTemplateId);
+          const fields = dataset?.fieldsSchema || {};
+
+          expect(cdc.xAxis, `${slug}:${chart.id} is missing xAxis`).toEqual(expect.any(String));
+          expect(cdc.yAxis, `${slug}:${chart.id} is missing yAxis`).toEqual(expect.any(String));
+          expect(cdc.yAxisOperation, `${slug}:${chart.id} is missing yAxisOperation`).toEqual(expect.any(String));
+
+          if (cdc.xAxis !== "root[]") {
+            expect(fields[cdc.xAxis], `${slug}:${chart.id} xAxis is not in dataset fieldsSchema`).toBeTruthy();
+          }
+          expect(fields[cdc.yAxis], `${slug}:${chart.id} yAxis is not in dataset fieldsSchema`).toBeTruthy();
+        });
+      });
+    });
+  });
+
+  it("sets dateField for date-based chart dataset configs", () => {
+    TEMPLATE_SLUGS.forEach((slug) => {
+      const template = loadTemplate("jira", slug);
+      const datasetsById = new Map(template.datasets.map((dataset) => [dataset.id, dataset]));
+
+      template.charts.forEach((chart) => {
+        getChartDatasetConfigs(chart).forEach((cdc) => {
+          const dataset = datasetsById.get(cdc.datasetTemplateId);
+          const fields = dataset?.fieldsSchema || {};
+
+          if (fields[cdc.xAxis] !== "date") return;
+
+          expect(cdc.dateField, `${slug}:${chart.id} is missing dateField`).toBe(cdc.xAxis);
+          expect(cdc.yAxisOperation, `${slug}:${chart.id} should let AxisChart aggregate date buckets`).toBe("none");
+        });
+      });
+    });
+  });
+
+  it("uses a yearly default range for Jira trend datasets", () => {
+    TEMPLATE_SLUGS.forEach((slug) => {
+      const template = loadTemplate("jira", slug);
+
+      template.datasets
+        .filter((dataset) => dataset.dataRequest?.configuration?.transform?.type === "created_resolved_trend")
+        .forEach((dataset) => {
+          expect(dataset.dataRequest.variableBindings).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: "start_date", default_value: "-365d" }),
+            expect.objectContaining({ name: "end_date", default_value: "now()" }),
+          ]));
+        });
+    });
+  });
+
   it("includes variable bindings on Jira template data requests", () => {
     const template = loadTemplate("jira", "project-overview");
     const dataRequest = template.datasets[0].dataRequest;

--- a/server/tests/unit/jiraTemplates.test.js
+++ b/server/tests/unit/jiraTemplates.test.js
@@ -1,0 +1,102 @@
+import {
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { loadTemplate } = require("../../sources/shared/templates/chartTemplateLoader");
+const { chartColors, Colors } = require("../../charts/colors");
+
+const TEMPLATE_SLUGS = [
+  "project-overview",
+  "sprint-health",
+  "bug-tracking",
+  "team-workload",
+];
+
+const JIRA_ALLOWED_DATASET_COLORS = new Set([
+  chartColors.blue.rgb,
+  chartColors.amber.rgb,
+  chartColors.teal.rgb,
+  Colors.positive,
+  Colors.negative,
+  "rgba(255, 255, 255, 1)",
+]);
+
+function getChartDatasetConfigs(chart) {
+  return chart.cdcs || [chart.cdc];
+}
+
+describe("Jira chart templates", () => {
+  it("loads every Jira template bundle with datasets and charts", () => {
+    TEMPLATE_SLUGS.forEach((slug) => {
+      const template = loadTemplate("jira", slug);
+
+      expect(template.source).toBe("jira");
+      expect(template.slug).toBe(slug);
+      expect(template.requiredConnection).toEqual({ type: "jira", subType: "jira" });
+      expect(template.datasets.length).toBeGreaterThan(0);
+      expect(template.charts.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("uses layoutIntent and valid dataset references for every Jira chart", () => {
+    TEMPLATE_SLUGS.forEach((slug) => {
+      const template = loadTemplate("jira", slug);
+      const datasetIds = template.datasets.map((dataset) => dataset.id);
+
+      template.charts.forEach((chart) => {
+        expect(chart.layoutIntent).toEqual(expect.objectContaining({
+          kind: expect.any(String),
+          priority: expect.any(Number),
+        }));
+        chart.requiredDatasetIds.forEach((datasetId) => {
+          expect(datasetIds).toContain(datasetId);
+        });
+        const cdcs = chart.cdcs || [chart.cdc];
+        cdcs.forEach((cdc) => {
+          expect(datasetIds).toContain(cdc.datasetTemplateId);
+        });
+      });
+    });
+  });
+
+  it("includes variable bindings on Jira template data requests", () => {
+    const template = loadTemplate("jira", "project-overview");
+    const dataRequest = template.datasets[0].dataRequest;
+
+    expect(dataRequest.variableBindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "projects", type: "string", required: true }),
+      expect.objectContaining({ name: "start_date", type: "date" }),
+      expect.objectContaining({ name: "end_date", type: "date" }),
+    ]));
+  });
+
+  it("uses the shared restrained chart palette for Jira chart datasets", () => {
+    TEMPLATE_SLUGS.forEach((slug) => {
+      const template = loadTemplate("jira", slug);
+
+      template.charts.flatMap(getChartDatasetConfigs).forEach((cdc) => {
+        expect(cdc.datasetColor).toEqual(expect.any(String));
+        expect(
+          JIRA_ALLOWED_DATASET_COLORS.has(cdc.datasetColor),
+          `${cdc.legend || cdc.datasetTemplateId} uses non-shared color ${cdc.datasetColor}`
+        ).toBe(true);
+
+        if (Array.isArray(cdc.fillColor)) {
+          cdc.fillColor.forEach((color) => {
+            expect(
+              JIRA_ALLOWED_DATASET_COLORS.has(color),
+              `${cdc.legend || cdc.datasetTemplateId} uses non-shared fill color ${color}`
+            ).toBe(true);
+          });
+          expect(cdc.multiFill).toBe(true);
+        } else if (cdc.fillColor) {
+          expect(cdc.fill).toBe(true);
+        }
+      });
+    });
+  });
+});

--- a/server/tests/unit/orchestratorDashboardTemplate.test.js
+++ b/server/tests/unit/orchestratorDashboardTemplate.test.js
@@ -1,0 +1,63 @@
+import {
+  afterEach, describe, expect, it, vi
+} from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const ChartTemplateController = require("../../controllers/ChartTemplateController");
+const createDashboardFromTemplate = require("../../modules/ai/orchestrator/tools/createDashboardFromTemplate");
+const { availableTools } = require("../../modules/ai/orchestrator/orchestrator");
+
+describe("AI orchestrator dashboard template tool", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a dashboard through the generic chart template controller", async () => {
+    const createSpy = vi.spyOn(ChartTemplateController.prototype, "createFromTemplate")
+      .mockResolvedValue({
+        project_id: 77,
+        datasets: [{ id: 99, name: "Issues" }],
+        charts: [{ id: 55, name: "Open issues" }],
+      });
+
+    const result = await createDashboardFromTemplate({
+      team_id: 7,
+      user_id: 3,
+      source_id: "jira",
+      template_slug: "project-overview",
+      connection_id: 42,
+      dashboard: { type: "new", name: "Jira Project Overview" },
+      dataset_template_ids: ["issues_by_status"],
+      chart_template_ids: ["issues-by-status"],
+      variable_defaults: {
+        projects: "CHART",
+      },
+    });
+
+    expect(createSpy).toHaveBeenCalledWith(7, "jira", "project-overview", {
+      connection_id: 42,
+      dashboard: { type: "new", name: "Jira Project Overview" },
+      dataset_template_ids: ["issues_by_status"],
+      chart_template_ids: ["issues-by-status"],
+      variable_defaults: {
+        projects: "CHART",
+      },
+    }, { id: 3 });
+    expect(result).toMatchObject({
+      status: "ok",
+      dashboard_created: true,
+      source: "jira",
+      template_slug: "project-overview",
+      project_id: 77,
+      datasets: [{ id: 99, name: "Issues" }],
+      charts: [{ id: 55, name: "Open issues" }],
+    });
+  });
+
+  it("exposes the dashboard template tool to the orchestrator", async () => {
+    const toolNames = (await availableTools()).map((tool) => tool.name);
+
+    expect(toolNames).toContain("create_dashboard_from_template");
+  });
+});

--- a/server/tests/unit/orchestratorResponsesApi.test.js
+++ b/server/tests/unit/orchestratorResponsesApi.test.js
@@ -5,7 +5,9 @@ import {
 const {
   buildResponseInputFromMessages,
   buildAssistantMessageFromResponse,
+  buildDisambiguationAssistantMessage,
   buildFallbackAssistantMessage,
+  sanitizeToolError,
   buildUsageRecordFromResponse,
 } = require("../../modules/ai/orchestrator/orchestrator");
 
@@ -107,5 +109,31 @@ describe("orchestrator Responses API adapters", () => {
     });
 
     expect(message).toBe("I created Total sessions.");
+  });
+
+  it("builds a persisted assistant message with quick replies for disambiguation", () => {
+    const message = buildDisambiguationAssistantMessage({
+      prompt: "Which sprint should I use?",
+      options: [
+        { label: "Use the active sprint", value: "active_sprint" },
+        { label: "Pick a board", value: "pick_board" },
+      ],
+    });
+
+    expect(message).toContain("Which sprint should I use?");
+    expect(message).toContain("```cb-actions");
+    expect(message).toContain("\"version\": 1");
+    expect(message).toContain("\"id\": \"active_sprint\"");
+    expect(message).toContain("\"label\": \"Use the active sprint\"");
+    expect(message).toContain("\"action\": \"reply\"");
+  });
+
+  it("redacts sensitive request details from tool errors", () => {
+    const message = sanitizeToolError(new Error("401 - authorization: Basic abc123def456 token=secret"));
+
+    expect(message).toContain("Basic [REDACTED]");
+    expect(message).toContain("token=[REDACTED]");
+    expect(message).not.toContain("abc123def456");
+    expect(message).not.toContain("secret");
   });
 });

--- a/server/tests/unit/orchestratorResponsesApi.test.js
+++ b/server/tests/unit/orchestratorResponsesApi.test.js
@@ -9,6 +9,7 @@ const {
   buildFallbackAssistantMessage,
   sanitizeToolError,
   buildUsageRecordFromResponse,
+  availableTools,
 } = require("../../modules/ai/orchestrator/orchestrator");
 
 describe("orchestrator Responses API adapters", () => {
@@ -135,5 +136,52 @@ describe("orchestrator Responses API adapters", () => {
     expect(message).toContain("token=[REDACTED]");
     expect(message).not.toContain("abc123def456");
     expect(message).not.toContain("secret");
+  });
+
+  it("exposes the generic source context resolution tool", async () => {
+    const tools = await availableTools();
+    const tool = tools.find((candidate) => candidate.name === "source_resolve_context");
+
+    expect(tool).toMatchObject({
+      name: "source_resolve_context",
+      displayName: "Resolve source context",
+    });
+    expect(tool.parameters.required).toEqual(expect.arrayContaining(["connection_id", "question"]));
+  });
+
+  it("exposes generic source action and record search tools", async () => {
+    const tools = await availableTools();
+    const actionTool = tools.find((candidate) => candidate.name === "source_run_action");
+    const searchTool = tools.find((candidate) => candidate.name === "source_search_records");
+
+    expect(actionTool).toMatchObject({
+      name: "source_run_action",
+      displayName: "Run source action",
+    });
+    expect(actionTool.parameters.required).toEqual(expect.arrayContaining(["connection_id", "action"]));
+    expect(searchTool).toMatchObject({
+      name: "source_search_records",
+      displayName: "Search source records",
+    });
+    expect(searchTool.parameters.required).toEqual(expect.arrayContaining(["connection_id", "question"]));
+  });
+
+  it("lets source-owned planning choose preview or persist mode", async () => {
+    const tools = await availableTools();
+    const tool = tools.find((candidate) => candidate.name === "source_plan_dataset");
+
+    expect(tool.parameters.properties.mode).toMatchObject({
+      type: "string",
+      enum: ["preview", "persist"],
+      default: "preview",
+    });
+  });
+
+  it("does not advertise source-owned Jira for generic query generation", async () => {
+    const tools = await availableTools();
+    const tool = tools.find((candidate) => candidate.name === "generate_query");
+
+    expect(tool.parameters.properties.source_id.enum).not.toContain("jira");
+    expect(tool.parameters.properties.preferred_dialect.enum).not.toContain("jira");
   });
 });

--- a/server/tests/unit/sourceAiHarness.test.js
+++ b/server/tests/unit/sourceAiHarness.test.js
@@ -816,12 +816,12 @@ describe("Source AI harness", () => {
     vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -834,14 +834,14 @@ describe("Source AI harness", () => {
       team_id: TOOL_TEAM_ID,
       connection_id: toolHarnessConnections.jira.id,
       source_id: "jira",
-      question: "show active sprint status for D2371",
+      question: "show active sprint status for A4321",
       intent: { id: "sprint_status", resource: "sprint_issues" },
       mode: "preview",
     });
 
     expect(result.source).toBe("jira");
     expect(result.resolution.entities.project).toMatchObject({
-      key: "D2371",
+      key: "A4321",
     });
     expect(result.resolution.entities.board).toMatchObject({
       id: "77",
@@ -889,7 +889,7 @@ describe("Source AI harness", () => {
     }]);
     vi.spyOn(jiraConnection, "jiraRequest").mockResolvedValue({
       issues: [{
-        key: "D2371-1",
+        key: "A4321-1",
         fields: {
           summary: "Fix Jira AI search",
           status: { name: "In Progress", statusCategory: { name: "In Progress", key: "indeterminate" } },
@@ -914,7 +914,7 @@ describe("Source AI harness", () => {
       source: "jira",
       status: "ok",
       rows: [expect.objectContaining({
-        key: "D2371-1",
+        key: "A4321-1",
         summary: "Fix Jira AI search",
         status: "In Progress",
         assignee: "Razvan Ilin",
@@ -935,15 +935,15 @@ describe("Source AI harness", () => {
 
   it("keeps Jira fallback plans usable for preview", async () => {
     vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
-    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{ id: "10001", key: "D2371", name: "D2371 Project" }]);
-    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{ id: 77, name: "D2371 Scrum Board", type: "scrum" }]);
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{ id: "10001", key: "A4321", name: "A4321 Project" }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{ id: 77, name: "A4321 Scrum Board", type: "scrum" }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
 
     const plan = await sourcePlanDataset({
       team_id: TOOL_TEAM_ID,
       connection_id: toolHarnessConnections.jira.id,
       source_id: "jira",
-      question: "show active sprint status for D2371",
+      question: "show active sprint status for A4321",
       mode: "preview",
     });
 
@@ -958,12 +958,12 @@ describe("Source AI harness", () => {
     vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -980,7 +980,7 @@ describe("Source AI harness", () => {
       team_id: TOOL_TEAM_ID,
       connection_id: toolHarnessConnections.jira.id,
       source_id: "jira",
-      question: "save the active sprint status for D2371",
+      question: "save the active sprint status for A4321",
       mode: "persist",
     });
 
@@ -996,12 +996,12 @@ describe("Source AI harness", () => {
     vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
     vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
       id: "10001",
-      key: "D2371",
-      name: "D2371 Project",
+      key: "A4321",
+      name: "A4321 Project",
     }]);
     vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
       id: 77,
-      name: "D2371 Scrum Board",
+      name: "A4321 Scrum Board",
       type: "scrum",
     }]);
     vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
@@ -1018,7 +1018,7 @@ describe("Source AI harness", () => {
       team_id: TOOL_TEAM_ID,
       connection_id: toolHarnessConnections.jira.id,
       source_id: "jira",
-      question: "show active sprint status for D2371",
+      question: "show active sprint status for A4321",
       intent: { id: "sprint_status", resource: "sprint_issues" },
       mode: "persist",
     });

--- a/server/tests/unit/sourceAiHarness.test.js
+++ b/server/tests/unit/sourceAiHarness.test.js
@@ -7,6 +7,8 @@ const realtimeDbProtocol = require("../../sources/plugins/realtimedb/realtimedb.
 const CustomerioConnection = require("../../sources/plugins/customerio/customerio.connection");
 const googleAnalyticsConnection = require("../../sources/plugins/googleAnalytics/googleAnalytics.connection");
 const googleAnalyticsProtocol = require("../../sources/plugins/googleAnalytics/googleAnalytics.protocol");
+const jiraConnection = require("../../sources/plugins/jira/jira.connection");
+const jiraProtocol = require("../../sources/plugins/jira/jira.protocol");
 const stripeOfficialProtocol = require("../../sources/plugins/stripeOfficial/stripeOfficial.protocol");
 const apiProtocol = require("../../sources/shared/protocols/api.protocol");
 const db = require("../../models/models");
@@ -16,6 +18,7 @@ const createChart = require("../../modules/ai/orchestrator/tools/createChart");
 const createTemporaryChart = require("../../modules/ai/orchestrator/tools/createTemporaryChart");
 const generateQueryTool = require("../../modules/ai/orchestrator/tools/generateQuery");
 const getSchemaTool = require("../../modules/ai/orchestrator/tools/getSchema");
+const { sourceUsesSourceOwnedConfiguration } = require("../../modules/ai/orchestrator/sourceSupport");
 const {
   sourceGetCapabilities,
   sourceGetSampleData,
@@ -40,6 +43,7 @@ const SOURCE_OWNED_IDS = [
   "customerio",
   "firestore",
   "googleAnalytics",
+  "jira",
   "realtimedb",
   "stripeOfficial",
 ];
@@ -91,7 +95,7 @@ function expectDataRequestContract(sourceId, plan) {
   expect(sourceId !== "firestore" || hasQuery).toBe(true);
   expect(!["api", "customerio", "realtimedb"].includes(sourceId) || hasRoute).toBe(true);
   expect(!["api", "customerio"].includes(sourceId) || hasMethod).toBe(true);
-  expect(!["googleAnalytics", "stripeOfficial"].includes(sourceId) || hasConfiguration).toBe(true);
+  expect(!["googleAnalytics", "jira", "stripeOfficial"].includes(sourceId) || hasConfiguration).toBe(true);
 }
 
 function expectChartPlanContract(plan) {
@@ -132,7 +136,7 @@ async function planFixture(fixture) {
 }
 
 async function validateFixturePlan({ source, sourceId, payload, plan }) {
-  if (["googleAnalytics", "stripeOfficial"].includes(sourceId)) {
+  if (["googleAnalytics", "jira", "stripeOfficial"].includes(sourceId)) {
     return source.backend.ai.validateConfiguration(plan.configuration);
   }
 
@@ -225,6 +229,12 @@ const plannerContractFixtures = [{
   payload: {
     question: "Create an MRR chart over the last 6 months",
   },
+}, {
+  name: "Jira issue breakdown",
+  sourceId: "jira",
+  payload: {
+    question: "Show open Jira issues by status",
+  },
 }];
 
 const toolHarnessConnections = {
@@ -266,6 +276,25 @@ const toolHarnessConnections = {
         accountId: "accounts/1",
         propertyId: "properties/123",
         propertyName: "Example GA4",
+      },
+    },
+  },
+  jira: {
+    id: 107,
+    team_id: TOOL_TEAM_ID,
+    type: "jira",
+    subType: "jira",
+    name: "Jira",
+    host: "https://chartbrew.atlassian.net",
+    authentication: {
+      email: "raz@example.com",
+      apiToken: "redacted-test-token",
+    },
+    options: {
+      jira: {
+        fieldMappings: {
+          storyPoints: "customfield_10016",
+        },
       },
     },
   },
@@ -370,6 +399,40 @@ function setupGoogleAnalyticsToolRuntime() {
   }]);
 }
 
+function setupJiraToolRuntime() {
+  vi.spyOn(jiraConnection, "jiraRequest").mockResolvedValue({
+    issues: [{
+      key: "CHART-1",
+      fields: {
+        summary: "Build Jira source",
+        project: { key: "CHART" },
+        issuetype: { name: "Story" },
+        status: { name: "In Progress", statusCategory: { name: "In Progress" } },
+        assignee: { displayName: "Raz" },
+        priority: { name: "High" },
+        created: "2026-05-01T00:00:00.000Z",
+        updated: "2026-05-02T00:00:00.000Z",
+        customfield_10016: 5,
+      },
+    }],
+    total: 1,
+  });
+  vi.spyOn(jiraProtocol, "fetchJiraRows").mockResolvedValue([{
+    key: "CHART-1",
+    fields: {
+      summary: "Build Jira source",
+      project: { key: "CHART" },
+      issuetype: { name: "Story" },
+      status: { name: "In Progress", statusCategory: { name: "In Progress" } },
+      assignee: { displayName: "Raz" },
+      priority: { name: "High" },
+      created: "2026-05-01T00:00:00.000Z",
+      updated: "2026-05-02T00:00:00.000Z",
+      customfield_10016: 5,
+    },
+  }]);
+}
+
 function setupRealtimeDbToolRuntime() {
   vi.spyOn(realtimeDbProtocol, "createRealtimeDatabase").mockReturnValue({
     getData: vi.fn().mockResolvedValue([{ _key: "order_1", total: 25 }]),
@@ -436,6 +499,20 @@ const compactToolFixtures = [{
     dimensions: "date",
   },
   setup: setupGoogleAnalyticsToolRuntime,
+}, {
+  sourceId: "jira",
+  question: "Show Jira issues by status",
+  resource: "issues",
+  previewConfiguration: {
+    source: "jira",
+    resource: "issues",
+    mode: "jql",
+    jql: "project = CHART",
+    fields: ["key", "summary", "status", "assignee", "created", "updated"],
+    transform: { type: "grouped", groupBy: "status", metric: "count" },
+    pagination: { startAt: 0, maxResults: 100, maxRecords: 5 },
+  },
+  setup: setupJiraToolRuntime,
 }, {
   sourceId: "realtimedb",
   question: "Show /orders",
@@ -850,5 +927,45 @@ describe("Source AI harness", () => {
       status: "ok",
       chart_created: true,
     });
+  });
+
+  it("formats Jira request errors without raw request headers", () => {
+    const message = jiraConnection.getSafeJiraErrorMessage({
+      statusCode: 400,
+      error: {
+        errorMessages: ["Invalid JQL"],
+        errors: {
+          jql: "The sprint field is invalid",
+        },
+      },
+      options: {
+        headers: {
+          authorization: "Basic abc123",
+        },
+      },
+    });
+
+    expect(message).toBe("400 - Invalid JQL The sprint field is invalid");
+    expectNoSensitiveOutput(message);
+  });
+
+  it("preserves plain Jira error bodies without request metadata", () => {
+    const message = jiraConnection.getSafeJiraErrorMessage({
+      statusCode: 401,
+      error: "Client must be authenticated to access this resource.",
+      request: {
+        headers: {
+          authorization: "Basic abc123",
+        },
+      },
+    });
+
+    expect(message).toBe("401 - Client must be authenticated to access this resource.");
+    expectNoSensitiveOutput(message);
+  });
+
+  it("marks Jira as source-owned configuration so generic run_query stays out of the flow", () => {
+    expect(sourceUsesSourceOwnedConfiguration(getSourceById("jira"))).toBe(true);
+    expect(sourceUsesSourceOwnedConfiguration(getSourceById("postgres"))).toBe(false);
   });
 });

--- a/server/tests/unit/sourceAiHarness.test.js
+++ b/server/tests/unit/sourceAiHarness.test.js
@@ -25,12 +25,16 @@ const {
   sourceListResources,
   sourcePlanDataset,
   sourcePreviewConfiguration,
+  sourceResolveContext,
+  sourceRunAction,
+  sourceSearchRecords,
   sourceValidateConfiguration,
 } = require("../../modules/ai/orchestrator/tools/sourceTools");
 const { getSourceById } = require("../../sources");
 
 const ALLOWED_STATUSES = new Set([
   "ok",
+  "fallback",
   "needs_disambiguation",
   "needs_more_context",
   "needs_model_planning",
@@ -806,6 +810,226 @@ describe("Source AI harness", () => {
     expectToolOutputContract(validation);
     expectToolOutputContract(preview);
     expectToolOutputContract(sample);
+  });
+
+  it("resolves Jira context through the generic source tool", async () => {
+    vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "Sprint 14",
+      state: "active",
+    }]);
+
+    const result = await sourceResolveContext({
+      team_id: TOOL_TEAM_ID,
+      connection_id: toolHarnessConnections.jira.id,
+      source_id: "jira",
+      question: "show active sprint status for D2371",
+      intent: { id: "sprint_status", resource: "sprint_issues" },
+      mode: "preview",
+    });
+
+    expect(result.source).toBe("jira");
+    expect(result.resolution.entities.project).toMatchObject({
+      key: "D2371",
+    });
+    expect(result.resolution.entities.board).toMatchObject({
+      id: "77",
+    });
+    expect(result.resolution.entities.sprint).toMatchObject({
+      id: "123",
+    });
+    expectToolOutputContract(result);
+  });
+
+  it("runs safe Jira source actions through the generic source tool", async () => {
+    vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
+    vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
+      accountId: "raz-account",
+      displayName: "Razvan Ilin",
+      active: true,
+    }]);
+
+    const result = await sourceRunAction({
+      team_id: TOOL_TEAM_ID,
+      connection_id: toolHarnessConnections.jira.id,
+      source_id: "jira",
+      action: "listUsers",
+      params: { query: "Razvan", maxResults: 10 },
+    });
+
+    expect(result).toMatchObject({
+      source: "jira",
+      action: "listUsers",
+      rows: [expect.objectContaining({
+        accountId: "raz-account",
+        displayName: "Razvan Ilin",
+      })],
+      rowCount: 1,
+    });
+    expectToolOutputContract(result);
+  });
+
+  it("searches compact Jira issue records without creating a dataset", async () => {
+    vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([]);
+    vi.spyOn(jiraConnection, "listUsers").mockResolvedValue([{
+      accountId: "raz-account",
+      displayName: "Razvan Ilin",
+    }]);
+    vi.spyOn(jiraConnection, "jiraRequest").mockResolvedValue({
+      issues: [{
+        key: "D2371-1",
+        fields: {
+          summary: "Fix Jira AI search",
+          status: { name: "In Progress", statusCategory: { name: "In Progress", key: "indeterminate" } },
+          assignee: { displayName: "Razvan Ilin" },
+          priority: { name: "High" },
+          issuetype: { name: "Task" },
+          created: "2026-05-15T00:00:00.000Z",
+          updated: "2026-05-18T00:00:00.000Z",
+        },
+      }],
+    });
+
+    const result = await sourceSearchRecords({
+      team_id: TOOL_TEAM_ID,
+      connection_id: toolHarnessConnections.jira.id,
+      source_id: "jira",
+      question: "Show all open issues assigned to Razvan",
+      row_limit: 10,
+    });
+
+    expect(result).toMatchObject({
+      source: "jira",
+      status: "ok",
+      rows: [expect.objectContaining({
+        key: "D2371-1",
+        summary: "Fix Jira AI search",
+        status: "In Progress",
+        assignee: "Razvan Ilin",
+      })],
+      rowCount: 1,
+    });
+    expect(jiraConnection.jiraRequest).toHaveBeenCalledWith(expect.any(Object), "/rest/api/3/search/jql", {
+      method: "POST",
+      body: expect.objectContaining({
+        jql: expect.stringContaining("assignee IN (\"raz-account\")"),
+        maxResults: 10,
+      }),
+    });
+    expect(jiraConnection.jiraRequest.mock.calls[0][2].body.jql).toContain("statusCategory != Done");
+    expect(jiraConnection.jiraRequest.mock.calls[0][2].body.jql).not.toContain("project IN ()");
+    expectToolOutputContract(result);
+  });
+
+  it("keeps Jira fallback plans usable for preview", async () => {
+    vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{ id: "10001", key: "D2371", name: "D2371 Project" }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{ id: 77, name: "D2371 Scrum Board", type: "scrum" }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([]);
+
+    const plan = await sourcePlanDataset({
+      team_id: TOOL_TEAM_ID,
+      connection_id: toolHarnessConnections.jira.id,
+      source_id: "jira",
+      question: "show active sprint status for D2371",
+      mode: "preview",
+    });
+
+    expect(plan.status).toBe("fallback");
+    expect(plan.configuration).toMatchObject({ source: "jira", resource: "issues" });
+    expect(plan.chartSpec).toMatchObject({ type: "bar", xAxis: "root[].status", yAxis: "root[].issueCount" });
+    expect(plan.needs_user_input).toBeUndefined();
+    expectToolOutputContract(plan);
+  });
+
+  it("passes persist mode through Jira source planning before saved creation", async () => {
+    vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "Sprint 14",
+      state: "active",
+    }, {
+      id: 124,
+      name: "Sprint 15",
+      state: "active",
+    }]);
+
+    const plan = await sourcePlanDataset({
+      team_id: TOOL_TEAM_ID,
+      connection_id: toolHarnessConnections.jira.id,
+      source_id: "jira",
+      question: "save the active sprint status for D2371",
+      mode: "persist",
+    });
+
+    expect(plan.needs_user_input).toBe(true);
+    expect(plan.status).toBe("needs_disambiguation");
+    expect(plan.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({ value: "sprint:123" }),
+      expect.objectContaining({ value: "sprint:124" }),
+    ]));
+  });
+
+  it("flattens Jira sprint disambiguation through the generic source tool", async () => {
+    vi.spyOn(db.Connection, "findByPk").mockResolvedValue(toolHarnessConnections.jira);
+    vi.spyOn(jiraConnection, "listProjects").mockResolvedValue([{
+      id: "10001",
+      key: "D2371",
+      name: "D2371 Project",
+    }]);
+    vi.spyOn(jiraConnection, "listBoards").mockResolvedValue([{
+      id: 77,
+      name: "D2371 Scrum Board",
+      type: "scrum",
+    }]);
+    vi.spyOn(jiraConnection, "listSprints").mockResolvedValue([{
+      id: 123,
+      name: "Sprint 14",
+      state: "active",
+    }, {
+      id: 124,
+      name: "Sprint 15",
+      state: "active",
+    }]);
+
+    const result = await sourceResolveContext({
+      team_id: TOOL_TEAM_ID,
+      connection_id: toolHarnessConnections.jira.id,
+      source_id: "jira",
+      question: "show active sprint status for D2371",
+      intent: { id: "sprint_status", resource: "sprint_issues" },
+      mode: "persist",
+    });
+
+    expect(result.needs_user_input).toBe(true);
+    expect(result.prompt).toBeTruthy();
+    expect(result.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({ value: "sprint:123" }),
+      expect.objectContaining({ value: "sprint:124" }),
+    ]));
+    expect(result.resolution.needsDisambiguation).toBe(true);
   });
 
   it.each(toolRoutingReplays)("$name follows the allowed high-risk tool sequence", (replay) => {

--- a/server/tests/unit/sourcePluginStructure.test.js
+++ b/server/tests/unit/sourcePluginStructure.test.js
@@ -59,6 +59,14 @@ describe("source plugin structure", () => {
     expectFile("server/sources/plugins/customerio/customerio.plugin.js");
     expectFile("server/sources/plugins/customerio/customerio.protocol.js");
     expectFile("server/sources/plugins/customerio/customerio.connection.js");
+    expectFile("server/sources/plugins/jira/jira.plugin.js");
+    expectFile("server/sources/plugins/jira/jira.protocol.js");
+    expectFile("server/sources/plugins/jira/jira.connection.js");
+    expectFile("server/sources/plugins/jira/jira.resources.js");
+    expectFile("server/sources/plugins/jira/templates/project-overview.json");
+    expectFile("server/sources/plugins/jira/templates/sprint-health.json");
+    expectFile("server/sources/plugins/jira/templates/bug-tracking.json");
+    expectFile("server/sources/plugins/jira/templates/team-workload.json");
   });
 
   it("keeps shared source backend code under server/sources/shared", () => {

--- a/server/tests/unit/sourceRegistry.test.js
+++ b/server/tests/unit/sourceRegistry.test.js
@@ -79,6 +79,28 @@ describe("source registry", () => {
     expect(source.backend.testUnsavedConnection).toEqual(expect.any(Function));
   });
 
+  it("resolves Jira by id", () => {
+    const source = getSourceById("jira");
+
+    expect(source).toMatchObject({
+      id: "jira",
+      type: "jira",
+      subType: "jira",
+      name: "Jira",
+      availability: {
+        server: {
+          enabled: true,
+        },
+      },
+    });
+    expect(source.backend.runDataRequest).toEqual(expect.any(Function));
+    expect(source.backend.getBuilderMetadata).toEqual(expect.any(Function));
+    expect(source.backend.getDefaultDataRequest).toEqual(expect.any(Function));
+    expect(source.backend.getSchema).toEqual(expect.any(Function));
+    expect(source.backend.testConnection).toEqual(expect.any(Function));
+    expect(source.backend.testUnsavedConnection).toEqual(expect.any(Function));
+  });
+
   it("includes source availability in source summaries", () => {
     const stripeSummary = getSourceSummaries().find((source) => source.id === "stripe");
 
@@ -484,6 +506,15 @@ describe("source registry", () => {
     expect(source.id).toBe("stripeOfficial");
   });
 
+  it("resolves Jira from its persisted source identity", () => {
+    const source = getSourceForConnection({
+      type: "jira",
+      subType: "jira",
+    });
+
+    expect(source.id).toBe("jira");
+  });
+
   it("resolves generic API connections through the API protocol fallback", () => {
     expect(getSourceForConnection({
       type: "api",
@@ -562,6 +593,12 @@ describe("source registry", () => {
       id: "stripeOfficial",
       type: "stripeOfficial",
       subType: "stripeOfficial",
+      capabilities: expect.any(Object),
+    }));
+    expect(summaries).toContainEqual(expect.objectContaining({
+      id: "jira",
+      type: "jira",
+      subType: "jira",
       capabilities: expect.any(Object),
     }));
     expect(summaries[0].backend).toBeUndefined();

--- a/source-plugin-guide.md
+++ b/source-plugin-guide.md
@@ -355,6 +355,7 @@ If the source ships built-in chart templates:
 
 4. Custom setup UI goes in `client/src/sources/<sourceId>/<sourceId>-template-setup.jsx`.
 5. Built-in templates must resolve through registered source plugins.
+6. Template setup UIs should expose one selectable card per chart, grouped by domain when useful. Selecting one chart must create only that chart's required datasets, not the entire template bundle.
 
 Template chart bindings:
 


### PR DESCRIPTION
### Description

Adds a custom Jira Cloud source with API-token auth, source-owned builder UI, Jira-specific templates, Agile/sprint support, and AI orchestration tools.

Includes:

* Jira connection, metadata, schema, preview, and runtime protocol
* Project/board/sprint/user/version discovery actions
* Visual/JQL builder flows with Jira filter controls
* Template bundles with one-card-per-chart selection
* Normalized Jira issue/sprint outputs, including optional done-date derivation
* Jira AI planning/resolution tools for projects, users, boards, sprints, and common issue queries
* Chart/template fixes for date-based Jira trends and editor-safe CDC defaults

Also updates shared chart aggregation so date-bucketed numeric charts with no explicit operation correctly sum values within each interval.