### PR TITLE
Feat/litellm OpenAI base url

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -95,6 +95,8 @@ CB_GOOGLE_CLIENT_SECRET=
 # OpenAI API key
 CB_OPENAI_API_KEY=
 CB_OPENAI_MODEL=gpt-5.4-mini
+# Optional OpenAI-compatible endpoint, such as a LiteLLM proxy ending in /v1
+CB_OPENAI_BASE_URL=
 
 ## Slack integration
 # The client ID of the Slack app is used in both server and client apps
@@ -178,6 +180,8 @@ CB_GOOGLE_CLIENT_SECRET_DEV=
 # OpenAI API key
 CB_OPENAI_API_KEY_DEV=
 CB_OPENAI_MODEL_DEV=gpt-5.4-mini
+# Optional OpenAI-compatible endpoint, such as a LiteLLM proxy ending in /v1
+CB_OPENAI_BASE_URL_DEV=
 
 # Slack Integration backend redirect host (useful when using ngrok or other tunneling services)
 CB_SLACK_REDIRECT_HOST_DEV=

--- a/server/modules/ai/generateClickhouseQuery.js
+++ b/server/modules/ai/generateClickhouseQuery.js
@@ -1,14 +1,7 @@
-const OpenAI = require("openai");
+const { createOpenAiClient, getOpenAiConfig } = require("./openAiClient");
 
-const openAiKey = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_API_KEY : process.env.CB_OPENAI_API_KEY_DEV;
-const openAiModel = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_MODEL : process.env.CB_OPENAI_MODEL_DEV;
-let openaiClient;
-
-if (openAiKey) {
-  openaiClient = new OpenAI({
-    apiKey: openAiKey,
-  });
-}
+const { model: openAiModel } = getOpenAiConfig();
+const openaiClient = createOpenAiClient();
 
 async function generateClickhouseQuery(schema, question, conversationHistory = [], currentQuery = "") {
   if (!openaiClient) {

--- a/server/modules/ai/generateMongoQuery.js
+++ b/server/modules/ai/generateMongoQuery.js
@@ -1,14 +1,7 @@
-const OpenAI = require("openai");
+const { createOpenAiClient, getOpenAiConfig } = require("./openAiClient");
 
-const openAiKey = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_API_KEY : process.env.CB_OPENAI_API_KEY_DEV;
-const openAiModel = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_MODEL : process.env.CB_OPENAI_MODEL_DEV;
-let openaiClient;
-
-if (openAiKey) {
-  openaiClient = new OpenAI({
-    apiKey: openAiKey,
-  });
-}
+const { model: openAiModel } = getOpenAiConfig();
+const openaiClient = createOpenAiClient();
 
 async function generateMongoQuery(schema, question, conversationHistory = [], currentQuery = "") {
   if (!openaiClient) {

--- a/server/modules/ai/generateSqlQuery.js
+++ b/server/modules/ai/generateSqlQuery.js
@@ -1,14 +1,7 @@
-const OpenAI = require("openai");
+const { createOpenAiClient, getOpenAiConfig } = require("./openAiClient");
 
-const openAiKey = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_API_KEY : process.env.CB_OPENAI_API_KEY_DEV;
-const openAiModel = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_MODEL : process.env.CB_OPENAI_MODEL_DEV;
-let openaiClient;
-
-if (openAiKey) {
-  openaiClient = new OpenAI({
-    apiKey: openAiKey,
-  });
-}
+const { model: openAiModel } = getOpenAiConfig();
+const openaiClient = createOpenAiClient();
 
 async function generateSqlQuery(schema, question, conversationHistory = [], currentQuery = "") {
   if (!openaiClient) {

--- a/server/modules/ai/openAiClient.js
+++ b/server/modules/ai/openAiClient.js
@@ -1,0 +1,26 @@
+const OpenAI = require("openai");
+
+function getOpenAiConfig() {
+  const isProduction = process.env.NODE_ENV === "production";
+  const suffix = isProduction ? "" : "_DEV";
+  const apiKey = process.env[`CB_OPENAI_API_KEY${suffix}`];
+  const baseURL = process.env[`CB_OPENAI_BASE_URL${suffix}`];
+
+  return {
+    model: process.env[`CB_OPENAI_MODEL${suffix}`],
+    clientOptions: {
+      apiKey,
+      ...(baseURL ? { baseURL } : {}),
+    },
+  };
+}
+
+function createOpenAiClient() {
+  const { clientOptions } = getOpenAiConfig();
+  return clientOptions.apiKey ? new OpenAI(clientOptions) : undefined;
+}
+
+module.exports = {
+  createOpenAiClient,
+  getOpenAiConfig,
+};

--- a/server/modules/ai/orchestrator/orchestrator.js
+++ b/server/modules/ai/orchestrator/orchestrator.js
@@ -12,10 +12,10 @@
  * Main entry point: orchestrate(teamId, question, conversationHistory)
  */
 
-const OpenAI = require("openai");
 const db = require("../../../models/models");
 const socketManager = require("../../socketManager");
 const { sanitizeSnippet } = require("../../updateAudit");
+const { createOpenAiClient, getOpenAiConfig } = require("../openAiClient");
 const { emitProgressEvent, parseProgressEvents } = require("./responseParser");
 const { ENTITY_CREATION_RULES } = require("./entityCreationRules");
 const { isCapabilityQuestion, generateCapabilityResponse } = require("./capabilityHandler");
@@ -30,15 +30,8 @@ const {
   getTemplateSourceIds,
 } = require("./sourceSupport");
 
-const openAiKey = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_API_KEY : process.env.CB_OPENAI_API_KEY_DEV;
-const openAiModel = process.env.NODE_ENV === "production" ? process.env.CB_OPENAI_MODEL : process.env.CB_OPENAI_MODEL_DEV;
-let openaiClient;
-
-if (openAiKey) {
-  openaiClient = new OpenAI({
-    apiKey: openAiKey,
-  });
-}
+const { model: openAiModel } = getOpenAiConfig();
+const openaiClient = createOpenAiClient();
 
 const clientUrl = process.env.NODE_ENV === "production" ? process.env.VITE_APP_CLIENT_HOST : process.env.VITE_APP_CLIENT_HOST_DEV;
 

--- a/server/tests/unit/openAiClient.test.js
+++ b/server/tests/unit/openAiClient.test.js
@@ -1,0 +1,82 @@
+import {
+  afterEach, describe, expect, it, vi
+} from "vitest";
+import { createServer } from "node:http";
+
+const { createOpenAiClient, getOpenAiConfig } = require("../../modules/ai/openAiClient");
+
+describe("OpenAI client configuration", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the production LiteLLM endpoint when configured", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CB_OPENAI_API_KEY", "production-key");
+    vi.stubEnv("CB_OPENAI_MODEL", "production-model");
+    vi.stubEnv("CB_OPENAI_BASE_URL", "http://litellm.example/v1");
+
+    expect(getOpenAiConfig()).toEqual({
+      model: "production-model",
+      clientOptions: {
+        apiKey: "production-key",
+        baseURL: "http://litellm.example/v1",
+      },
+    });
+  });
+
+  it("uses development variables and leaves the default endpoint unchanged", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CB_OPENAI_API_KEY_DEV", "development-key");
+    vi.stubEnv("CB_OPENAI_MODEL_DEV", "development-model");
+    vi.stubEnv("CB_OPENAI_BASE_URL_DEV", "");
+
+    expect(getOpenAiConfig()).toEqual({
+      model: "development-model",
+      clientOptions: {
+        apiKey: "development-key",
+      },
+    });
+  });
+
+  it("routes chat completions through the configured OpenAI-compatible endpoint", async () => {
+    let requestUrl;
+    let authorization;
+    const server = createServer((request, response) => {
+      requestUrl = request.url;
+      authorization = request.headers.authorization;
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({
+        id: "chatcmpl-test",
+        object: "chat.completion",
+        created: 0,
+        model: "gateway-model",
+        choices: [{
+          index: 0,
+          message: { role: "assistant", content: "Gateway response" },
+          finish_reason: "stop",
+        }],
+      }));
+    });
+
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    try {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", "gateway-key");
+      vi.stubEnv("CB_OPENAI_BASE_URL", `http://127.0.0.1:${port}/v1`);
+
+      const response = await createOpenAiClient().chat.completions.create({
+        model: "gateway-model",
+        messages: [{ role: "user", content: "Hello" }],
+      });
+
+      expect(response.choices[0].message.content).toBe("Gateway response");
+      expect(requestUrl).toBe("/v1/chat/completions");
+      expect(authorization).toBe("Bearer gateway-key");
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+});

--- a/server/tests/unit/openAiClient.test.js
+++ b/server/tests/unit/openAiClient.test.js
@@ -39,6 +39,14 @@ describe("OpenAI client configuration", () => {
     });
   });
 
+  it("does not create a client without the selected environment API key", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CB_OPENAI_API_KEY", "");
+    vi.stubEnv("OPENAI_API_KEY", "must-not-be-used");
+
+    expect(createOpenAiClient()).toBeUndefined();
+  });
+
   it("routes chat completions through the configured OpenAI-compatible endpoint", async () => {
     let requestUrl;
     let authorization;
@@ -79,4 +87,186 @@ describe("OpenAI client configuration", () => {
       await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     }
   });
+
+  it("routes Responses API calls through the configured endpoint", async () => {
+    let requestUrl;
+    let requestedModel;
+    const server = createServer((request, response) => {
+      requestUrl = request.url;
+      let body = "";
+      request.on("data", (chunk) => { body += chunk; });
+      request.on("end", () => {
+        requestedModel = JSON.parse(body).model;
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({
+          id: "resp-test",
+          object: "response",
+          created_at: 1,
+          status: "completed",
+          model: "gateway-model",
+          output: [{
+            id: "msg-test",
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "Gateway response", annotations: [] }],
+          }],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        }));
+      });
+    });
+
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    try {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", "gateway-key");
+      vi.stubEnv("CB_OPENAI_BASE_URL", `http://127.0.0.1:${port}/v1`);
+
+      const response = await createOpenAiClient().responses.create({
+        model: "gateway-model",
+        input: "Hello",
+      });
+
+      expect(response.output_text).toBe("Gateway response");
+      expect(requestUrl).toBe("/v1/responses");
+      expect(requestedModel).toBe("gateway-model");
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it.each([
+    [401, "invalid API key"],
+    [404, "model not found"],
+    [400, "context window exceeded"],
+  ])("preserves SDK errors for HTTP %i", async (status, message) => {
+    const server = createServer((_request, response) => {
+      response.writeHead(status, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: { message } }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    try {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", "gateway-key");
+      vi.stubEnv("CB_OPENAI_BASE_URL", `http://127.0.0.1:${port}/v1`);
+
+      await expect(createOpenAiClient().chat.completions.create({
+        model: "gateway-model",
+        messages: [{ role: "user", content: "Hello" }],
+      }, { maxRetries: 0 })).rejects.toMatchObject({ status });
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("retries a rate-limited request", async () => {
+    let requests = 0;
+    const server = createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(requests === 1 ? 429 : 200, {
+        "Content-Type": "application/json",
+        "retry-after-ms": "1",
+      });
+      response.end(JSON.stringify(requests === 1
+        ? { error: { message: "rate limited" } }
+        : {
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          created: 0,
+          model: "gateway-model",
+          choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        }));
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    try {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", "gateway-key");
+      vi.stubEnv("CB_OPENAI_BASE_URL", `http://127.0.0.1:${port}/v1`);
+
+      const result = await createOpenAiClient().chat.completions.create({
+        model: "gateway-model",
+        messages: [{ role: "user", content: "Hello" }],
+      }, { maxRetries: 1 });
+
+      expect(result.choices[0].message.content).toBe("ok");
+      expect(requests).toBe(2);
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("surfaces timeout failures", async () => {
+    const server = createServer((_request, response) => {
+      setTimeout(() => {
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.end("not-json");
+      }, 100);
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    try {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", "gateway-key");
+      vi.stubEnv("CB_OPENAI_BASE_URL", `http://127.0.0.1:${port}/v1`);
+
+      await expect(createOpenAiClient().chat.completions.create({
+        model: "gateway-model",
+        messages: [{ role: "user", content: "Hello" }],
+      }, { maxRetries: 0, timeout: 10 })).rejects.toBeDefined();
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("rejects malformed JSON responses", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end("not-json");
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+
+    try {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", "gateway-key");
+      vi.stubEnv("CB_OPENAI_BASE_URL", `http://127.0.0.1:${port}/v1`);
+
+      await expect(createOpenAiClient().chat.completions.create({
+        model: "gateway-model",
+        messages: [{ role: "user", content: "Hello" }],
+      }, { maxRetries: 0 })).rejects.toBeDefined();
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it.skipIf(!process.env.LITELLM_E2E_BASE_URL || !process.env.LITELLM_E2E_API_KEY || !process.env.LITELLM_E2E_MODEL)(
+    "completes live Chat Completions and Responses API requests",
+    async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("CB_OPENAI_API_KEY", process.env.LITELLM_E2E_API_KEY);
+      vi.stubEnv("CB_OPENAI_BASE_URL", process.env.LITELLM_E2E_BASE_URL);
+      const client = createOpenAiClient();
+      const model = process.env.LITELLM_E2E_MODEL;
+
+      const chat = await client.chat.completions.create({
+        model,
+        messages: [{ role: "user", content: "Reply with OK." }],
+      });
+      const responses = await client.responses.create({
+        model,
+        input: "Reply with OK.",
+      });
+
+      expect(chat.choices[0].message.content?.trim()).toBeTruthy();
+      expect(responses.output_text.trim()).toBeTruthy();
+    }
+  );
 });


### PR DESCRIPTION
### Description
- Add optional `CB_OPENAI_BASE_URL` and `CB_OPENAI_BASE_URL_DEV` configuration so Chartbrew's AI features can use OpenAI-compatible endpoints such as a LiteLLM proxy.
- Centralize API key, model, base URL, and OpenAI client construction in `server/modules/ai/openAiClient.js`.
- Route SQL, MongoDB, ClickHouse, and orchestrator AI requests through the shared client while preserving the existing OpenAI endpoint when no base URL is configured.
- Document the new environment variables and add regression coverage for both Chat Completions and Responses API requests.

#### Configuration example

```env
CB_OPENAI_API_KEY_DEV=sk-litellm-master-key
CB_OPENAI_MODEL_DEV=chartbrew-default
CB_OPENAI_BASE_URL_DEV=http://localhost:4000/v1
```

`CB_OPENAI_MODEL` can be any model name or model-group alias exposed by the
LiteLLM proxy. It selects the model Chartbrew sends for its AI workflows; it
does not limit which other models the gateway can serve. The alias can route to
multiple deployments and use LiteLLM fallbacks or load balancing. When the base
URL is omitted, the OpenAI SDK continues using its default hosted endpoint.

#### Implementation usage

Chartbrew users do not need to instantiate a new provider class. Existing AI workflows use the shared client helper, so configuring the environment variables routes those workflows through LiteLLM automatically.

```js
const {
  createOpenAiClient,
  getOpenAiConfig,
} = require("./openAiClient");

const { model } = getOpenAiConfig();
const client = createOpenAiClient();

// Used by the SQL, MongoDB, and ClickHouse query generators
const completion = await client.chat.completions.create({
  model,
  messages: [{ role: "user", content: "Generate a SQL query for monthly revenue" }],
});

// The same configured client also supports Chartbrew's Responses API workflows
const response = await client.responses.create({
  model,
  input: "Summarize this dataset",
});
```

The query generators and AI orchestrator already call this helper internally; no application-code changes are required for deployment users.

#### Tests

**Focused tests**

```text
npm run test:run -- tests/unit/openAiClient.test.js

Test Files  1 passed (1)
Tests       12 passed (12)
```

Coverage includes production/development configuration, missing credentials, model alias forwarding, 401 authentication errors, 404 model errors, context-window errors, 429 retry behavior, timeouts, malformed responses, Chat Completions, and Responses API calls.

**Full regression**

```text
Test Files  92 passed (92)
Tests       728 passed | 1 skipped (729)
```

**Live provider E2E**

The opt-in E2E test completed both API paths through a live LiteLLM 1.96 proxy:

```text
LiteLLM -> OpenAI gpt-4o-mini
Chat Completions: PASS
Responses API:    PASS

LiteLLM -> Anthropic Claude Haiku 4.5
Chat Completions: PASS
Responses API:    PASS
```

No database or API migration is required. Existing deployments continue using the default OpenAI endpoint unless `CB_OPENAI_BASE_URL` or `CB_OPENAI_BASE_URL_DEV` is set.

### Spec or ADR
Required for features that or changes that span over multiple files and are >= 100 lines of code.

- FS-ID or ADR-ID: [FS-20260803-openai-compatible-ai-endpoint](https://github.com/prodmanpd/chartbrew/blob/feat/litellm-openai-base-url/docs/specs/FS-20260803-openai-compatible-ai-endpoint.md)

### Checklist
- [x] Linked spec or ADR
- [x] Tests updated
- [x] Migration notes, if any (no migration required; configuration-only additive change)
