### PR TITLE
Fix untriaged security advisories

### DIFF
--- a/server/apps/slack/utils/slackClient.js
+++ b/server/apps/slack/utils/slackClient.js
@@ -3,7 +3,6 @@ const crypto = require("crypto");
 
 const slackClientId = process.env.VITE_APP_SLACK_CLIENT_ID;
 const slackClientSecret = process.env.CB_SLACK_CLIENT_SECRET;
-const slackSigningSecret = process.env.CB_SLACK_SIGNING_SECRET;
 
 /**
  * Verify Slack request signature
@@ -12,10 +11,11 @@ const slackSigningSecret = process.env.CB_SLACK_SIGNING_SECRET;
  * This is a simplified version that works with parsed body
  */
 function verifySignature(req) {
+  const slackSigningSecret = process.env.CB_SLACK_SIGNING_SECRET;
   if (!slackSigningSecret) {
     // oxlint-disable-next-line no-console
-    console.warn("SLACK_SIGNING_SECRET not configured, skipping signature verification");
-    return true;
+    console.warn("CB_SLACK_SIGNING_SECRET is not configured; rejecting Slack request");
+    return false;
   }
 
   const timestamp = req.headers["x-slack-request-timestamp"];
@@ -24,13 +24,18 @@ function verifySignature(req) {
   if (!timestamp || !signature) {
     // oxlint-disable-next-line no-console
     console.warn("Missing Slack signature headers");
-    // Allow request to proceed for now (can be strict later)
-    return true;
+    return false;
   }
 
   // Check if request is too old (replay attack protection)
+  const parsedTimestamp = Number(timestamp);
+  if (!Number.isInteger(parsedTimestamp)) {
+    // oxlint-disable-next-line no-console
+    console.warn("Invalid Slack request timestamp");
+    return false;
+  }
   const currentTime = Math.floor(Date.now() / 1000);
-  if (Math.abs(currentTime - parseInt(timestamp, 10)) > 300) {
+  if (Math.abs(currentTime - parsedTimestamp) > 300) {
     // oxlint-disable-next-line no-console
     console.warn("Slack request timestamp too old");
     return false;
@@ -74,33 +79,13 @@ function verifySignature(req) {
     );
     if (!isValid) {
       // oxlint-disable-next-line no-console
-      console.warn("Invalid Slack signature - this may be due to body parsing");
-      // oxlint-disable-next-line no-console
-      console.warn("Expected:", signature);
-      // oxlint-disable-next-line no-console
-      console.warn("Computed:", mySignature);
-
-      // In development, allow interactive payloads and events to proceed for testing
-      // These are harder to verify without raw body
-      if (process.env.NODE_ENV !== "production") {
-        if (req.body && req.body.payload) {
-          // oxlint-disable-next-line no-console
-          console.warn("Allowing interactive payload in development mode");
-          return true;
-        }
-        if (req.body && (req.body.type === "event_callback" || req.body.event)) {
-          // oxlint-disable-next-line no-console
-          console.warn("Allowing event payload in development mode");
-          return true;
-        }
-      }
+      console.warn("Invalid Slack signature");
     }
     return isValid;
   } catch (e) {
     // oxlint-disable-next-line no-console
     console.warn("Signature verification error:", e.message);
-    // Allow request to proceed for debugging
-    return true;
+    return false;
   }
 }
 

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -1097,8 +1097,18 @@ class ChartController {
       });
   }
 
-  testQuery(chart) {
-    return this.connectionController.findById(chart.connection_id)
+  findConnectionForProject(connectionId, projectId) {
+    return db.Project.findByPk(projectId, { attributes: ["team_id"] })
+      .then((project) => {
+        if (!project) {
+          throw new Error(404);
+        }
+        return this.connectionController.findByIdAndTeam(connectionId, project.team_id);
+      });
+  }
+
+  testQuery(chart, projectId) {
+    return this.findConnectionForProject(chart.connection_id, projectId)
       .then((connection) => {
         const source = findSourceForConnection(connection);
         if (source?.backend?.runChartQuery) {
@@ -1120,7 +1130,7 @@ class ChartController {
           return new Promise((resolve) => resolve(cache));
         }
 
-        return this.connectionController.findById(chart.connection_id);
+        return this.findConnectionForProject(chart.connection_id, projectId);
       })
       .then((connection) => {
         if (noSource === "true") {

--- a/server/controllers/TeamController.js
+++ b/server/controllers/TeamController.js
@@ -16,6 +16,7 @@ const TEAM_ROLES = new Set([
   "projectEditor",
   "projectViewer",
 ]);
+const TEAM_ROLE_UPDATE_FIELDS = new Set(["role", "projects", "canExport"]);
 
 class TeamController {
   constructor() {
@@ -276,22 +277,26 @@ class TeamController {
   }
 
   updateTeamRole(teamId, userId, data) {
+    const updateData = Object.fromEntries(
+      Object.entries(data).filter(([field]) => TEAM_ROLE_UPDATE_FIELDS.has(field))
+    );
+
     return this.getTeamRole(teamId, userId)
       .then((currentTeamRole) => {
         if (!currentTeamRole) {
           throw new Error(404);
         }
 
-        if (data.role) {
-          if (!TEAM_ROLES.has(data.role)) {
+        if (updateData.role) {
+          if (!TEAM_ROLES.has(updateData.role)) {
             throw new Error("Invalid team role");
           }
-          if (currentTeamRole.role === "teamOwner" || data.role === "teamOwner") {
+          if (currentTeamRole.role === "teamOwner" || updateData.role === "teamOwner") {
             throw new Error("Team ownership can only be changed through an ownership transfer");
           }
         }
 
-        return db.TeamRole.update(data, { where: { "team_id": teamId, "user_id": userId } });
+        return db.TeamRole.update(updateData, { where: { "team_id": teamId, "user_id": userId } });
       })
       .then(() => {
         return this.getTeamRole(teamId, userId);

--- a/server/controllers/TeamController.js
+++ b/server/controllers/TeamController.js
@@ -9,6 +9,14 @@ const UserController = require("./UserController");
 
 const settings = process.env.NODE_ENV === "production" ? require("../settings") : require("../settings-dev");
 
+const TEAM_ROLES = new Set([
+  "teamOwner",
+  "teamAdmin",
+  "projectAdmin",
+  "projectEditor",
+  "projectViewer",
+]);
+
 class TeamController {
   constructor() {
     this.userController = new UserController();
@@ -268,7 +276,23 @@ class TeamController {
   }
 
   updateTeamRole(teamId, userId, data) {
-    return db.TeamRole.update(data, { where: { "team_id": teamId, "user_id": userId } })
+    return this.getTeamRole(teamId, userId)
+      .then((currentTeamRole) => {
+        if (!currentTeamRole) {
+          throw new Error(404);
+        }
+
+        if (data.role) {
+          if (!TEAM_ROLES.has(data.role)) {
+            throw new Error("Invalid team role");
+          }
+          if (currentTeamRole.role === "teamOwner" || data.role === "teamOwner") {
+            throw new Error("Team ownership can only be changed through an ownership transfer");
+          }
+        }
+
+        return db.TeamRole.update(data, { where: { "team_id": teamId, "user_id": userId } });
+      })
       .then(() => {
         return this.getTeamRole(teamId, userId);
       })

--- a/server/modules/outboundTargetPolicy.js
+++ b/server/modules/outboundTargetPolicy.js
@@ -114,6 +114,7 @@ function getGlobalAllowPrivateNetworkCalls() {
 function normalizeHostname(hostname) {
   return String(hostname || "")
     .trim()
+    .replace(/^\[|\]$/g, "")
     .replace(/\.$/, "")
     .toLowerCase();
 }
@@ -170,25 +171,27 @@ function expandIpv6(address) {
 function isMetadataAddress(address) {
   if (METADATA_IP_ADDRESSES.has(address)) return true;
 
-  if (address.startsWith("::ffff:")) {
-    const mappedIpv4 = address.replace("::ffff:", "");
-    return METADATA_IP_ADDRESSES.has(mappedIpv4);
-  }
-
-  const nat64Ipv4 = getNat64EmbeddedIpv4(address);
-  if (nat64Ipv4) {
-    return METADATA_IP_ADDRESSES.has(nat64Ipv4);
+  const translatedIpv4 = getMappedIpv4(address);
+  if (translatedIpv4) {
+    return METADATA_IP_ADDRESSES.has(translatedIpv4);
   }
 
   return false;
 }
 
 function getMappedIpv4(address) {
-  if (address.startsWith("::ffff:")) {
-    const mappedIpv4 = address.replace("::ffff:", "");
-    return net.isIP(mappedIpv4) === 4 ? mappedIpv4 : null;
+  const normalizedAddress = normalizeIpAddress(address).replace(/^\[|\]$/g, "");
+  if (normalizedAddress.startsWith("::ffff:")) {
+    const mappedIpv4 = normalizedAddress.replace("::ffff:", "");
+    if (net.isIP(mappedIpv4) === 4) return mappedIpv4;
+
+    const groups = expandIpv6(normalizedAddress);
+    if (!groups || groups[5] !== 0xffff) return null;
+
+    const lo = (groups[6] << 16) | groups[7];
+    return [(lo >>> 24) & 0xff, (lo >>> 16) & 0xff, (lo >>> 8) & 0xff, lo & 0xff].join(".");
   }
-  return getNat64EmbeddedIpv4(address);
+  return getNat64EmbeddedIpv4(normalizedAddress);
 }
 
 function isPrivateOrReservedAddress(address) {

--- a/server/modules/validateMongoQuery.js
+++ b/server/modules/validateMongoQuery.js
@@ -5,6 +5,40 @@ const BLOCKED_MEMBER_NAMES = new Set([
   "__proto__",
   "prototype",
 ]);
+const BLOCKED_QUERY_KEYS = new Set([
+  "$accumulator",
+  "$function",
+  "$merge",
+  "$out",
+  "$where",
+]);
+const READ_ONLY_METHODS = new Set([
+  "aggregate",
+  "allowDiskUse",
+  "batchSize",
+  "collation",
+  "collection",
+  "comment",
+  "count",
+  "countDocuments",
+  "distinct",
+  "estimatedDocumentCount",
+  "find",
+  "findOne",
+  "hint",
+  "indexExists",
+  "indexInformation",
+  "indexes",
+  "limit",
+  "listIndexes",
+  "maxAwaitTimeMS",
+  "maxTimeMS",
+  "project",
+  "readConcern",
+  "readPreference",
+  "skip",
+  "sort",
+]);
 
 const ALLOWED_HELPER_CALLS = new Set(["ObjectId", "Date"]);
 const ALLOWED_HELPER_CONSTRUCTORS = new Set(["Date", "ObjectId"]);
@@ -47,6 +81,12 @@ function validateDataExpression(node) {
         }
         if (property.key.type !== "Identifier" && property.key.type !== "Literal") {
           return invalid("Invalid object property key");
+        }
+        const propertyName = property.key.type === "Identifier"
+          ? property.key.name
+          : String(property.key.value);
+        if (BLOCKED_QUERY_KEYS.has(propertyName)) {
+          return invalid(`Blocked MongoDB query operator: "${propertyName}"`);
         }
 
         const result = validateDataExpression(property.value);
@@ -133,6 +173,10 @@ function validateMongoCallChain(node) {
 
   if (BLOCKED_MEMBER_NAMES.has(node.callee.property.name)) {
     return invalid(`Blocked member access: "${node.callee.property.name}"`);
+  }
+
+  if (!READ_ONLY_METHODS.has(node.callee.property.name)) {
+    return invalid(`MongoDB method is not read-only: "${node.callee.property.name}"`);
   }
 
   if (node.callee.object.type === "Identifier") {

--- a/server/tests/unit/chartControllerConnectionScope.test.js
+++ b/server/tests/unit/chartControllerConnectionScope.test.js
@@ -1,0 +1,62 @@
+import {
+  beforeEach, describe, expect, it, vi
+} from "vitest";
+
+const db = require("../../models/models");
+const ChartController = require("../../controllers/ChartController");
+const { getSourceById } = require("../../sources");
+
+describe("ChartController connection scoping", () => {
+  let controller;
+  let runChartQuerySpy;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    controller = new ChartController();
+    vi.spyOn(db.Project, "findByPk").mockResolvedValue({ id: 10, team_id: 7 });
+    runChartQuerySpy = vi.spyOn(getSourceById("postgres").backend, "runChartQuery")
+      .mockResolvedValue({ data: [{ value: 1 }] });
+  });
+
+  it("scopes test queries to the project's team", async () => {
+    const connection = { id: 42, team_id: 7, type: "postgres" };
+    const scopedLookupSpy = vi.spyOn(controller.connectionController, "findByIdAndTeam")
+      .mockResolvedValue(connection);
+    const unscopedLookupSpy = vi.spyOn(controller.connectionController, "findById");
+
+    await controller.testQuery({ connection_id: 42, query: "SELECT 1" }, 10);
+
+    expect(scopedLookupSpy).toHaveBeenCalledWith(42, 7);
+    expect(unscopedLookupSpy).not.toHaveBeenCalled();
+    expect(runChartQuerySpy).toHaveBeenCalledWith({ connection, query: "SELECT 1" });
+  });
+
+  it("scopes preview queries to the project's team", async () => {
+    const connection = { id: 42, team_id: 7, type: "postgres" };
+    vi.spyOn(controller.chartCache, "findLast").mockResolvedValue(null);
+    vi.spyOn(controller.chartCache, "create").mockResolvedValue(null);
+    const scopedLookupSpy = vi.spyOn(controller.connectionController, "findByIdAndTeam")
+      .mockResolvedValue(connection);
+    const unscopedLookupSpy = vi.spyOn(controller.connectionController, "findById");
+
+    await controller.getPreviewData(
+      { id: 9, connection_id: 42, query: "SELECT 1" },
+      10,
+      { id: 5 },
+      false
+    );
+
+    expect(scopedLookupSpy).toHaveBeenCalledWith(42, 7);
+    expect(unscopedLookupSpy).not.toHaveBeenCalled();
+    expect(runChartQuerySpy).toHaveBeenCalledWith({ connection, query: "SELECT 1" });
+  });
+
+  it("rejects queries when the project does not exist", async () => {
+    db.Project.findByPk.mockResolvedValue(null);
+    const scopedLookupSpy = vi.spyOn(controller.connectionController, "findByIdAndTeam");
+
+    await expect(controller.testQuery({ connection_id: 42, query: "SELECT 1" }, 999))
+      .rejects.toThrow("404");
+    expect(scopedLookupSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/unit/outboundTargetPolicy.test.js
+++ b/server/tests/unit/outboundTargetPolicy.test.js
@@ -55,6 +55,22 @@ describe("outboundTargetPolicy", () => {
     });
   });
 
+  it("blocks IPv4-mapped IPv6 private targets", async () => {
+    await expect(validateOutboundUrl("http://[::ffff:127.0.0.1]:4019"))
+      .rejects.toMatchObject({
+        code: "SSRF_BLOCKED",
+        reason: "private_network",
+      });
+  });
+
+  it("blocks IPv4-mapped IPv6 metadata targets", async () => {
+    await expect(validateOutboundUrl("http://[::ffff:169.254.169.254]/latest/meta-data"))
+      .rejects.toMatchObject({
+        code: "SSRF_BLOCKED",
+        reason: "metadata_endpoint",
+      });
+  });
+
   it("allows private literal IP targets when global policy allows them", async () => {
     process.env.CB_ALLOW_PRIVATE_NETWORK_CALLS = "true";
     const result = await validateOutboundUrl("http://10.0.0.12");

--- a/server/tests/unit/slackSignature.test.js
+++ b/server/tests/unit/slackSignature.test.js
@@ -1,0 +1,90 @@
+import {
+  afterEach, describe, expect, it, vi
+} from "vitest";
+import crypto from "crypto";
+
+const { verifySignature } = require("../../apps/slack/utils/slackClient");
+
+function createSignedRequest(body, signingSecret, timestamp = Math.floor(Date.now() / 1000)) {
+  const signature = `v0=${crypto
+    .createHmac("sha256", signingSecret)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+
+  return {
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": `${timestamp}`,
+      "x-slack-signature": signature,
+    },
+    rawBody: body,
+    body: JSON.parse(body),
+  };
+}
+
+describe("Slack signature verification", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects requests when the signing secret is not configured", () => {
+    vi.stubEnv("CB_SLACK_SIGNING_SECRET", "");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(verifySignature({ headers: {}, body: {} })).toBe(false);
+  });
+
+  it("rejects requests without Slack signature headers", () => {
+    vi.stubEnv("CB_SLACK_SIGNING_SECRET", "signing-secret");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(verifySignature({ headers: {}, body: { type: "event_callback" } })).toBe(false);
+  });
+
+  it("accepts a valid signature over the raw request body", () => {
+    const signingSecret = "signing-secret";
+    vi.stubEnv("CB_SLACK_SIGNING_SECRET", signingSecret);
+    const request = createSignedRequest(
+      JSON.stringify({ type: "event_callback", event: { type: "app_mention" } }),
+      signingSecret
+    );
+
+    expect(verifySignature(request)).toBe(true);
+  });
+
+  it("rejects invalid signatures even outside production", () => {
+    vi.stubEnv("CB_SLACK_SIGNING_SECRET", "signing-secret");
+    vi.stubEnv("NODE_ENV", "development");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = createSignedRequest(
+      JSON.stringify({ type: "event_callback", event: { type: "app_mention" } }),
+      "wrong-secret"
+    );
+
+    expect(verifySignature(request)).toBe(false);
+  });
+
+  it("rejects expired signatures", () => {
+    const signingSecret = "signing-secret";
+    vi.stubEnv("CB_SLACK_SIGNING_SECRET", signingSecret);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = createSignedRequest("{}", signingSecret, Math.floor(Date.now() / 1000) - 301);
+
+    expect(verifySignature(request)).toBe(false);
+  });
+
+  it("rejects malformed signature timestamps", () => {
+    vi.stubEnv("CB_SLACK_SIGNING_SECRET", "signing-secret");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(verifySignature({
+      headers: {
+        "x-slack-request-timestamp": "not-a-timestamp",
+        "x-slack-signature": "v0=invalid",
+      },
+      rawBody: "{}",
+      body: {},
+    })).toBe(false);
+  });
+});

--- a/server/tests/unit/teamRoleSecurity.test.js
+++ b/server/tests/unit/teamRoleSecurity.test.js
@@ -54,4 +54,30 @@ describe("TeamController role security", () => {
     expect(getTeamRoleSpy).toHaveBeenCalledTimes(2);
     expect(result.role).toBe("teamAdmin");
   });
+
+  it("only writes supported team role fields", async () => {
+    vi.spyOn(controller, "getTeamRole")
+      .mockResolvedValueOnce({ team_id: 7, user_id: 42, role: "projectEditor" })
+      .mockResolvedValueOnce({ team_id: 7, user_id: 42, role: "projectAdmin" });
+    const updateSpy = vi.spyOn(db.TeamRole, "update").mockResolvedValue([1]);
+
+    await controller.updateTeamRole(7, 42, {
+      id: 99,
+      user_id: 84,
+      team_id: 12,
+      role: "projectAdmin",
+      projects: [3],
+      canExport: true,
+      createdAt: "2026-08-04T00:00:00.000Z",
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      {
+        role: "projectAdmin",
+        projects: [3],
+        canExport: true,
+      },
+      { where: { team_id: 7, user_id: 42 } }
+    );
+  });
 });

--- a/server/tests/unit/teamRoleSecurity.test.js
+++ b/server/tests/unit/teamRoleSecurity.test.js
@@ -1,0 +1,57 @@
+import {
+  beforeEach, describe, expect, it, vi
+} from "vitest";
+
+const db = require("../../models/models");
+const TeamController = require("../../controllers/TeamController");
+
+describe("TeamController role security", () => {
+  let controller;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    controller = new TeamController();
+  });
+
+  it("rejects assigning team ownership through a role update", async () => {
+    vi.spyOn(controller, "getTeamRole").mockResolvedValue({
+      team_id: 7,
+      user_id: 42,
+      role: "teamAdmin",
+    });
+    const updateSpy = vi.spyOn(db.TeamRole, "update").mockResolvedValue([1]);
+
+    await expect(controller.updateTeamRole(7, 42, { role: "teamOwner" }))
+      .rejects.toThrow("Team ownership can only be changed through an ownership transfer");
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects changing the current team owner's role", async () => {
+    vi.spyOn(controller, "getTeamRole").mockResolvedValue({
+      team_id: 7,
+      user_id: 42,
+      role: "teamOwner",
+    });
+    const updateSpy = vi.spyOn(db.TeamRole, "update").mockResolvedValue([1]);
+
+    await expect(controller.updateTeamRole(7, 42, { role: "teamAdmin" }))
+      .rejects.toThrow("Team ownership can only be changed through an ownership transfer");
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("still allows routine non-owner role changes", async () => {
+    const getTeamRoleSpy = vi.spyOn(controller, "getTeamRole")
+      .mockResolvedValueOnce({ team_id: 7, user_id: 42, role: "projectEditor" })
+      .mockResolvedValueOnce({ team_id: 7, user_id: 42, role: "teamAdmin" });
+    const updateSpy = vi.spyOn(db.TeamRole, "update").mockResolvedValue([1]);
+
+    const result = await controller.updateTeamRole(7, 42, { role: "teamAdmin" });
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      { role: "teamAdmin" },
+      { where: { team_id: 7, user_id: 42 } }
+    );
+    expect(getTeamRoleSpy).toHaveBeenCalledTimes(2);
+    expect(result.role).toBe("teamAdmin");
+  });
+});

--- a/server/tests/unit/validateMongoQuery.test.js
+++ b/server/tests/unit/validateMongoQuery.test.js
@@ -1,0 +1,55 @@
+import {
+  describe, expect, it
+} from "vitest";
+
+const validateMongoQuery = require("../../modules/validateMongoQuery");
+
+describe("validateMongoQuery read-only enforcement", () => {
+  it("allows read-only collection queries and cursor modifiers", () => {
+    for (const query of [
+      "collection('users').find({ active: true }).sort({ createdAt: -1 }).limit(10)",
+      "collection('orders').aggregate([{ $match: { status: 'paid' } }, { $limit: 5 }])",
+      "collection('users').countDocuments({ active: true })",
+      "db.collection('users').distinct('country', { active: true })",
+    ]) {
+      expect(validateMongoQuery(query)).toEqual({ valid: true });
+    }
+  });
+
+  it("rejects write-capable collection methods", () => {
+    for (const methodCall of [
+      "drop()",
+      "deleteMany({})",
+      "updateOne({}, { $set: { role: 'admin' } })",
+      "insertOne({ role: 'admin' })",
+      "findOneAndUpdate({}, { $set: { role: 'admin' } })",
+    ]) {
+      const result = validateMongoQuery(`collection('users').${methodCall}`);
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("is not read-only");
+    }
+  });
+
+  it("rejects server-side JavaScript operators", () => {
+    for (const query of [
+      "collection('users').find({ $where: 'sleep(1000)' })",
+      "collection('users').aggregate([{ $project: { value: { $function: { body: 'return 1', args: [], lang: 'js' } } } }])",
+      "collection('users').aggregate([{ $group: { _id: null, value: { $accumulator: { init: 'return 0', accumulate: 'return 1', accumulateArgs: [], merge: 'return 1', finalize: 'return 1', lang: 'js' } } } }])",
+    ]) {
+      const result = validateMongoQuery(query);
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("Blocked MongoDB query operator");
+    }
+  });
+
+  it("rejects aggregation stages that can write data", () => {
+    for (const query of [
+      "collection('users').aggregate([{ $out: 'copied_users' }])",
+      "collection('users').aggregate([{ $merge: { into: 'copied_users' } }])",
+    ]) {
+      const result = validateMongoQuery(query);
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain("Blocked MongoDB query operator");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent team-role privilege escalation and mass assignment
- Scope chart preview connections to their team
- Block IPv4-mapped IPv6 SSRF targets
- Require valid Slack signatures and enforce read-only MongoDB queries

## Compatibility
Self-hosted Slack integrations must configure `CB_SLACK_SIGNING_SECRET`.

## Testing
`cd server && npm run test:run` — 736 tests passed.