### PR TITLE
feat: add versioned data API

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "lint": "oxlint",
     "test:ai": "node --test src/containers/Ai/aiMessageUtils.test.js src/containers/Ai/chartPreviewState.test.js src/containers/Ai/chatScroll.test.js src/modules/workspaceAuditFormat.test.js",
     "test:visualization": "node --test src/containers/Chart/components/ChartTooltip.test.js src/containers/Chart/components/barDataLabels.test.js src/containers/Chart/components/cartesianChartPerformance.test.js src/containers/Chart/components/echartsTooltip.test.js src/modules/visualization.test.js src/visualization/echartsRenderState.test.js src/visualization/presetRegistry.test.js src/visualization/responsiveLayout.test.js",
+    "test:data-api": "node --test src/containers/ApiKeys/apiKeyPresentation.test.js",
     "preview": "vite preview",
     "tailwind": "npx tailwindcss -i ./src/input.css -o ./dist/output.css --watch",
     "prepareSettings": "echo n | cp -vipr src/config/settings.template.js src/config/settings.js | true"

--- a/client/src/containers/ApiKeys/ApiKeys.jsx
+++ b/client/src/containers/ApiKeys/ApiKeys.jsx
@@ -1,16 +1,22 @@
 import React, { useEffect, useRef, useState } from "react";
-import PropTypes from "prop-types";
 import {
-  Alert,
-  Button, EmptyState, Input, Modal, ProgressCircle, Table,
+  Alert, Checkbox,
+  Button, Chip, EmptyState, InputGroup, Label, Modal, ProgressCircle, Radio, RadioGroup, Table, TextField, Tooltip,
 } from "@heroui/react";
 import { formatRelative } from "date-fns";
-import { LuClipboard, LuClipboardCheck, LuKeyRound, LuPlus, LuTrash } from "react-icons/lu";
+import {
+  LuCheck, LuCopy, LuKeyRound, LuPlus, LuTrash, LuTriangleAlert,
+} from "react-icons/lu";
 import { useDispatch, useSelector } from "react-redux";
 
 import { getApiKeys, createApiKey, deleteApiKey, selectTeam } from "../../slices/team";
 import canAccess from "../../config/canAccess";
 import { selectUser } from "../../slices/user";
+import {
+  getPermissionLabels,
+  getProjectAccessLabel,
+  isLegacyApiKey,
+} from "./apiKeyPresentation";
 
 function ApiKeys() {
   const [apiKeys, setApiKeys] = useState([]);
@@ -21,6 +27,10 @@ function ApiKeys() {
   const [createMode, setCreateMode] = useState(false);
   const [createLoading, setCreateLoading] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [allProjects, setAllProjects] = useState(true);
+  const [selectedProjects, setSelectedProjects] = useState([]);
+  const [allowRefresh, setAllowRefresh] = useState(false);
+  const [createError, setCreateError] = useState("");
 
   const dispatch = useDispatch();
   const initRef = useRef(false);
@@ -29,8 +39,8 @@ function ApiKeys() {
   const user = useSelector(selectUser);
 
   useEffect(() => {
-    if (team?.id && !initRef.current) {
-      initRef.current = true;
+    if (team?.id && initRef.current !== team.id) {
+      initRef.current = team.id;
       _fetchApiKeys();
     }
   }, [team]);
@@ -49,24 +59,58 @@ function ApiKeys() {
       .catch(() => setLoading(false));
   };
 
+  const projects = (team?.Projects || []).filter((project) => !project.ghost);
+
   const _onCreateRequested = () => {
+    setNewKey("");
+    setAllProjects(true);
+    setSelectedProjects([]);
+    setAllowRefresh(false);
+    setCreateError("");
     setCreateMode(true);
+  };
+
+  const _onCreateModeChange = (nextOpen) => {
+    setCreateMode(nextOpen);
+    if (!nextOpen) {
+      setCreateError("");
+    }
+  };
+
+  const _onProjectChange = (projectId, selected) => {
+    setSelectedProjects((currentProjects) => {
+      if (selected) return [...new Set([...currentProjects, projectId])];
+      return currentProjects.filter((id) => id !== projectId);
+    });
   };
 
   const _onCreateKey = () => {
     setCreateLoading(true);
-    dispatch(createApiKey({ team_id: team.id, keyName: newKey }))
+    setCreateError("");
+    dispatch(createApiKey({
+      team_id: team.id,
+      key: {
+        name: newKey,
+        scopes: allowRefresh ? ["data:read", "data:refresh"] : ["data:read"],
+        allProjects,
+        projectIds: allProjects ? [] : selectedProjects,
+      },
+    })).unwrap()
       .then((createdKey) => {
         setCreateLoading(false);
         setCreateMode(false);
         setNewKey("");
+        setTokenCopied(false);
         _fetchApiKeys();
 
         setTimeout(() => {
-          setCreatedKey(createdKey.payload);
+          setCreatedKey(createdKey);
         }, 500);
       })
-      .catch(() => setCreateLoading(false));
+      .catch((error) => {
+        setCreateError(error.message || "The API key could not be created.");
+        setCreateLoading(false);
+      });
   };
 
   const _onRemoveConfirmation = (key) => {
@@ -136,7 +180,13 @@ function ApiKeys() {
               <Table.Column id="created" className="text-end">
                 Date created
               </Table.Column>
-              <Table.Column id="actions" className="w-12 text-end">
+              <Table.Column id="access">
+                Access
+              </Table.Column>
+              <Table.Column id="permissions">
+                Permissions
+              </Table.Column>
+              <Table.Column id="actions" className="text-end">
                 <span className="sr-only">Actions</span>
               </Table.Column>
             </Table.Header>
@@ -149,27 +199,67 @@ function ApiKeys() {
                 </EmptyState>
               )}
             >
-              {apiKeys.map((key) => (
-                <Table.Row key={key.id} id={String(key.id)}>
-                  <Table.Cell>
-                    {key.name}
-                  </Table.Cell>
-                  <Table.Cell className="text-end">
-                    {formatRelative(new Date(key.createdAt), new Date())}
-                  </Table.Cell>
-                  <Table.Cell className="text-end">
-                    <Button
-                      isIconOnly
-                      variant="danger-soft"
-                      onPress={() => _onRemoveConfirmation(key)}
-                      size="sm"
-                      aria-label={`Delete API key ${key.name}`}
-                    >
-                      <LuTrash />
-                    </Button>
-                  </Table.Cell>
-                </Table.Row>
-              ))}
+              {apiKeys.map((key) => {
+                const isLegacy = isLegacyApiKey(key);
+                const permissionLabels = getPermissionLabels(key);
+
+                return (
+                  <Table.Row key={key.id} id={String(key.id)}>
+                    <Table.Cell>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span>{key.name}</span>
+                        {isLegacy && (
+                          <Tooltip delay={0}>
+                            <Tooltip.Trigger>
+                              <Chip color="warning" size="sm" variant="soft">
+                                <LuTriangleAlert size={14} aria-hidden />
+                                Legacy key
+                              </Chip>
+                            </Tooltip.Trigger>
+                            <Tooltip.Content>
+                              This key still works with existing integrations. Create a new key to use the Data API.
+                            </Tooltip.Content>
+                          </Tooltip>
+                        )}
+                      </div>
+                    </Table.Cell>
+                    <Table.Cell className="text-end">
+                      {formatRelative(new Date(key.createdAt), new Date())}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Chip size="sm" variant="secondary">
+                        {getProjectAccessLabel(key, projects)}
+                      </Chip>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <div className="flex flex-wrap gap-1">
+                        {permissionLabels.length > 0 ? permissionLabels.map((label) => (
+                          <Chip key={label} size="sm" variant="secondary">
+                            {label}
+                          </Chip>
+                        )) : (
+                          <Chip size="sm" variant="secondary">
+                            Not available
+                          </Chip>
+                        )}
+                      </div>
+                    </Table.Cell>
+                    <Table.Cell className="text-end">
+                      <div className="flex items-center justify-end">
+                        <Button
+                          isIconOnly
+                          variant="danger-soft"
+                          onPress={() => _onRemoveConfirmation(key)}
+                          size="sm"
+                          aria-label={`Delete API key ${key.name}`}
+                        >
+                          <LuTrash />
+                        </Button>
+                      </div>
+                    </Table.Cell>
+                  </Table.Row>
+                );
+              })}
             </Table.Body>
           </Table.Content>
         </Table.ScrollContainer>
@@ -179,32 +269,31 @@ function ApiKeys() {
         <Modal.Backdrop isOpen={!!createdKey.id} onOpenChange={(nextOpen) => { if (!nextOpen) setCreatedKey({}); }}>
           <Modal.Container>
             <Modal.Dialog className="sm:max-w-xl">
-              <Modal.Header>
-                <Modal.Heading className="text-lg font-semibold font-tw">
-                  Your new API Key
-                </Modal.Heading>
+              <Modal.CloseTrigger />
+              <Modal.Header className="flex flex-col items-start gap-1 pr-12">
+                <Modal.Heading>Your new API Key</Modal.Heading>
+                <p className="text-sm font-normal text-foreground-500">
+                  Copy it now. This is the only time Chartbrew shows the key.
+                </p>
               </Modal.Header>
-              <Modal.Body className="p-6">
-                <div className="text-success">{"Congrats! your new API key has been created."}</div>
-                <div className="text-gray-500">{"This is the only time we show you the code, so please copy it before closing this window."}</div>
-                <div className="h-1" />
-                <div>
-                  <Input
-                    label="Your new API Key"
-                    value={createdKey.token}
-                    variant="secondary"
-                    fullWidth
-                  />
-                </div>
-                <div>
-                  <Button
-                    onPress={_onCopyToken}
-                    variant={tokenCopied ? "secondary" : "primary"}
-                  >
-                    {tokenCopied ? <LuClipboardCheck /> : <LuClipboard />}
-                    {tokenCopied ? "Copied!" : "Copy to clipboard"}
-                  </Button>
-                </div>
+              <Modal.Body className="flex flex-col gap-5">
+                <TextField className="w-full" name="created-api-key">
+                  <Label>API key</Label>
+                  <InputGroup variant="secondary" fullWidth>
+                    <InputGroup.Input readOnly value={createdKey.token || ""} />
+                    <InputGroup.Suffix className="pr-0">
+                      <Button
+                        aria-label={tokenCopied ? "API key copied" : "Copy API key"}
+                        isIconOnly
+                        onPress={_onCopyToken}
+                        size="sm"
+                        variant={tokenCopied ? "primary" : "tertiary"}
+                      >
+                        {tokenCopied ? <LuCheck /> : <LuCopy />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
+                </TextField>
               </Modal.Body>
               <Modal.Footer>
                 <Button slot="close" variant="secondary">
@@ -217,36 +306,108 @@ function ApiKeys() {
       </Modal>
 
       <Modal>
-        <Modal.Backdrop isOpen={createMode} onOpenChange={(nextOpen) => { if (!nextOpen) setCreateMode(false); }}>
+        <Modal.Backdrop isOpen={createMode} onOpenChange={_onCreateModeChange}>
           <Modal.Container>
             <Modal.Dialog className="sm:max-w-xl">
-              <Modal.Header>
-                <Modal.Heading className="text-lg font-semibold font-tw">
-                  Create a new API Key
-                </Modal.Heading>
+              <Modal.CloseTrigger />
+              <Modal.Header className="flex flex-col items-start gap-1 pr-12">
+                <Modal.Heading>Create a new API Key</Modal.Heading>
               </Modal.Header>
-              <Modal.Body className="p-2">
-                <div className="text-gray-500">{"The API key will give the same access to your team as your current account. Please make sure you do not misplace the key."}</div>
-                <div className="h-1" />
-                <div>
-                  <Input
-                    label="Enter a name to remember it later"
-                    value={newKey}
-                    onChange={(e) => setNewKey(e.target.value)}
-                    placeholder="Enter a name here"
+              <Modal.Body className="flex flex-col gap-5">
+                {createError && (
+                  <Alert status="danger">
+                    <Alert.Indicator />
+                    <Alert.Content>
+                      <Alert.Title>{createError}</Alert.Title>
+                    </Alert.Content>
+                  </Alert>
+                )}
+                <TextField className="w-full" name="api-key-name">
+                  <Label>Key name</Label>
+                  <InputGroup variant="secondary" fullWidth>
+                    <InputGroup.Input
+                      autoFocus
+                      onChange={(e) => setNewKey(e.target.value)}
+                      placeholder="Enter a descriptive name for your key"
+                      value={newKey}
+                    />
+                  </InputGroup>
+                </TextField>
+                <RadioGroup
+                  name="api-key-project-access"
+                  onChange={(value) => {
+                    const nextAll = value === "all";
+                    setAllProjects(nextAll);
+                    if (nextAll) setSelectedProjects([]);
+                  }}
+                  value={allProjects ? "all" : "selected"}
+                >
+                  <Label>Project access</Label>
+                  <Radio value="all">
+                    <Radio.Content>
+                      <Radio.Control>
+                        <Radio.Indicator />
+                      </Radio.Control>
+                      All projects in this team
+                    </Radio.Content>
+                  </Radio>
+                  <Radio value="selected">
+                    <Radio.Content>
+                      <Radio.Control>
+                        <Radio.Indicator />
+                      </Radio.Control>
+                      Selected projects
+                    </Radio.Content>
+                  </Radio>
+                </RadioGroup>
+                {!allProjects && (
+                  <div className="flex flex-row flex-wrap items-center gap-2">
+                    {projects.map((project) => (
+                      <Chip
+                        className="cursor-pointer rounded-sm"
+                        key={project.id}
+                        onClick={() => _onProjectChange(project.id, !selectedProjects.includes(project.id))}
+                        variant={selectedProjects.includes(project.id) ? "primary" : "soft"}
+                        color={selectedProjects.includes(project.id) ? "accent" : "default"}
+                      >
+                        {project.name}
+                      </Chip>
+                    ))}
+                  </div>
+                )}
+                <div className="flex flex-col gap-3">
+                  <Label>Permissions</Label>
+                  <Checkbox id="api-key-read-data" isDisabled isSelected variant="secondary">
+                    <Checkbox.Content>
+                      <Checkbox.Control className="size-4 shrink-0">
+                        <Checkbox.Indicator />
+                      </Checkbox.Control>
+                      Read chart and dataset data
+                    </Checkbox.Content>
+                  </Checkbox>
+                  <Checkbox
+                    id="api-key-refresh-data"
+                    isSelected={allowRefresh}
+                    onChange={setAllowRefresh}
                     variant="secondary"
-                    fullWidth
-                  />
+                  >
+                    <Checkbox.Content>
+                      <Checkbox.Control className="size-4 shrink-0">
+                        <Checkbox.Indicator />
+                      </Checkbox.Control>
+                      Refresh data from sources
+                    </Checkbox.Content>
+                  </Checkbox>
                 </div>
               </Modal.Body>
               <Modal.Footer>
                 <Button slot="close" variant="secondary">
-                  Close
+                  Cancel
                 </Button>
                 <Button
-                  onPress={_onCreateKey}
-                  isDisabled={!newKey}
+                  isDisabled={!newKey.trim() || (!allProjects && selectedProjects.length === 0)}
                   isPending={createLoading}
+                  onPress={_onCreateKey}
                   variant="primary"
                 >
                   Create the key
@@ -258,25 +419,26 @@ function ApiKeys() {
       </Modal>
 
       <Modal>
-        <Modal.Backdrop variant="blur" isOpen={!!confirmDelete} onOpenChange={(nextOpen) => { if (!nextOpen) setConfirmDelete(false); }}>
+        <Modal.Backdrop isOpen={!!confirmDelete} onOpenChange={(nextOpen) => { if (!nextOpen) setConfirmDelete(false); }} variant="blur">
           <Modal.Container>
             <Modal.Dialog>
-              <Modal.Header>
-                <Modal.Heading className="text-lg font-semibold font-tw">
+              <Modal.CloseTrigger />
+              <Modal.Header className="pr-12">
+                <Modal.Heading>
                   Are you sure you want to delete the key?
                 </Modal.Heading>
               </Modal.Header>
               <Modal.Body>
-                <div className="text-gray-500">{"This key will lose access to Chartbrew. This action cannot be undone."}</div>
+                <p className="text-foreground-500">This key will lose access to Chartbrew. This action cannot be undone.</p>
               </Modal.Body>
               <Modal.Footer>
                 <Button slot="close" variant="secondary">
-                  Go back
+                  Cancel
                 </Button>
                 <Button
-                  variant="danger"
-                  onPress={_onRemoveKey}
                   isPending={createLoading}
+                  onPress={_onRemoveKey}
+                  variant="danger"
                 >
                   Remove key permanently
                 </Button>
@@ -288,9 +450,5 @@ function ApiKeys() {
     </div>
   );
 }
-
-ApiKeys.propTypes = {
-  teamId: PropTypes.number.isRequired,
-};
 
 export default ApiKeys;

--- a/client/src/containers/ApiKeys/apiKeyPresentation.js
+++ b/client/src/containers/ApiKeys/apiKeyPresentation.js
@@ -1,0 +1,21 @@
+export function isLegacyApiKey(apiKey) {
+  return apiKey.dataApiAccess === "unavailable";
+}
+
+export function getPermissionLabels(apiKey) {
+  if (isLegacyApiKey(apiKey)) return [];
+
+  const permissions = ["Read data"];
+  if (apiKey.permissions?.includes("data:refresh")) permissions.push("Refresh data");
+  return permissions;
+}
+
+export function getProjectAccessLabel(apiKey, projects = []) {
+  if (!apiKey.projectAccess) return "Existing integrations only";
+  if (apiKey.projectAccess.allProjects) return "All projects in this team";
+
+  const selectedIds = new Set(apiKey.projectAccess.projectIds || []);
+  const selectedProjects = projects.filter((project) => selectedIds.has(project.id));
+  if (selectedProjects.length === 1) return selectedProjects[0].name;
+  return `${selectedProjects.length} projects`;
+}

--- a/client/src/containers/ApiKeys/apiKeyPresentation.test.js
+++ b/client/src/containers/ApiKeys/apiKeyPresentation.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getPermissionLabels,
+  getProjectAccessLabel,
+  isLegacyApiKey,
+} from "./apiKeyPresentation.js";
+
+test("marks old API keys as unavailable for the Data API", () => {
+  const key = { dataApiAccess: "unavailable" };
+
+  assert.equal(isLegacyApiKey(key), true);
+  assert.deepEqual(getPermissionLabels(key), []);
+  assert.equal(getProjectAccessLabel(key), "Existing integrations only");
+});
+
+test("shows scoped key permissions and selected projects", () => {
+  const key = {
+    dataApiAccess: "ready",
+    permissions: ["data:read", "data:refresh"],
+    projectAccess: { allProjects: false, projectIds: [2, 3] },
+  };
+
+  assert.deepEqual(getPermissionLabels(key), ["Read data", "Refresh data"]);
+  assert.equal(getProjectAccessLabel(key, [
+    { id: 1, name: "One" },
+    { id: 2, name: "Two" },
+    { id: 3, name: "Three" },
+  ]), "2 projects");
+});
+
+test("states that an all-project key is limited to its team", () => {
+  assert.equal(getProjectAccessLabel({
+    dataApiAccess: "ready",
+    projectAccess: { allProjects: true, projectIds: [] },
+  }), "All projects in this team");
+});

--- a/client/src/slices/team.js
+++ b/client/src/slices/team.js
@@ -279,17 +279,21 @@ export const getApiKeys = createAsyncThunk(
 
 export const createApiKey = createAsyncThunk(
   "team/createApiKey",
-  async ({ team_id, keyName }) => {
+  async ({ team_id, key }) => {
     const token = getAuthToken();
     const headers = new Headers({
       "Accept": "application/json",
       "content-type": "application/json",
       "authorization": `Bearer ${token}`,
     });
-    const body = JSON.stringify({ name: keyName });
+    const body = JSON.stringify(key);
 
-    const response = await fetch(`${API_HOST}/team/${team_id}/apikey`, { method: "POST", body, headers })
+    const response = await fetch(`${API_HOST}/team/${team_id}/apikey`, { method: "POST", body, headers });
     const responseJson = await response.json();
+
+    if (!response.ok) {
+      throw new Error(responseJson.error || "The API key could not be created.");
+    }
 
     return responseJson;
   }

--- a/docs/specs/FS-20260819-echarts-rendering-data-api.md
+++ b/docs/specs/FS-20260819-echarts-rendering-data-api.md
@@ -4,6 +4,8 @@ Status: accepted
 
 Related: [Next-Generation Visualization Engine](FS-20260719-next-generation-visualization-engine.md)
 
+Detailed delivery: [Versioned Data API](FS-20260825-versioned-data-api.md)
+
 > Visualization must be a core Chartbrew power. It must not limit v6.
 
 ## Summary
@@ -309,6 +311,10 @@ or internal cache state.
   preset-aware builder control rules.
 
 ### Phase 5: Release The Data API
+
+The detailed Data API contract and delivery plan are defined in
+[Versioned Data API](FS-20260825-versioned-data-api.md). This phase is a separate feature delivery
+that depends on `PreparedData`; it does not depend on ECharts compilation.
 
 - Add scoped API-key validation and the four dataset/chart routes.
 - Reuse the exact runtime filter, variable, timezone, access, and prepared-cache paths used by charts.

--- a/docs/specs/FS-20260825-versioned-data-api.md
+++ b/docs/specs/FS-20260825-versioned-data-api.md
@@ -1,0 +1,1138 @@
+# Versioned Data API
+
+Status: implemented
+
+Related:
+
+- [ECharts Rendering And Data API](FS-20260819-echarts-rendering-data-api.md)
+- [Next-Generation Visualization Engine](FS-20260719-next-generation-visualization-engine.md)
+
+> The Data API exposes Chartbrew data contracts. It does not expose a renderer contract.
+
+## Summary
+
+Add a read-only, versioned Data API for reusable dataset results and prepared chart data. The API
+uses the existing dataset execution, runtime filter, variable, timezone, prepared-cache, and
+prepared-snapshot paths. It must not create a second data pipeline.
+
+The API has four JSON endpoints:
+
+```text
+GET  /api/v1/teams/:team_id/datasets/:dataset_id/data
+POST /api/v1/teams/:team_id/datasets/:dataset_id/data
+GET  /api/v1/projects/:project_id/charts/:chart_id/data
+POST /api/v1/projects/:project_id/charts/:chart_id/data
+```
+
+The chart endpoints return the existing public `PreparedData` v1 contract. The dataset endpoints
+return a new `DatasetData` v1 contract. Responses contain no Chart.js configuration, ECharts
+option, source query, connection data, credential, or internal cache key.
+
+The Data API is a separate feature from ECharts rendering and image sharing. It depends on the
+renderer-neutral `PreparedData` boundary that the rendering work created. It does not depend on
+ECharts and it does not compile renderer output.
+
+## Goals
+
+- Add stable, versioned dataset and chart data contracts.
+- Use bearer API keys that are bound to an `Apikey` database record, team, user, scopes, and
+  project access.
+- Apply current team roles and project assignments at request time.
+- Reuse the same variables, filters, timezone, source cache, prepared cache, and durable prepared
+  snapshot paths as Chartbrew charts.
+- Return chart rows that are byte-equivalent to the public serialization of the internal
+  `PreparedData`, except for documented generation metadata.
+- Return dataset results after source execution, joins, and dataset-owned transformations, but
+  before chart encoding, aggregation, or presentation.
+- Add deterministic serialization, `ETag`, freshness headers, stable error codes, request audit
+  records, rate limits, execution limits, and response-size limits.
+- Document authentication, request formats, response formats, errors, limits, and caching.
+- Publish JavaScript examples for ECharts and Chart.js to show that the API is renderer-neutral.
+
+## Non-Goals
+
+- Public or anonymous data links.
+- Authentication with chart shares, dashboard shares, report tokens, or cookies.
+- Write, create, update, or delete operations for charts, datasets, or source records.
+- A general SQL, source-query, or connection API.
+- Pagination, sorting, projection, GraphQL, CSV, Arrow, or streaming responses in v1.
+- Renderer options, renderer selection, image generation, or screenshot sharing.
+- A new dataset execution engine, filter grammar, variable grammar, or cache service.
+- A replacement for all existing Chartbrew API authentication in this phase.
+- A change to which user roles can manage API keys.
+
+## Current Repository Baseline
+
+The implementation must use these existing components:
+
+| Component | Current responsibility | Data API use |
+| --- | --- | --- |
+| `server/visualization/VisualizationEngine.js` | Builds `VizFrame`, prepares data, and compiles renderers | Call `prepare()`, never the compiler |
+| `server/visualization/preparedData.js` | Creates, validates, normalizes, fingerprints, and serializes `PreparedData` | Use its public serializer without a second chart serializer |
+| `server/controllers/ChartController.js` | Runs datasets, applies runtime context, reads and writes prepared caches and snapshots | Add a prepared-only result mode |
+| `server/controllers/DatasetController.js` | Runs DataRequests, joins results, applies dataset transformations, detects fields, and uses source caches | Use as the dataset execution path |
+| `server/modules/chartRuntimeFilters.js` | Normalizes variables and filters and builds stable variant hashes | Use for Data API runtime requests |
+| `server/modules/runtimeCache.js` | Stores default source results and runtime prepared/source variants | Reuse current keys and fingerprints |
+| `server/modules/preparedSnapshot.js` | Loads and persists the default chart snapshot | Use for default chart reads |
+| `server/modules/updateAudit.js` | Records bounded request and execution audit data | Add a Data API trigger and API-key identity |
+| `server/modules/verifyToken.js` | Accepts user session JWTs | Do not use as the Data API trust boundary |
+| `server/models/models/apikey.js` | Stores an encrypted long-lived user JWT and a team ID | Extend with database-bound Data API identity and scope |
+
+Current `Apikey` records do not store the creating user, scopes, project restrictions, or last-use
+time. The token contains a user ID, but `verifyToken` does not prove that the token belongs to an
+active `Apikey` row or to the team in the route. An old team API key is therefore not sufficient
+for the Data API.
+
+## Design Principles
+
+1. Authorization happens before resource execution or snapshot loading.
+2. A key is a bearer credential. Possession of the key grants the authority stored on its active
+   database record.
+3. The database record is the source of truth for scopes and project restrictions. Token claims do
+   not grant authority by themselves.
+4. The current role and project assignment of the key owner can only reduce key access.
+5. A route parameter never grants scope. Team, project, chart, and dataset relationships must be
+   checked in database queries.
+6. Default chart data comes from `Chart.preparedData` when it is valid. Runtime chart data comes
+   from the prepared cache or the canonical preparation path.
+7. Data API code stops at preparation. It does not compile or remove renderer output after the
+   compiler runs.
+8. Public serializers use explicit allowlists. They do not copy model objects into responses.
+9. Response freshness is user information. Internal cache names, keys, variants, and fingerprints
+   are not user information.
+10. A limit failure returns an error. It never returns truncated data.
+
+## API-Key Contract
+
+### Database Changes
+
+Add these nullable or default-safe fields to `Apikey` in a new migration:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `user_id` | integer, nullable | Binds new keys to the user who created them. Legacy records remain null. |
+| `scopes` | long text JSON, non-null, default `[]` | Stores canonical Data API permissions. |
+| `project_ids` | long text JSON, nullable | Stores the projects that the key can access when `all_projects` is false. |
+| `all_projects` | boolean, non-null, default false | Gives the key access to all projects that its current owner role can access. |
+| `last_used_at` | date, nullable | Supports key management and security review. |
+
+Do not edit the original API-key migration. Do not add Data API authority to existing records in a
+backfill. Their signed tokens do not contain a database key identity.
+
+New manually created keys use the existing signed token format so that existing authenticated API
+routes continue to accept them. Add these signed claims:
+
+```json
+{
+  "id": 17,
+  "apiKeyId": "5e951c4f-0c79-4f70-b8fb-5993ea20bc12",
+  "teamId": 4,
+  "tokenType": "api_key"
+}
+```
+
+Generate the API-key UUID before token signing. Store the token with the current encrypted `token`
+field. Store scopes and project access only in the database. Do not trust scope or project claims
+from the token.
+
+The create response shows the token once. List responses never include the token. Deletion keeps
+the current blacklist behavior and removes the database record, which makes Data API revocation
+immediate.
+
+### Scopes
+
+The first release defines two scopes:
+
+| Scope | Authority |
+| --- | --- |
+| `data:read` | Read default data and run cache-aware requests with parse-only field filters. |
+| `data:refresh` | Bypass caches or run a request whose variables or date filters require a source refresh. Requires `data:read`. |
+
+All four routes require `data:read`.
+
+The following requests also require `data:refresh`:
+
+- `refresh: true`
+- A non-empty `variables` object
+- A chart date-range filter
+- A filter with `forceSourceRefresh: true`
+
+A normal cache miss on a default `GET` can use the canonical cache-aware source path with
+`data:read`. It does not bypass a valid source cache. The `data:refresh` scope controls explicit or
+runtime-forced cache bypasses.
+
+Unknown scopes are rejected when a key is created or updated. The server checks stored scopes on
+every request. A scope removed from the database stops access without token rotation.
+
+### Key Creation And Management
+
+The current role rules remain:
+
+| Role | Create, list, and revoke API keys | Use data made available by a scoped key |
+| --- | --- | --- |
+| `teamOwner` | Yes | All team projects, limited by the key project scope |
+| `teamAdmin` | Yes | All team projects, limited by the key project scope |
+| `projectAdmin` | No | Only projects in the current team-role project list and the key scope |
+| `projectEditor` | No | Only projects in the current team-role project list and the key scope |
+| `projectViewer` | No | Only projects in the current team-role project list and the key scope |
+| No current team role | No | No access; the key is rejected |
+
+The last column describes the effective authority if a key owner is later moved to a more limited
+role. It also describes the authority of the bearer credential. A bearer cannot gain more access
+than the stored key and current owner permit.
+
+The key creation interface must require an explicit project choice:
+
+- All projects in this team, or
+- One or more selected projects.
+
+An API key is always bound to the team where the user creates it. An all-project key does not grant
+access to projects in another team.
+
+It must also show two concise permissions:
+
+- Read chart and dataset data
+- Refresh data from sources
+
+`data:read` is required. `data:refresh` is optional. The interface must not show token claims,
+database fields, contract versions, or implementation terms.
+
+Requests to the existing key-creation endpoint that contain only `name` continue to create a
+legacy key with no Data API scopes. This avoids a silent expansion of existing automation access.
+
+The key list response must identify whether each key can use the Data API. Derive this state from
+the stored database identity and scopes. Do not decrypt and inspect tokens while listing keys. A
+safe list item can contain:
+
+```json
+{
+  "id": "5e951c4f-0c79-4f70-b8fb-5993ea20bc12",
+  "name": "Warehouse export",
+  "createdAt": "2026-05-01T08:00:00.000Z",
+  "lastUsedAt": null,
+  "dataApiAccess": "unavailable",
+  "permissions": [],
+  "projectAccess": null
+}
+```
+
+`dataApiAccess` has two v1 values: `ready` and `unavailable`. This is a key-management
+contract. It is not returned by the Data API routes.
+
+### Data API Authentication Middleware
+
+Add `server/modules/verifyDataApiKey.js`. It performs these checks in order:
+
+1. Read one `Authorization: Bearer <token>` header. Reject missing, empty, repeated, or malformed
+   authorization values.
+2. Verify the signature with the current session-token verifier.
+3. Require `tokenType: "api_key"`, `apiKeyId`, `teamId`, and a user `id`.
+4. Load the `Apikey` record by `apiKeyId` with an explicit attribute allowlist.
+5. Compare a SHA-256 digest of the supplied token with a SHA-256 digest of the decrypted stored
+   token by using `crypto.timingSafeEqual()`.
+6. Require exact matches for token user ID, token team ID, record user ID, and record team ID.
+7. Require the requested stored scope.
+8. Load the current user and `TeamRole`. Reject deleted users, removed team members, and disabled or
+   missing roles.
+9. Calculate effective projects from the current role and stored key project scope.
+10. Attach a minimal `req.apiKeyAccess` object. Do not attach the token or raw database record.
+11. Update `last_used_at` after successful authorization. Throttle this write to at most once per
+    key per five minutes so that data reads do not cause one database write each.
+
+`req.apiKeyAccess` contains only:
+
+```json
+{
+  "apiKeyId": "5e951c4f-0c79-4f70-b8fb-5993ea20bc12",
+  "teamId": 4,
+  "userId": 17,
+  "role": "projectViewer",
+  "allProjects": false,
+  "projectIds": [8, 12],
+  "scopes": ["data:read"]
+}
+```
+
+Do not call `verifyToken` before or instead of this middleware. Session JWTs, Slack-created legacy
+keys, old manually created keys, public share tokens, report tokens, and chart share tokens do not
+contain a valid database API-key identity and must return `401`.
+
+### Project Access Calculation
+
+Use `TeamController.getTeamRole()` as the role source. `TeamRole.projects` is the current list for
+project-scoped roles.
+
+Calculate access as follows:
+
+```text
+owner/admin role projects = all projects in Apikey.team_id
+project role projects     = TeamRole.projects
+
+if key.all_projects:
+  effective projects = role projects
+else:
+  effective projects = intersection(role projects, key.project_ids)
+```
+
+An empty effective project list denies project, chart, and project-bound dataset access.
+
+For a chart request, query the chart and project with all these conditions:
+
+- `Chart.id = :chart_id`
+- `Chart.project_id = :project_id`
+- `Project.id = :project_id`
+- `Project.team_id = Apikey.team_id`
+- `Project.id` is in the effective project list
+
+For a dataset request, require:
+
+- `Dataset.id = :dataset_id`
+- `Dataset.team_id = :team_id`
+- Route `team_id = Apikey.team_id`
+- At least one `Dataset.project_ids` value is in the effective project list
+
+A team owner or team admin with an all-project key can read a team dataset whose `project_ids` is
+empty. A project-scoped role or a restricted key cannot read such a dataset.
+
+Return `404 RESOURCE_NOT_FOUND` for a missing resource, a mismatched parent ID, a cross-team ID, or
+a resource outside the effective project list. This prevents resource enumeration. Return `403`
+only when the key is valid for the resource scope but lacks the required API permission.
+
+## Route Contract
+
+### Common Rules
+
+- The first release supports `application/json` only.
+- IDs must be positive base-10 integers. Values such as `1e2`, `1.5`, `-1`, and `01abc` are invalid.
+- `GET` does not accept runtime values in query parameters.
+- `POST` accepts one JSON object. Unknown top-level fields return `400`.
+- A response uses the same data contract for `GET` and `POST` on the same resource type.
+- A successful response does not include an outer `data` wrapper.
+- `GET` is cache-aware. It does not force a refresh.
+- `POST` is used for runtime variables, runtime filters, or an explicit refresh.
+- Runtime requests never persist a filtered or variable-specific chart snapshot.
+- A default `POST` with `refresh: true` can replace the durable default chart snapshot after a
+  successful canonical preparation.
+
+### POST Request Body
+
+```json
+{
+  "variables": {
+    "region": "APAC"
+  },
+  "filters": [{
+    "type": "field",
+    "field": "root[].status",
+    "operator": "is",
+    "value": "paid"
+  }],
+  "refresh": false,
+  "timezone": "Asia/Bangkok"
+}
+```
+
+All properties are optional. Defaults are:
+
+```json
+{
+  "variables": {},
+  "filters": [],
+  "refresh": false
+}
+```
+
+`timezone` is accepted only by the dataset endpoint. It must be a valid IANA timezone. It defaults
+to `UTC`. A chart always uses its project timezone, so a chart request with `timezone` returns
+`400 INVALID_REQUEST`.
+
+### Variables
+
+Variables use the current object contract and the current `applySourceVariables()` path.
+
+- Keys must be non-empty strings.
+- Values can be JSON scalars or bounded JSON arrays and objects.
+- Empty string, `null`, and missing values have the current fallback behavior.
+- Runtime values override saved VariableBinding defaults.
+- The original DataRequest must not be mutated.
+- A variable request requires `data:refresh` because variables can change a source query or API
+  request.
+
+Do not return substituted queries, request bodies, headers, routes, or variable values in audit
+records or errors.
+
+### Chart Filters
+
+Chart requests use `buildChartRuntimeContext()` without a new filter grammar. They support current
+server-meaningful field and date filters, including CDC-scoped filters.
+
+Allowed field operators are:
+
+```text
+is
+isNot
+contains
+notContains
+greaterThan
+greaterOrEqual
+lessThan
+lessOrEqual
+isNull
+isNotNull
+```
+
+Date-range filters use the current shape:
+
+```json
+{
+  "type": "date",
+  "startDate": "2026-08-01",
+  "endDate": "2026-08-31",
+  "scope": "chart"
+}
+```
+
+The server intersects this range with the configured chart date range in the project timezone.
+CDC-scoped field filters must contain a valid `cdcId` that belongs to the requested chart. A filter
+cannot name a CDC from another chart.
+
+Reject client-only filter types such as pagination, local sorting, display state, and column-toggle
+state. The Data API must not silently ignore a supplied filter.
+
+### Dataset Filters
+
+Dataset responses are not chart bindings. They do not have a canonical CDC or chart date field.
+The dataset endpoint therefore accepts only chart-wide field filters with an explicit field path.
+The field path must start with `root` and identify exactly one array collection.
+
+Use field comparisons for dates:
+
+```json
+{
+  "type": "field",
+  "field": "root[].createdAt",
+  "operator": "greaterOrEqual",
+  "value": "2026-08-01T00:00:00.000Z"
+}
+```
+
+Dataset requests reject:
+
+- `type: "date"`
+- `scope: "cdc"`
+- `cdcId`
+- Client-only filter types
+- Fields that do not exist in `Dataset.fieldsSchema` when a schema is available
+
+Apply runtime field filters after joins and dataset-owned transformations. Pass source-affecting
+filters through the existing connector path where it already supports them. Do not apply legacy
+dataset visualization conditions, chart encodings, CDC conditions, chart aggregation, formulas,
+goals, sorting, or record presentation limits.
+
+## Chart Response: PreparedData v1
+
+The chart response is the result of `toPublicPreparedData()`. Do not add a Data API-specific chart
+serializer.
+
+Example:
+
+```json
+{
+  "version": 1,
+  "frameVersion": 1,
+  "identityVersion": 1,
+  "generatedAt": "2026-08-25T08:00:00.000Z",
+  "resource": {
+    "kind": "chart",
+    "id": 42
+  },
+  "results": [{
+    "id": "revenue",
+    "mark": "line",
+    "name": "Revenue",
+    "fields": [
+      {
+        "key": "time",
+        "type": "temporal",
+        "role": "dimension",
+        "sourceField": "root[].createdAt"
+      },
+      {
+        "key": "value",
+        "type": "quantitative",
+        "role": "measure",
+        "sourceField": "root[].revenue"
+      }
+    ],
+    "series": [{
+      "id": "series-ec3bc4d7d9f66b02",
+      "label": "Pro"
+    }],
+    "availableSeries": [{
+      "id": "series-ec3bc4d7d9f66b02",
+      "label": "Pro"
+    }],
+    "rows": [{
+      "time": "2026-08-01T00:00:00.000Z",
+      "value": 21400,
+      "seriesId": "series-ec3bc4d7d9f66b02"
+    }],
+    "stats": {},
+    "warnings": []
+  }],
+  "stats": {},
+  "warnings": []
+}
+```
+
+Public serialization rules remain:
+
+- JSON values only.
+- Dates use ISO 8601.
+- Non-finite numbers become `null`.
+- Meaningful `null` values stay `null`.
+- Result, field, series, row, object-key, and warning order is deterministic.
+- Stable layer and series IDs use the current identity contract.
+- `generatedAt` is excluded from the content fingerprint and `ETag`.
+- Internal `bindingId`, `__seriesId`, source options, cache values, and renderer data are removed.
+
+The response must not contain these keys at any depth unless they occur as user source column names
+inside a dataset response:
+
+```text
+chartData
+configuration
+render
+renderer
+bindingId
+sourceOptions
+__seriesId
+query
+headers
+token
+password
+cacheKey
+variantHash
+```
+
+## Dataset Response: DatasetData v1
+
+Create `server/modules/datasetData.js` as the contract owner.
+
+Example:
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-08-25T08:00:00.000Z",
+  "resource": {
+    "kind": "dataset",
+    "id": 18,
+    "name": "Orders"
+  },
+  "fields": [
+    {
+      "key": "root[].amount",
+      "type": "number"
+    },
+    {
+      "key": "root[].createdAt",
+      "type": "date"
+    },
+    {
+      "key": "root[].customer.name",
+      "type": "string"
+    }
+  ],
+  "data": [{
+    "amount": 120,
+    "createdAt": "2026-08-20T04:00:00.000Z",
+    "customer": {
+      "name": "Ada"
+    }
+  }]
+}
+```
+
+`data` preserves the joined dataset shape. It can be an array, object, scalar, or `null`. Do not
+force nested or scalar results into a row array.
+
+Build `fields` from the stored `Dataset.fieldsSchema` after a successful default execution. Sort it
+by field key. If no stored schema exists, detect fields from the returned result with
+`discoverDatasetFieldsSchema()`. Supported field types are:
+
+```text
+number
+date
+string
+boolean
+array
+object
+unknown
+```
+
+The public DatasetData serializer must:
+
+- Reuse the JSON normalization rules from `preparedData.toJsonValue()`.
+- Sort object keys without changing array order.
+- Keep `null` values.
+- Convert Date objects to ISO 8601 strings.
+- Convert non-finite numbers to `null`.
+- Remove `undefined`, functions, symbols, and Sequelize metadata.
+- Exclude `generatedAt` from the fingerprint.
+
+DatasetData does not include DataRequest IDs, connection IDs, project IDs, joins, transformations,
+saved variables, source cache metadata, or dataset compatibility visualization fields.
+
+## Execution Semantics
+
+### Default Chart GET
+
+1. Authorize the key and chart-project relationship.
+2. Load the explicit prepared snapshot through `loadPreparedSnapshot()`.
+3. Build the current visualization and source fingerprints.
+4. If the visualization fingerprint matches, return the snapshot.
+5. If only the source fingerprint is stale, return the last-known snapshot and start the existing
+   single-flight background refresh.
+6. If the visualization fingerprint does not match, prepare current data synchronously. Do not
+   compile a renderer.
+7. If no valid snapshot exists, run the canonical default preparation with cache-aware source reads.
+8. If the source fails and no valid snapshot exists, return `503 DATA_UNAVAILABLE`.
+
+### Runtime Chart POST
+
+1. Validate the body and required scopes.
+2. Build the current chart runtime context.
+3. Use the current chart version, runtime variant hash, and a dedicated `data-api` viewer scope.
+4. Return a fresh or stale prepared-cache payload when allowed.
+5. On a miss, run the same datasets, variables, filters, joins, and `VisualizationEngine.prepare()`
+   path used by the chart.
+6. Write cacheable runtime `PreparedData` through `setPreparedCache()`.
+7. Never persist a runtime variant to `Chart.preparedData`.
+8. Never call `compilePreparedRender()`, `renderPrepared()`, or a Chart.js or ECharts compiler.
+
+The `ChartController.updateChartData()` pipeline currently returns compiled chart responses and its
+`returnPreparedData` option does not cover every runtime-cache short circuit. Add a prepared-only
+result mode or extract a shared prepared-data service. All cache-hit, cache-miss, snapshot, refresh,
+and error paths must return the same internal result shape:
+
+```json
+{
+  "preparedData": {},
+  "fingerprint": "sha256",
+  "generatedAt": "2026-08-25T08:00:00.000Z",
+  "stale": false
+}
+```
+
+This internal result is not the HTTP response.
+
+### Dataset GET And POST
+
+Use `DatasetController.runRequest()` with the authorized `team_id`, effective timezone, variables,
+runtime context, and source-cache settings.
+
+- `GET` and `POST refresh:false` use DataRequest and source caches when valid.
+- On a default cache miss, the request can execute the source.
+- `POST refresh:true` bypasses cache reads and requires `data:refresh`.
+- Joins and the main DataRequest transformation run before serialization.
+- Runtime field filters run after joins and transformations.
+- A runtime response does not update `Dataset.fieldsSchema` or dataset intelligence.
+- A successful unfiltered default response can use the current schema-discovery update behavior.
+- Dataset execution must be team-scoped in the database call, not only in route middleware.
+
+## HTTP Caching And Freshness
+
+Default `GET` responses support conditional requests.
+
+Response headers:
+
+```text
+Content-Type: application/json; charset=utf-8
+Cache-Control: private, no-cache
+Vary: Authorization
+ETag: "pd-v1-<sha256>" or "dd-v1-<sha256>"
+Last-Modified: <HTTP date>
+X-Chartbrew-Data-Stale: true|false
+```
+
+Use `getPreparedDataFingerprint()` for chart responses. Add an equivalent DatasetData fingerprint.
+Both fingerprints exclude `generatedAt`. Do not use a renderer, snapshot, Redis, or query
+fingerprint as the public `ETag`.
+
+After authorization and resource-scope checks, return `304` with no body when `If-None-Match`
+matches the current default response. Authorization must run for every conditional request.
+
+`POST` responses use `Cache-Control: private, no-store`. They do not return `304`. They can return
+an `ETag` only as informational content identity when the response is a default variant; v1 does
+not require this behavior.
+
+`X-Chartbrew-Data-Stale` is result freshness, not internal cache state. Do not return cache hit,
+cache miss, Redis key, cache type, or variant data.
+
+## Limits
+
+Add a small `server/modules/dataApiLimits.js` module. All limits are configurable positive integers
+with safe defaults:
+
+| Environment variable | Default | Behavior |
+| --- | ---: | --- |
+| `CB_DATA_API_RATE_LIMIT_MAX` | 60 | Maximum authenticated requests per API key per minute. |
+| `CB_DATA_API_AUTH_RATE_LIMIT_MAX` | 30 | Maximum failed or unknown-key attempts per IP per minute. |
+| `CB_DATA_API_MAX_REQUEST_BYTES` | 65536 | Maximum raw POST body size. |
+| `CB_DATA_API_MAX_RESPONSE_BYTES` | 5242880 | Maximum serialized JSON response size. |
+| `CB_DATA_API_MAX_EXECUTION_MS` | 30000 | Maximum time before the API returns a timeout. |
+| `CB_DATA_API_MAX_FILTERS` | 50 | Maximum filters in one request. |
+| `CB_DATA_API_MAX_VARIABLES` | 100 | Maximum variable keys in one request. |
+| `CB_DATA_API_MAX_VALUE_DEPTH` | 10 | Maximum variable or filter-value nesting depth. |
+| `CB_DATA_API_MAX_STRING_BYTES` | 8192 | Maximum bytes in one variable name, field, operator, or string value. |
+
+Apply the failed-auth limiter before expensive database or source work. Apply the per-key limiter
+after key identity is known. Its key is `Apikey.id`, not user ID, IP, token text, team ID, or route.
+Return standard rate-limit headers and `Retry-After`.
+
+Serialize the full response to a string and measure it with `Buffer.byteLength(..., "utf8")` before
+sending. If it is too large, return `413`. Never slice rows or strings to fit.
+
+The execution deadline includes resource loading, cache reads, source execution, joins,
+transformation, preparation, serialization, and audit completion needed for the response. Pass an
+`AbortSignal` or deadline through the canonical source path where the connector supports it. A
+timeout returns `504` even if a connector cannot stop immediately. Existing connector timeouts
+remain active and must not be increased by this feature.
+
+## Error Contract
+
+All Data API errors use this shape:
+
+```json
+{
+  "error": {
+    "code": "RESOURCE_NOT_FOUND",
+    "message": "The requested resource was not found.",
+    "requestId": "7a39da10-819c-4db4-9dcf-f27d48e3a7c0"
+  }
+}
+```
+
+`message` is safe for users. It does not contain a stack trace, SQL, source request, endpoint,
+connection name, database name, cache key, file path, or implementation stage.
+
+Required codes:
+
+| HTTP | Code | Use |
+| ---: | --- | --- |
+| 400 | `INVALID_REQUEST` | Invalid JSON shape, unknown property, invalid ID, timezone, or content type. |
+| 400 | `INVALID_VARIABLE` | Invalid variable name, type, value, count, depth, or size. |
+| 400 | `INVALID_FILTER` | Invalid field, operator, scope, CDC, date range, count, depth, or size. |
+| 401 | `API_KEY_REQUIRED` | No valid bearer value was supplied. |
+| 401 | `API_KEY_INVALID` | Signature, key identity, record, token comparison, user, or team membership failed. |
+| 403 | `API_KEY_SCOPE_REQUIRED` | The key lacks `data:read` or `data:refresh`. |
+| 404 | `RESOURCE_NOT_FOUND` | Resource is absent, cross-team, under a different parent, or outside project scope. |
+| 406 | `NOT_ACCEPTABLE` | The client does not accept JSON. |
+| 413 | `REQUEST_TOO_LARGE` | The request body exceeds its limit. |
+| 413 | `RESPONSE_TOO_LARGE` | The complete response exceeds its limit. |
+| 415 | `UNSUPPORTED_MEDIA_TYPE` | A POST does not use JSON. |
+| 429 | `RATE_LIMITED` | The failed-auth or per-key rate limit was reached. |
+| 500 | `INTERNAL_ERROR` | An unexpected server failure occurred. |
+| 503 | `DATA_UNAVAILABLE` | No valid default data exists and the source cannot supply it. |
+| 504 | `EXECUTION_TIMEOUT` | The request exceeded the execution deadline. |
+
+Connector policy errors can map to a stable Data API code, but their public message must remain
+source-neutral unless an action from the caller can fix the problem. Do not pass existing raw
+controller error strings through this API.
+
+## Audit And Observability
+
+Extend `UpdateRun` with nullable `apiKeyId` and add an index on `(apiKeyId, startedAt)`. Keep the
+identifier after a key is deleted. Do not add a foreign-key cascade that deletes audit history.
+
+Start one root run for each authorized Data API request:
+
+```text
+triggerType = data_api
+entityType  = chart_data or dataset_data
+```
+
+Child dataset and connector runs use the current trace parent. Record only bounded metadata:
+
+- Request ID and trace ID
+- API-key ID
+- Team, project, chart, and dataset IDs as applicable
+- HTTP method and API version
+- Refresh requested: true or false
+- Variable count and filter count, but not names or values
+- Result status and stable error code
+- Duration in milliseconds
+- Serialized response bytes
+- Data stale: true or false
+
+Never record:
+
+- Bearer token or token fragment
+- Authorization header
+- Variable names or values
+- Filter fields or values
+- SQL or source query text
+- API source URL, headers, or body
+- Raw source rows or response rows
+- Connection credentials
+- Redis keys or cache payloads
+
+Failed authentication attempts do not create normal `UpdateRun` rows because no trusted team or key
+identity exists. Emit a bounded security log with request ID, failure class, and server-derived IP
+rate-limit key. Do not log the supplied token.
+
+Add counters and timing metrics for request count, authorization failure, status code, resource
+type, response bytes, duration, stale response, timeout, and size rejection. Labels must not contain
+user input, token data, resource names, filter fields, or variable names.
+
+## Server Structure
+
+Add or change these server areas:
+
+```text
+server/api/DataApiRoute.js
+server/controllers/DataApiController.js
+server/modules/verifyDataApiKey.js
+server/modules/dataApiAccess.js
+server/modules/dataApiLimits.js
+server/modules/dataApiResponse.js
+server/modules/datasetData.js
+server/models/models/apikey.js
+server/models/models/updaterun.js
+server/models/migrations/<timestamp>-add-data-api-key-scope.js
+server/models/migrations/<timestamp>-add-data-api-audit-key.js
+server/controllers/TeamController.js
+server/controllers/ChartController.js
+server/controllers/DatasetController.js
+server/visualization/filterDatasets.js
+server/modules/updateAudit.js
+server/api/index.js
+```
+
+Responsibilities:
+
+- `DataApiRoute` defines only the four versioned routes and middleware order.
+- `DataApiController` coordinates authorization results, request validation, chart or dataset
+  service calls, headers, serialization, limits, and errors.
+- `verifyDataApiKey` proves key identity and stored scopes.
+- `dataApiAccess` calculates effective projects and performs scoped resource lookups.
+- `dataApiLimits` owns environment parsing and deadline helpers.
+- `dataApiResponse` owns stable errors, headers, byte checks, and conditional responses.
+- `datasetData` owns DatasetData v1 normalization, validation, serialization, and fingerprinting.
+- `ChartController` or an extracted chart-preparation service owns prepared-only execution.
+- `DatasetController` remains the owner of source execution, joins, and dataset transformation.
+
+Do not place Data API routes in `ChartRoute.js` or `DatasetRoute.js`. Those files contain legacy
+application, public-share, and session-authenticated behavior that must not become part of the
+versioned Data API contract.
+
+Any changes to source runtime signatures or connector behavior must follow `source-plugin-guide.md`.
+The preferred implementation reuses current source execution and only passes a bounded deadline or
+abort context.
+
+## Client Key Management
+
+Update the existing Developer settings API-key view. Do not add a Data API screen to the chart
+builder.
+
+The create form contains:
+
+- Key name
+- Project access: all accessible projects or selected projects
+- Read chart and dataset data, always selected
+- Refresh data from sources, optional
+
+The key list can show name, project access summary, permissions, created date, and last-used date.
+It never shows the token after creation.
+
+Clearly identify old keys that cannot use the Data API. Use a visible warning state with this user
+meaning:
+
+```text
+Data API unavailable
+This key still works with existing integrations. Create a new key to use the Data API.
+```
+
+Do not add a separate replacement action or flow. The normal `Create a new API Key` action opens
+the same scoped-key form for all users.
+
+Do not modify, upgrade, rotate, revoke, or delete an old key automatically. The server cannot
+change its signed identity, and Chartbrew cannot know where the bearer token is in use. The user
+must revoke the old key in a separate explicit action when it is no longer in use.
+
+The warning must not depend on color only. Include visible text and an accessible label. Keep the
+current key order unless the user selects another order.
+
+Keep user copy concise. Do not show JWT, scope identifiers, database IDs, token claims, contract
+versions, migrations, or cache details.
+
+## Documentation
+
+Every server contract in this feature must be present in the `v6` branch of:
+
+```text
+../chartbrew-docs/api-reference/openapi.json
+```
+
+The OpenAPI update must include:
+
+- Four paths and both methods
+- A Data API bearer security scheme that is distinct in description from a session token
+- Path parameters
+- POST request schemas
+- PreparedData and DatasetData schemas
+- Field, filter, variable, series, warning, error, and resource schemas
+- All response status codes
+- `ETag`, `Last-Modified`, `Retry-After`, and freshness headers
+- Rate, request, response, and execution limits
+- Examples for default, runtime, conditional, stale, and error responses
+
+Add endpoint MDX pages for the four resources and update the API introduction. Add one guide that
+shows:
+
+1. How a team owner or team admin creates a project-scoped key.
+2. How to send a default `GET`.
+3. How to send variables and filters with `POST`.
+4. How to use `If-None-Match`.
+5. How to handle `401`, `403`, `404`, `413`, `429`, `503`, and `504`.
+6. How to map PreparedData fields and rows into ECharts.
+7. How to map the same response into Chart.js.
+
+Update `../chartbrew-docs/environment-variables.mdx` with all Data API limit settings.
+
+Validate the documentation with:
+
+- JSON parsing
+- OpenAPI validation
+- Documentation-site link and schema validation
+
+The Data API is not complete until the documentation change is validated and ready to land with
+the server change.
+
+## Test Plan
+
+### Unit Tests
+
+Add focused tests for:
+
+- API-key claim validation
+- Database-record, user, team, scope, and token comparison
+- Constant-time digest comparison behavior
+- Effective project calculations for all five roles
+- Key project restrictions and empty project sets
+- Legacy, session, Slack, share, and deleted token rejection
+- Legacy-key list status and warning serialization
+- Request schema validation
+- Variable limits and normalization
+- Chart and dataset filter validation
+- DatasetData field ordering and JSON normalization
+- PreparedData public serialization use
+- Deterministic fingerprints that exclude only `generatedAt`
+- `ETag` matching
+- Response-size measurement with UTF-8 content
+- Deadline and timeout mapping
+- Stable public errors and secret redaction
+- Audit allowlists
+
+### Integration Tests
+
+Add route tests for:
+
+- All four paths and methods
+- Team owner and team admin keys
+- Project-admin, project-editor, and project-viewer effective access after a role change
+- Removed user and removed team-role behavior
+- All-project and selected-project keys
+- Cross-team dataset IDs
+- Chart under a different project ID
+- Dataset outside the key project list
+- Empty-project datasets
+- Missing `data:read`
+- Missing `data:refresh`
+- Deleted and blacklisted keys
+- Session JWT, public chart token, project share token, and old API-key rejection
+- Legacy-key warning, new scoped-key creation, and no automatic revocation
+- Default chart snapshot read with sources unavailable
+- Stale-source snapshot read and background refresh
+- Visualization-mismatch synchronous preparation
+- Runtime prepared-cache hit and miss
+- Runtime filters, variables, timezone, joins, transformations, aggregation, and breakdowns
+- Dataset nested, array, object, scalar, and null results
+- `If-None-Match` and `304`
+- Rate-limit headers and per-key isolation
+- Request and response byte limits
+- Execution timeout
+- JSON content negotiation
+- Audit success and failure records
+- No renderer configuration or secret fields in any successful response
+
+### Parity Tests
+
+For every supported chart preset, prepare one chart through the normal chart path and one through
+the Data API path with the same inputs. Compare:
+
+- Public serialized results
+- Layer IDs
+- Field metadata
+- Series IDs and labels
+- Row values and order
+- Nulls and non-finite values
+- Stats and warnings
+
+Run the comparison for:
+
+- Default data
+- Field filters
+- Date filters
+- Variables
+- Project timezone
+- Sparse values
+- Multiple bindings
+- Breakdowns
+- Table, KPI, average, gauge, matrix, markdown, and graphical presets
+
+The Data API result must not depend on whether the current preset renderer is ECharts, native, or
+the Chart.js fallback.
+
+### Repository Validation
+
+Run from `server/`:
+
+```text
+npm run test:unit
+npm run test:integration
+npm run lint
+```
+
+Use focused test commands during implementation, then run the full server suite before completion.
+Do not start a UI development server for this validation.
+
+## Delivery Plan
+
+### Stage 1: Contracts And Key Security
+
+- Add API-key and audit migrations.
+- Add model fields and associations.
+- Add key claims, stored scopes, project restrictions, and last-use tracking.
+- Add strict Data API authentication and access calculation.
+- Update key-management API and UI.
+- Add unit and integration tests for all roles and token types.
+
+Exit gate: no session, share, legacy, deleted, cross-team, or out-of-project token can reach a Data
+API controller.
+
+### Stage 2: Chart Data Endpoint
+
+- Add prepared-only chart execution.
+- Cover durable snapshots and prepared-cache short circuits.
+- Add chart `GET` and `POST` routes.
+- Add public serialization, `ETag`, freshness, errors, limits, and audit data.
+- Add chart parity tests.
+
+Exit gate: API chart rows match normal prepared chart rows for default and runtime inputs, and no
+renderer compiler runs.
+
+### Stage 3: Dataset Data Endpoint
+
+- Add DatasetData v1.
+- Add explicit dataset runtime filter handling.
+- Add dataset `GET` and `POST` routes.
+- Add dataset cache, join, transformation, nested result, limit, and access tests.
+
+Exit gate: dataset responses preserve joined result shape, apply only documented runtime behavior,
+and expose no chart presentation or source secrets.
+
+### Stage 4: Hardening, Documentation, And Release
+
+- Complete rate, timeout, response-size, audit, and redaction tests.
+- Update and validate OpenAPI and MDX documentation on `v6`.
+- Add ECharts and Chart.js examples.
+- Run the full server test and lint suites.
+- Confirm migration behavior on SQLite, PostgreSQL, and MySQL.
+
+Exit gate: all acceptance gates pass and the documentation change is ready to release with the
+server change.
+
+## Migration And Compatibility
+
+- All routes are additive and versioned under `/api/v1`.
+- Existing application, embed, report, share, and old API routes do not change.
+- Existing API keys keep their current old-API behavior.
+- Existing keys have empty scopes and cannot use the Data API.
+- Users must create a new scoped key for Data API access.
+- The key-management UI identifies these keys as `Data API unavailable`.
+- Creating a new scoped key never revokes an old key.
+- Slack-created keys remain legacy integration keys and cannot use the Data API unless a later
+  migration explicitly gives them database identity and scope.
+- API-key model fields are additive and safe for a rolling deployment.
+- New server code must tolerate old rows with null `user_id`, null project scope, and empty scopes.
+- A rollback can remove the new route registration while leaving additive columns in place.
+- `CB_DATA_API_ENABLED=false` can disable route execution during rollout. Disabled routes return
+  `404`, not an implementation or feature-flag message.
+
+## Security Review Checklist
+
+- [x] Authorization header parser accepts exactly one bearer credential.
+- [x] Token signature is valid.
+- [x] Token type is `api_key`.
+- [x] Token key ID loads one active database record.
+- [x] Supplied and stored tokens match in constant time.
+- [x] Token user and team match the database record.
+- [x] Current user and team role exist.
+- [x] Stored scope permits the operation.
+- [x] Effective project set permits the resource.
+- [x] Chart belongs to the route project.
+- [x] Project belongs to the key team.
+- [x] Dataset belongs to the route team.
+- [x] Dataset project access is valid.
+- [x] Public and share tokens fail before resource loading.
+- [x] Runtime input is bounded before source work.
+- [x] Source execution receives team and project scope.
+- [x] Response uses an explicit serializer.
+- [x] Error serialization removes internal details.
+- [x] Audit records contain no token, query, variables, filters, or rows.
+- [x] Rate-limit keys do not contain the bearer token.
+- [x] Conditional requests repeat authorization.
+- [x] Sensitive responses use private cache headers and vary on authorization.
+
+## Acceptance Gates
+
+- The four versioned routes return the documented JSON contracts.
+- Only an active database-bound API key with `data:read` can use the API.
+- Explicit or runtime-forced refresh requires `data:refresh`.
+- Session tokens, old API keys, integration keys, and all share tokens are rejected.
+- Team and project relationships are enforced in scoped database lookups.
+- Current roles and project assignments can reduce key authority immediately.
+- Team owner, team admin, project admin, project editor, and project viewer behavior matches the
+  documented matrix.
+- A deleted user, removed team member, revoked key, or removed scope loses access immediately.
+- Chart responses are the public serialization of canonical `PreparedData`.
+- Dataset responses preserve the canonical joined result before chart presentation.
+- Default and runtime chart API rows match normal prepared chart rows.
+- No successful response contains Chart.js, ECharts, renderer, source, credential, or cache data.
+- Default `GET` supports stable `ETag` and authorized `304` responses.
+- Stale last-known chart data is clearly marked without exposing cache internals.
+- Rate, request, response, filter, variable, depth, string, and execution limits are enforced.
+- Limit failures do not return partial data.
+- All errors use stable codes and safe messages.
+- Every authorized request produces bounded audit data.
+- OpenAPI, endpoint guides, environment variables, and JavaScript examples are complete and
+  validated on the documentation `v6` branch.
+- Existing Chartbrew dashboards, embeds, reports, exports, snapshots, alerts, observations,
+  automated refreshes, old APIs, and renderer fallbacks keep their behavior.
+
+## Follow-Up Work
+
+These items require a new specification or a new API version:
+
+- Public data links
+- Service-account keys that are independent of a user
+- Key expiry and rotation policies
+- Additional read and write scopes
+- Row-level policies
+- Pagination and field projection
+- Streaming, CSV, Arrow, and bulk export
+- Public schema discovery
+- Dataset or chart webhooks
+- Image, SVG, PNG, and screenshot sharing

--- a/server/api/DataApiRoute.js
+++ b/server/api/DataApiRoute.js
@@ -1,0 +1,159 @@
+const rateLimit = require("express-rate-limit");
+
+const DataApiController = require("../controllers/DataApiController");
+const verifyDataApiKey = require("../modules/verifyDataApiKey");
+const { getDataApiLimits } = require("../modules/dataApiLimits");
+const { incrementDataApiMetric } = require("../modules/dataApiMetrics");
+const {
+  DataApiError,
+  acceptsJson,
+  ensureRequestId,
+  sendDataApiError,
+  setDataHeaders,
+} = require("../modules/dataApiResponse");
+const { failRun, startRun } = require("../modules/updateAudit");
+
+function isDataApiEnabled() {
+  return process.env.CB_DATA_API_ENABLED !== "false";
+}
+
+function requestId(req, _res, next) {
+  ensureRequestId(req);
+  return next();
+}
+
+function requireEnabled(req, res, next) {
+  if (!isDataApiEnabled()) return sendDataApiError(req, res, new DataApiError("RESOURCE_NOT_FOUND"));
+  return next();
+}
+
+function validateHttpRequest(req, res, next) {
+  if (!acceptsJson(req)) return sendDataApiError(req, res, new DataApiError("NOT_ACCEPTABLE"));
+  if (req.method === "GET" && Object.keys(req.query || {}).length > 0) {
+    return sendDataApiError(req, res, new DataApiError("INVALID_REQUEST"));
+  }
+  if (req.method === "POST") {
+    if (!req.is("application/json")) {
+      return sendDataApiError(req, res, new DataApiError("UNSUPPORTED_MEDIA_TYPE"));
+    }
+    const rawBytes = Buffer.byteLength(req.rawBody || JSON.stringify(req.body || {}), "utf8");
+    if (rawBytes > getDataApiLimits().maxRequestBytes) {
+      incrementDataApiMetric("size_rejections", { resourceType: "request", type: "REQUEST_TOO_LARGE" });
+      return sendDataApiError(req, res, new DataApiError("REQUEST_TOO_LARGE"));
+    }
+  }
+  return next();
+}
+
+function createAuthLimiter() {
+  return rateLimit({
+    legacyHeaders: false,
+    limit: () => getDataApiLimits().authRateLimitMax,
+    standardHeaders: true,
+    windowMs: 60 * 1000,
+    requestWasSuccessful: (req) => Boolean(req.apiKeyAccess),
+    skipSuccessfulRequests: true,
+    handler: (req, res) => {
+      incrementDataApiMetric("authorization_failures", { code: "RATE_LIMITED" });
+      return sendDataApiError(req, res, new DataApiError("RATE_LIMITED"));
+    },
+  });
+}
+
+function positiveAuditId(value) {
+  if (!/^[1-9]\d*$/.test(`${value || ""}`)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+async function auditAuthenticatedRateLimit(req) {
+  const isChart = Boolean(req.params.chart_id);
+  const traceContext = await startRun({
+    triggerType: "data_api",
+    entityType: isChart ? "chart_data" : "dataset_data",
+    status: "running",
+    apiKeyId: req.apiKeyAccess.apiKeyId,
+    teamId: req.apiKeyAccess.teamId,
+    projectId: positiveAuditId(req.params.project_id),
+    chartId: positiveAuditId(req.params.chart_id),
+    datasetId: positiveAuditId(req.params.dataset_id),
+    summary: {
+      apiVersion: "v1",
+      method: req.method,
+      requestId: req.id,
+    },
+  });
+  await failRun(traceContext, new DataApiError("RATE_LIMITED"), {
+    stage: "data_api",
+    summary: {
+      apiVersion: "v1",
+      errorCode: "RATE_LIMITED",
+      method: req.method,
+      requestId: req.id,
+      responseBytes: 0,
+      statusCode: 429,
+    },
+  });
+}
+
+function createKeyLimiter() {
+  return rateLimit({
+    keyGenerator: (req) => req.apiKeyAccess.apiKeyId,
+    legacyHeaders: false,
+    limit: () => getDataApiLimits().rateLimitMax,
+    standardHeaders: true,
+    windowMs: 60 * 1000,
+    handler: async (req, res) => {
+      incrementDataApiMetric("requests", { resourceType: "rate_limit", statusCode: 429 });
+      await auditAuthenticatedRateLimit(req);
+      return sendDataApiError(req, res, new DataApiError("RATE_LIMITED"));
+    },
+  });
+}
+
+function sendResult(res, result) {
+  setDataHeaders(res, result);
+  if (result.notModified) return res.status(304).end();
+  res.status(200).set("Content-Type", "application/json; charset=utf-8");
+  return res.end(result.serialized);
+}
+
+function routeHandler(controllerMethod) {
+  return async (req, res) => {
+    try {
+      return sendResult(res, await controllerMethod(req));
+    } catch (error) {
+      return sendDataApiError(req, res, error);
+    }
+  };
+}
+
+module.exports = (app) => {
+  const controller = new DataApiController();
+  const authLimiter = createAuthLimiter();
+  const keyLimiter = createKeyLimiter();
+  const access = [requestId, requireEnabled, validateHttpRequest, authLimiter, verifyDataApiKey(), keyLimiter];
+
+  app.get(
+    "/api/v1/teams/:team_id/datasets/:dataset_id/data",
+    ...access,
+    routeHandler(controller.datasetData.bind(controller))
+  );
+  app.post(
+    "/api/v1/teams/:team_id/datasets/:dataset_id/data",
+    ...access,
+    routeHandler(controller.datasetData.bind(controller))
+  );
+  app.get(
+    "/api/v1/projects/:project_id/charts/:chart_id/data",
+    ...access,
+    routeHandler(controller.chartData.bind(controller))
+  );
+  app.post(
+    "/api/v1/projects/:project_id/charts/:chart_id/data",
+    ...access,
+    routeHandler(controller.chartData.bind(controller))
+  );
+
+  return (req, res, next) => next();
+};

--- a/server/api/TeamRoute.js
+++ b/server/api/TeamRoute.js
@@ -262,14 +262,14 @@ module.exports = (app) => {
 
   // route to create a new API key to access the team content
   app.post("/team/:id/apikey", verifyToken, checkPermissions("createAny", "apiKey"), (req, res) => {
-    if (!req.body.name) return res.status(400).send("Missing required fields.");
+    if (!req.body.name) return res.status(400).send({ error: "A key name is required." });
 
     return teamController.createApiKey(req.params.id, req.user, req.body)
       .then((apiKey) => {
         return res.status(200).send(apiKey);
       })
       .catch((err) => {
-        return res.status(400).send(err);
+        return res.status(400).send({ error: err.message || "The key could not be created." });
       });
   });
   // --------------------------------------

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -15,6 +15,7 @@ const ai = require("./AiRoute");
 const updateRun = require("./UpdateRunRoute");
 const observation = require("./ObservationRoute");
 const platform = require("./PlatformSettingsRoute");
+const dataApi = require("./DataApiRoute");
 
 module.exports = {
   team,
@@ -34,4 +35,5 @@ module.exports = {
   ai,
   observation,
   platform,
+  dataApi,
 };

--- a/server/controllers/ChartController.js
+++ b/server/controllers/ChartController.js
@@ -32,6 +32,7 @@ const ChartCacheController = require("./ChartCacheController");
 const dataExtractor = require("../charts/DataExtractor");
 const { snapChart } = require("../modules/snapshots");
 const { VisualizationEngine } = require("../visualization/VisualizationEngine");
+const { getPreparedDataFingerprint } = require("../visualization/preparedData");
 const {
   buildLegacyLayer,
   legacyChartToVisualization,
@@ -94,6 +95,15 @@ function createRuntimeShortCircuit(chart) {
 
 function isRuntimeShortCircuit(value) {
   return Boolean(value && value.__runtimeCachedChart);
+}
+
+function createPreparedResult(preparedData, options = {}) {
+  return {
+    preparedData,
+    fingerprint: getPreparedDataFingerprint(preparedData),
+    generatedAt: preparedData.generatedAt,
+    stale: Boolean(options.stale),
+  };
 }
 
 function reconcileVisualizationBindings(chart) {
@@ -654,6 +664,10 @@ class ChartController {
     traceContext,
     finalizeRun = true,
     returnPreparedData = false,
+    preparedOnly = false,
+    viewerScope,
+    signal,
+    deadlineAt,
   }) {
     let gChart;
     let gCache;
@@ -673,7 +687,7 @@ class ChartController {
     let runtimeChartCacheEntry;
     let runtimeChartCacheParams;
     let runtimeChartVersion;
-    let runtimeViewerScope = user ? "authenticated" : "anonymous";
+    let runtimeViewerScope = viewerScope || (user ? "authenticated" : "anonymous");
     let snapshotPersistResult = null;
 
     return this.findById(id, null, { hydratePreparedData: false })
@@ -740,19 +754,23 @@ class ChartController {
           });
 
           if (runtimeChartCacheEntry?.payload) {
-            const cachedChart = attachRuntimeCacheMetadata(compilePreparedRender(
-              gChart,
-              runtimeChartCacheEntry.payload,
-              {
+            const cachedChart = preparedOnly
+              ? createPreparedResult(runtimeChartCacheEntry.payload, {
                 stale: runtimeChartCacheEntry.stale,
-                timezone: project?.timezone,
-                updatedAt: runtimeChartCacheEntry.payload.generatedAt,
-              }
-            ), {
-              cacheStatus: runtimeChartCacheEntry.stale ? "stale" : "hit",
-              variantHash: runtimeContext.chartVariantHash,
-              stale: runtimeChartCacheEntry.stale,
-            });
+              })
+              : attachRuntimeCacheMetadata(compilePreparedRender(
+                gChart,
+                runtimeChartCacheEntry.payload,
+                {
+                  stale: runtimeChartCacheEntry.stale,
+                  timezone: project?.timezone,
+                  updatedAt: runtimeChartCacheEntry.payload.generatedAt,
+                }
+              ), {
+                cacheStatus: runtimeChartCacheEntry.stale ? "stale" : "hit",
+                variantHash: runtimeContext.chartVariantHash,
+                stale: runtimeChartCacheEntry.stale,
+              });
 
             await runtimeCache.trackChartVariantUsage({
               chartId: id,
@@ -775,6 +793,8 @@ class ChartController {
                   runtimeOnly: true,
                   traceContext: null,
                   finalizeRun: false,
+                  preparedOnly,
+                  viewerScope: runtimeViewerScope,
                 })
               );
             }
@@ -798,19 +818,29 @@ class ChartController {
           }
 
           const defaultSnapshot = await loadPreparedSnapshot(id);
-          const storedChart = defaultSnapshot
-            ? compilePreparedRender(gChart, defaultSnapshot.preparedData, {
+          if (preparedOnly && !defaultSnapshot) {
+            const cacheMissError = new Error("Prepared chart snapshot is not available");
+            cacheMissError.code = "PREPARED_SNAPSHOT_MISS";
+            throw cacheMissError;
+          }
+          let storedChart = attachLegacyRender(gChart, { stale: true });
+          if (defaultSnapshot && preparedOnly) {
+            storedChart = createPreparedResult(defaultSnapshot.preparedData, { stale: false });
+          } else if (defaultSnapshot) {
+            storedChart = compilePreparedRender(gChart, defaultSnapshot.preparedData, {
               snapshotUpdatedAt: defaultSnapshot.updatedAt,
               stale: false,
               timezone: project?.timezone,
               updatedAt: defaultSnapshot.updatedAt,
-            })
-            : attachLegacyRender(gChart, { stale: true });
-          return createRuntimeShortCircuit(attachRuntimeCacheMetadata(storedChart, {
-            cacheStatus: "stored",
-            variantHash: runtimeContext?.chartVariantHash || null,
-            stale: false,
-          }));
+            });
+          }
+          return createRuntimeShortCircuit(preparedOnly
+            ? storedChart
+            : attachRuntimeCacheMetadata(storedChart, {
+              cacheStatus: "stored",
+              variantHash: runtimeContext?.chartVariantHash || null,
+              stale: false,
+            }));
         }
 
         if (runtimeContext.needsSourceRefresh) {
@@ -888,6 +918,8 @@ class ChartController {
                 viewerScope: runtimeViewerScope,
                 readRuntimeSourceCache: shouldReadRuntimeCache,
                 writeRuntimeSourceCache: Boolean(runtimeContext?.cacheableChartPayload?.hasRuntimeFilters),
+                signal,
+                deadlineAt,
               })
             );
           } else {
@@ -907,6 +939,8 @@ class ChartController {
                 viewerScope: runtimeViewerScope,
                 readRuntimeSourceCache: shouldReadRuntimeCache,
                 writeRuntimeSourceCache: Boolean(runtimeContext?.cacheableChartPayload?.hasRuntimeFilters),
+                signal,
+                deadlineAt,
               })
             );
           }
@@ -923,6 +957,11 @@ class ChartController {
       .then(async (datasets) => {
         if (isRuntimeShortCircuit(datasets)) {
           return datasets;
+        }
+        if (signal?.aborted) {
+          const timeoutError = new Error("The request exceeded the execution time limit.");
+          timeoutError.code = "EXECUTION_TIMEOUT";
+          throw timeoutError;
         }
 
         const resolvedDatasets = datasets.map((dataset, index) => {
@@ -986,6 +1025,8 @@ class ChartController {
             variables: effectiveVariables,
           };
 
+          if (preparedOnly) return visualizationEngine.prepare(engineOptions);
+
           return isExport
             ? visualizationEngine.export({ ...engineOptions, mode: exportMode || "source" })
             : visualizationEngine.render(engineOptions);
@@ -997,6 +1038,11 @@ class ChartController {
         if (isRuntimeShortCircuit(chartData)) {
           return chartData;
         }
+        if (signal?.aborted) {
+          const timeoutError = new Error("The request exceeded the execution time limit.");
+          timeoutError.code = "EXECUTION_TIMEOUT";
+          throw timeoutError;
+        }
 
         gChartData = chartData;
         try {
@@ -1004,9 +1050,13 @@ class ChartController {
             await recordInstantEvent(chartTraceContext, "chart_parse_finished", {
               chartId: id,
               chartType: gChart.type,
-              isTimeseries: chartData?.isTimeseries || false,
-              datasetCount: chartData?.configuration?.data?.datasets?.length || 0,
-              labelCount: chartData?.configuration?.data?.labels?.length || 0,
+              isTimeseries: preparedOnly ? false : chartData?.isTimeseries || false,
+              datasetCount: preparedOnly
+                ? chartData?.preparedData?.results?.length || 0
+                : chartData?.configuration?.data?.datasets?.length || 0,
+              labelCount: preparedOnly
+                ? chartData?.preparedData?.results?.reduce((count, result) => count + result.rows.length, 0) || 0
+                : chartData?.configuration?.data?.labels?.length || 0,
               visualizationAdapted: Boolean(chartData?.adapted),
             });
           }
@@ -1083,6 +1133,10 @@ class ChartController {
             });
           }
 
+          if (preparedOnly) {
+            return createPreparedResult(chartData.preparedData, { stale: false });
+          }
+
           return attachPreparedRender(responseChart, chartData, chartData.preparedData, {
             snapshotUpdatedAt: snapshotPersistResult?.saved
               ? snapshotPersistResult.updatedAt
@@ -1118,11 +1172,13 @@ class ChartController {
           && runtimeChartCacheParams
           && runtimeContext?.cacheableChartPayload?.hasRuntimeFilters
         ) {
-          finalChart = attachRuntimeCacheMetadata(finalChart, {
-            cacheStatus: "miss",
-            variantHash: runtimeContext.chartVariantHash,
-            stale: false,
-          });
+          if (!preparedOnly) {
+            finalChart = attachRuntimeCacheMetadata(finalChart, {
+              cacheStatus: "miss",
+              variantHash: runtimeContext.chartVariantHash,
+              stale: false,
+            });
+          }
 
           await runtimeCache.setPreparedCache({
             ...runtimeChartCacheParams,
@@ -1168,10 +1224,14 @@ class ChartController {
               chartId: id,
               chartType: gChart?.type || null,
               datasetCount: gChart?.ChartDatasetConfigs?.length || 0,
-              labelCount: gChartData?.configuration?.data?.labels?.length || 0,
+              labelCount: preparedOnly
+                ? gChartData?.preparedData?.results?.reduce((count, result) => count + result.rows.length, 0) || 0
+                : gChartData?.configuration?.data?.labels?.length || 0,
             },
           });
         }
+
+        if (preparedOnly) return finalChart;
 
         if (returnPreparedData) {
           return {

--- a/server/controllers/DataApiController.js
+++ b/server/controllers/DataApiController.js
@@ -1,0 +1,349 @@
+const db = require("../models/models");
+const ChartController = require("./ChartController");
+const DatasetController = require("./DatasetController");
+const {
+  findAccessibleChart,
+  findAccessibleDataset,
+} = require("../modules/dataApiAccess");
+const { buildChartRuntimeContext } = require("../modules/chartRuntimeFilters");
+const { getDataApiLimits, withExecutionDeadline } = require("../modules/dataApiLimits");
+const { incrementDataApiMetric } = require("../modules/dataApiMetrics");
+const {
+  DataApiError,
+  matchesEtag,
+  serializeDataApiResponse,
+} = require("../modules/dataApiResponse");
+const {
+  parseDataApiId,
+  requiresRefreshScope,
+  validatePostBody,
+} = require("../modules/dataApiValidation");
+const {
+  createDatasetData,
+  getDatasetDataFingerprint,
+} = require("../modules/datasetData");
+const { loadPreparedSnapshot } = require("../modules/preparedSnapshot");
+const runtimeCache = require("../modules/runtimeCache");
+const {
+  completeRun,
+  failRun,
+  startRun,
+} = require("../modules/updateAudit");
+const {
+  getPreparedDataFingerprint,
+  toPublicPreparedData,
+} = require("../visualization/preparedData");
+const { filterDatasetResult } = require("../visualization/filterDatasets");
+
+function requestCounts(req) {
+  return {
+    filterCount: Array.isArray(req.body?.filters) ? req.body.filters.length : 0,
+    variableCount: req.body?.variables && typeof req.body.variables === "object"
+      && !Array.isArray(req.body.variables)
+      ? Object.keys(req.body.variables).length
+      : 0,
+  };
+}
+
+function safeAuditId(value) {
+  if (typeof value !== "string" || !/^[1-9]\d*$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function publicError(error, fallbackCode = "INTERNAL_ERROR") {
+  if (error instanceof DataApiError) return error;
+  if (error?.code === "EXECUTION_TIMEOUT") return new DataApiError("EXECUTION_TIMEOUT");
+  return new DataApiError(fallbackCode, { cause: error });
+}
+
+class DataApiController {
+  constructor() {
+    this.chartController = new ChartController();
+    this.datasetController = new DatasetController();
+  }
+
+  async _run(req, resourceType, identifiers, operation) {
+    const startedAt = Date.now();
+    const traceContext = await startRun({
+      triggerType: "data_api",
+      entityType: `${resourceType}_data`,
+      status: "running",
+      apiKeyId: req.apiKeyAccess.apiKeyId,
+      teamId: req.apiKeyAccess.teamId,
+      projectId: identifiers.projectId || null,
+      chartId: identifiers.chartId || null,
+      datasetId: identifiers.datasetId || null,
+      summary: {
+        apiVersion: "v1",
+        method: req.method,
+        refresh: req.body?.refresh === true,
+        requestId: req.id,
+        ...requestCounts(req),
+      },
+    });
+
+    try {
+      const response = await withExecutionDeadline(async (executionContext) => {
+        const result = await operation(traceContext, executionContext);
+        const notModified = req.method === "GET"
+          && matchesEtag(req.get("if-none-match"), result.etag);
+        if (notModified) {
+          return {
+            ...result,
+            bytes: 0,
+            notModified: true,
+            serialized: null,
+          };
+        }
+        const serialization = serializeDataApiResponse(result.body);
+        return {
+          ...result,
+          ...serialization,
+          notModified: false,
+        };
+      }, getDataApiLimits().executionMs);
+
+      await completeRun(traceContext, {
+        status: "success",
+        summary: {
+          apiVersion: "v1",
+          dataStale: Boolean(response.stale),
+          durationMs: Date.now() - startedAt,
+          errorCode: null,
+          filterCount: requestCounts(req).filterCount,
+          method: req.method,
+          refresh: req.body?.refresh === true,
+          requestId: req.id,
+          responseBytes: response.notModified ? 0 : response.bytes,
+          statusCode: response.notModified ? 304 : 200,
+          variableCount: requestCounts(req).variableCount,
+        },
+      });
+
+      incrementDataApiMetric("requests", {
+        resourceType,
+        statusCode: response.notModified ? 304 : 200,
+      });
+      incrementDataApiMetric("response_bytes", { resourceType }, response.notModified ? 0 : response.bytes);
+      incrementDataApiMetric("duration_ms", { resourceType }, Date.now() - startedAt);
+      if (response.stale) incrementDataApiMetric("stale_responses", { resourceType });
+      return response;
+    } catch (error) {
+      const safeError = publicError(error);
+      await failRun(traceContext, safeError, {
+        stage: "data_api",
+        summary: {
+          apiVersion: "v1",
+          durationMs: Date.now() - startedAt,
+          errorCode: safeError.code,
+          filterCount: requestCounts(req).filterCount,
+          method: req.method,
+          refresh: req.body?.refresh === true,
+          requestId: req.id,
+          responseBytes: 0,
+          statusCode: safeError.statusCode,
+          variableCount: requestCounts(req).variableCount,
+        },
+      });
+      incrementDataApiMetric("requests", {
+        resourceType,
+        statusCode: safeError.statusCode,
+      });
+      if (safeError.code === "EXECUTION_TIMEOUT") {
+        incrementDataApiMetric("timeouts", { resourceType });
+      }
+      if (["REQUEST_TOO_LARGE", "RESPONSE_TOO_LARGE"].includes(safeError.code)) {
+        incrementDataApiMetric("size_rejections", { resourceType, type: safeError.code });
+      }
+      throw safeError;
+    }
+  }
+
+  _requireRefreshScope(req, request) {
+    if (requiresRefreshScope(request)
+      && !req.apiKeyAccess.scopes.includes("data:refresh")) {
+      throw new DataApiError("API_KEY_SCOPE_REQUIRED");
+    }
+  }
+
+  async _prepareDefaultChart(chartId, timezone, traceContext, executionContext) {
+    const snapshot = await loadPreparedSnapshot(chartId);
+    if (snapshot) {
+      const fingerprints = await runtimeCache.buildChartFingerprints(chartId, timezone);
+      if (snapshot.visualizationFingerprint === fingerprints.visualization) {
+        const stale = snapshot.sourceFingerprint !== fingerprints.source;
+        if (stale) {
+          runtimeCache.triggerBackgroundRefresh(
+            `data-api-default-refresh:${chartId}`,
+            () => this.chartController.updateChartData(chartId, null, {
+              finalizeRun: false,
+              getCache: false,
+              noSource: false,
+              preparedOnly: true,
+              traceContext: null,
+              viewerScope: "data-api",
+            })
+          );
+        }
+        return {
+          fingerprint: getPreparedDataFingerprint(snapshot.preparedData),
+          generatedAt: snapshot.preparedData.generatedAt,
+          preparedData: snapshot.preparedData,
+          stale,
+        };
+      }
+    }
+
+    try {
+      return await this.chartController.updateChartData(chartId, null, {
+        finalizeRun: false,
+        getCache: true,
+        noSource: false,
+        preparedOnly: true,
+        traceContext,
+        viewerScope: "data-api",
+        signal: executionContext?.signal,
+        deadlineAt: executionContext?.deadlineAt,
+      });
+    } catch (error) {
+      if (executionContext?.signal?.aborted) throw new DataApiError("EXECUTION_TIMEOUT");
+      throw new DataApiError("DATA_UNAVAILABLE", { cause: error });
+    }
+  }
+
+  async chartData(req) {
+    return this._run(req, "chart", {
+      projectId: safeAuditId(req.params.project_id),
+      chartId: safeAuditId(req.params.chart_id),
+    }, async (traceContext, executionContext) => {
+      const projectId = parseDataApiId(req.params.project_id);
+      const chartId = parseDataApiId(req.params.chart_id);
+      const chart = await findAccessibleChart(db, req.apiKeyAccess, projectId, chartId);
+      if (!chart) throw new DataApiError("RESOURCE_NOT_FOUND");
+      const project = chart.Project || await db.Project.findByPk(projectId, { attributes: ["timezone"] });
+
+      let request = { filters: [], refresh: false, variables: {} };
+      if (req.method === "POST") {
+        const cdcs = await db.ChartDatasetConfig.findAll({
+          attributes: ["id"],
+          where: { chart_id: chartId },
+        });
+        request = validatePostBody(req.body, {
+          cdcIds: cdcs.map((cdc) => cdc.id),
+          resourceType: "chart",
+        });
+        this._requireRefreshScope(req, request);
+      }
+
+      let result;
+      const hasRuntimeValues = request.filters.length > 0 || Object.keys(request.variables).length > 0;
+      if (!hasRuntimeValues && !request.refresh) {
+        result = await this._prepareDefaultChart(
+          chartId,
+          project?.timezone,
+          traceContext,
+          executionContext
+        );
+      } else {
+        try {
+          result = await this.chartController.updateChartData(chartId, null, {
+            filters: request.filters,
+            getCache: !request.refresh,
+            noSource: false,
+            preparedOnly: true,
+            runtimeOnly: hasRuntimeValues,
+            skipSave: hasRuntimeValues,
+            traceContext,
+            finalizeRun: false,
+            variables: request.variables,
+            viewerScope: "data-api",
+            signal: executionContext.signal,
+            deadlineAt: executionContext.deadlineAt,
+          });
+        } catch (error) {
+          if (executionContext.signal.aborted) throw new DataApiError("EXECUTION_TIMEOUT");
+          throw new DataApiError("DATA_UNAVAILABLE", { cause: error });
+        }
+      }
+
+      const body = toPublicPreparedData(result.preparedData);
+      return {
+        body,
+        cacheable: req.method === "GET",
+        etag: `"pd-v1-${result.fingerprint || getPreparedDataFingerprint(result.preparedData)}"`,
+        generatedAt: result.generatedAt,
+        stale: result.stale,
+      };
+    });
+  }
+
+  async datasetData(req) {
+    return this._run(req, "dataset", {
+      datasetId: safeAuditId(req.params.dataset_id),
+    }, async (traceContext, executionContext) => {
+      const teamId = parseDataApiId(req.params.team_id);
+      const datasetId = parseDataApiId(req.params.dataset_id);
+      const dataset = await findAccessibleDataset(db, req.apiKeyAccess, teamId, datasetId);
+      if (!dataset) throw new DataApiError("RESOURCE_NOT_FOUND");
+
+      let request = { filters: [], refresh: false, timezone: "UTC", variables: {} };
+      if (req.method === "POST") {
+        request = validatePostBody(req.body, {
+          resourceType: "dataset",
+          schemaFields: Object.keys(dataset.fieldsSchema || {}),
+        });
+        this._requireRefreshScope(req, request);
+      }
+
+      const runtimeContext = buildChartRuntimeContext(
+        {},
+        request.filters,
+        request.variables,
+        request.timezone
+      );
+      const hasSourceRuntimeValues = runtimeContext.sourceAffecting.hasRuntimeFilters;
+      const bypassDefaultSourceCache = request.refresh || hasSourceRuntimeValues;
+      let result;
+      try {
+        result = await this.datasetController.runRequest({
+          dataset_id: datasetId,
+          team_id: teamId,
+          noSource: false,
+          getCache: !bypassDefaultSourceCache,
+          filters: runtimeContext.sourceAffecting.filters,
+          timezone: request.timezone,
+          variables: request.variables,
+          traceContext,
+          teamId,
+          runtimeContext,
+          viewerScope: "data-api",
+          readRuntimeSourceCache: !request.refresh && hasSourceRuntimeValues,
+          writeRuntimeSourceCache: hasSourceRuntimeValues,
+          maintainDatasetMetadata: req.method === "GET",
+          signal: executionContext.signal,
+          deadlineAt: executionContext.deadlineAt,
+        });
+      } catch (error) {
+        if (executionContext.signal.aborted) throw new DataApiError("EXECUTION_TIMEOUT");
+        throw new DataApiError("DATA_UNAVAILABLE", { cause: error });
+      }
+
+      const filteredData = filterDatasetResult(result.data, request.filters, request.timezone);
+      const body = createDatasetData({
+        dataset: result.options || dataset,
+        data: filteredData,
+      });
+      const fingerprint = getDatasetDataFingerprint(body);
+      return {
+        body,
+        cacheable: req.method === "GET",
+        etag: `"dd-v1-${fingerprint}"`,
+        generatedAt: body.generatedAt,
+        stale: Boolean(result.cacheMetadata?.sourceCache?.stale),
+      };
+    });
+  }
+}
+
+module.exports = DataApiController;

--- a/server/controllers/DatasetController.js
+++ b/server/controllers/DatasetController.js
@@ -117,6 +117,14 @@ function toAuditError(error, stage = "unknown") {
   return wrappedError;
 }
 
+function getRequestAuditError(error, traceContext) {
+  if (traceContext?.triggerType !== "data_api") return error;
+  const safeError = new Error("The data source request failed.");
+  safeError.code = "DATA_UNAVAILABLE";
+  safeError.auditStage = error.auditStage || "connection";
+  return safeError;
+}
+
 class DatasetController {
   constructor() {
     this.dataRequestController = new DataRequestController();
@@ -345,6 +353,9 @@ class DatasetController {
     viewerScope = "shared",
     readRuntimeSourceCache = false,
     writeRuntimeSourceCache = false,
+    maintainDatasetMetadata = true,
+    signal,
+    deadlineAt,
   }) {
     let gDataset;
     let mainDr;
@@ -507,16 +518,18 @@ class DatasetController {
                   } = applySourceVariables(dataRequest, variables);
                   const connection = originalDataRequest.Connection;
 
-                  requestMetadata = {
-                    ...requestMetadata,
-                    queryHash: createHash(processedQuery || originalDataRequest.query),
-                    queryPreview: sanitizeQueryPreview(processedQuery || originalDataRequest.query),
-                    routeHash: createHash(originalDataRequest.route),
-                    routeSnippet: sanitizeRouteSnippet(originalDataRequest.route),
-                    method: originalDataRequest.method || null,
-                    headerNames: sanitizeHeaderNames(originalDataRequest.headers),
-                    bodySnippet: sanitizeSnippet(originalDataRequest.body),
-                  };
+                  if (traceContext?.triggerType !== "data_api") {
+                    requestMetadata = {
+                      ...requestMetadata,
+                      queryHash: createHash(processedQuery || originalDataRequest.query),
+                      queryPreview: sanitizeQueryPreview(processedQuery || originalDataRequest.query),
+                      routeHash: createHash(originalDataRequest.route),
+                      routeSnippet: sanitizeRouteSnippet(originalDataRequest.route),
+                      method: originalDataRequest.method || null,
+                      headerNames: sanitizeHeaderNames(originalDataRequest.headers),
+                      bodySnippet: sanitizeSnippet(originalDataRequest.body),
+                    };
+                  }
 
                   if (requestTraceContext) {
                     requestEvent = await startEvent(requestTraceContext, "dataset_request_started", requestMetadata);
@@ -554,6 +567,7 @@ class DatasetController {
                     traceContext: requestTraceContext,
                     requestEvent,
                     requestMetadata,
+                    redactSensitivePayload: traceContext?.triggerType === "data_api",
                   };
 
                   const sourceResponse = runSourceDataRequest({
@@ -567,6 +581,8 @@ class DatasetController {
                     processedQuery,
                     processedDataRequest,
                     auditContext,
+                    signal,
+                    deadlineAt,
                   });
                   if (sourceResponse) {
                     return sourceResponse;
@@ -576,13 +592,14 @@ class DatasetController {
                 } catch (error) {
                   const wrappedError = toAuditError(error, error.auditStage || "connection");
                   if (requestTraceContext && !wrappedError.auditLogged) {
+                    const auditError = getRequestAuditError(wrappedError, traceContext);
                     if (requestEvent) {
                       await finishEvent(requestTraceContext, requestEvent, "failed", {
                         ...requestMetadata,
-                        errorMessage: wrappedError.message,
+                        errorMessage: auditError.message,
                       });
                     }
-                    await failRun(requestTraceContext, wrappedError, {
+                    await failRun(requestTraceContext, auditError, {
                       stage: wrappedError.auditStage || "connection",
                       payload: requestMetadata,
                       summary: requestMetadata,
@@ -630,16 +647,18 @@ class DatasetController {
             } = applySourceVariables(dataRequest, variables);
             const connection = originalDataRequest.Connection;
 
-            requestMetadata = {
-              ...requestMetadata,
-              queryHash: createHash(processedQuery || originalDataRequest.query),
-              queryPreview: sanitizeQueryPreview(processedQuery || originalDataRequest.query),
-              routeHash: createHash(originalDataRequest.route),
-              routeSnippet: sanitizeRouteSnippet(originalDataRequest.route),
-              method: originalDataRequest.method || null,
-              headerNames: sanitizeHeaderNames(originalDataRequest.headers),
-              bodySnippet: sanitizeSnippet(originalDataRequest.body),
-            };
+            if (traceContext?.triggerType !== "data_api") {
+              requestMetadata = {
+                ...requestMetadata,
+                queryHash: createHash(processedQuery || originalDataRequest.query),
+                queryPreview: sanitizeQueryPreview(processedQuery || originalDataRequest.query),
+                routeHash: createHash(originalDataRequest.route),
+                routeSnippet: sanitizeRouteSnippet(originalDataRequest.route),
+                method: originalDataRequest.method || null,
+                headerNames: sanitizeHeaderNames(originalDataRequest.headers),
+                bodySnippet: sanitizeSnippet(originalDataRequest.body),
+              };
+            }
 
             if (requestTraceContext) {
               requestEvent = await startEvent(requestTraceContext, "dataset_request_started", requestMetadata);
@@ -677,6 +696,7 @@ class DatasetController {
               traceContext: requestTraceContext,
               requestEvent,
               requestMetadata,
+              redactSensitivePayload: traceContext?.triggerType === "data_api",
             };
 
             const sourceResponse = runSourceDataRequest({
@@ -690,6 +710,8 @@ class DatasetController {
               processedQuery,
               processedDataRequest,
               auditContext,
+              signal,
+              deadlineAt,
             });
             if (sourceResponse) {
               return sourceResponse;
@@ -699,13 +721,14 @@ class DatasetController {
           } catch (error) {
             const wrappedError = toAuditError(error, error.auditStage || "connection");
             if (requestTraceContext && !wrappedError.auditLogged) {
+              const auditError = getRequestAuditError(wrappedError, traceContext);
               if (requestEvent) {
                 await finishEvent(requestTraceContext, requestEvent, "failed", {
                   ...requestMetadata,
-                  errorMessage: wrappedError.message,
+                  errorMessage: auditError.message,
                 });
               }
-              await failRun(requestTraceContext, wrappedError, {
+              await failRun(requestTraceContext, auditError, {
                 stage: wrappedError.auditStage || "connection",
                 payload: requestMetadata,
                 summary: requestMetadata,
@@ -720,6 +743,11 @@ class DatasetController {
       })
       .then(async (promisedRequests) => {
         try {
+          if (signal?.aborted) {
+            const timeoutError = new Error("The request exceeded the execution time limit.");
+            timeoutError.code = "EXECUTION_TIMEOUT";
+            throw timeoutError;
+          }
           if (promisedRequests?.__runtimeSourceCache) {
             return Promise.resolve({
               options: gDataset,
@@ -756,7 +784,7 @@ class DatasetController {
             data = applyTransformation(data, mainDr.transform);
           }
 
-          if (noSource !== true && !runtimeContext?.hasRuntimeFilters) {
+          if (maintainDatasetMetadata && noSource !== true && !runtimeContext?.hasRuntimeFilters) {
             const fieldsSchema = discoverDatasetFieldsSchema(data);
             if (!_.isEqual(gDataset.fieldsSchema || {}, fieldsSchema)) {
               await gDataset.update({ fieldsSchema });
@@ -781,11 +809,13 @@ class DatasetController {
             });
           }
 
-          scheduleDatasetProfile({
-            datasetId: gDataset?.id || dataset_id,
-            teamId: gDataset?.team_id || teamId || team_id,
-            sampleData: data,
-          }).catch(() => null);
+          if (maintainDatasetMetadata && !runtimeContext?.hasRuntimeFilters) {
+            scheduleDatasetProfile({
+              datasetId: gDataset?.id || dataset_id,
+              teamId: gDataset?.team_id || teamId || team_id,
+              sampleData: data,
+            }).catch(() => null);
+          }
 
           return Promise.resolve({
             options: gDataset,

--- a/server/controllers/TeamController.js
+++ b/server/controllers/TeamController.js
@@ -6,6 +6,12 @@ const { Op } = require("sequelize");
 
 const db = require("../models/models");
 const runtimeCache = require("../modules/runtimeCache");
+const {
+  DATA_API_SCOPES,
+  normalizeProjectIds,
+  normalizeScopes,
+  validateKeyProjectIds,
+} = require("../modules/dataApiAccess");
 const UserController = require("./UserController");
 
 const settings = process.env.NODE_ENV === "production" ? require("../settings") : require("../settings-dev");
@@ -492,31 +498,112 @@ class TeamController {
 
   async createApiKey(teamId, userData, body) {
     try {
-      const token = jwt.sign({
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      if (!name) throw new Error("A key name is required.");
+
+      const requestedFields = Object.keys(body);
+      const isDataApiKey = requestedFields.some((field) => field !== "name");
+      const allowedFields = new Set(["name", "scopes", "allProjects", "projectIds"]);
+      if (requestedFields.some((field) => !allowedFields.has(field))) {
+        throw new Error("The key settings are not valid.");
+      }
+
+      const apiKeyId = uuidv4();
+      const claims = {
         id: userData.id,
         email: userData.email,
-      }, settings.encryptionKey, { expiresIn: "9999 years" });
+      };
+      const createValues = {
+        id: apiKeyId,
+        name,
+        team_id: Number(teamId),
+      };
 
-      return await db.Apikey.create({
-        name: body.name,
-        team_id: teamId,
+      if (isDataApiKey) {
+        if (!Array.isArray(body.scopes) || body.scopes.some((scope) => !DATA_API_SCOPES.has(scope))) {
+          throw new Error("The key permissions are not valid.");
+        }
+
+        const scopes = normalizeScopes(body.scopes);
+        if (!scopes.includes("data:read")) {
+          throw new Error("Read access is required.");
+        }
+        if (typeof body.allProjects !== "boolean") {
+          throw new Error("Select the projects that this key can access.");
+        }
+
+        const projectIds = normalizeProjectIds(body.projectIds);
+        if (!body.allProjects && projectIds.length === 0) {
+          throw new Error("Select at least one project.");
+        }
+        if (!Array.isArray(body.projectIds) || !await validateKeyProjectIds(db, Number(teamId), body.projectIds)) {
+          throw new Error("The selected projects are not valid.");
+        }
+
+        Object.assign(claims, {
+          apiKeyId,
+          teamId: Number(teamId),
+          tokenType: "api_key",
+        });
+        Object.assign(createValues, {
+          user_id: userData.id,
+          scopes,
+          project_ids: body.allProjects ? [] : projectIds,
+          all_projects: body.allProjects,
+        });
+      }
+
+      const token = jwt.sign(claims, settings.encryptionKey, { expiresIn: "9999 years" });
+      createValues.token = token;
+
+      const apiKey = await db.Apikey.create(createValues);
+
+      return {
+        id: apiKey.id,
+        name: apiKey.name,
         token,
-      });
+        createdAt: apiKey.createdAt,
+        lastUsedAt: apiKey.last_used_at,
+        dataApiAccess: isDataApiKey ? "ready" : "unavailable",
+        permissions: isDataApiKey ? apiKey.scopes : [],
+        projectAccess: isDataApiKey ? {
+          allProjects: apiKey.all_projects,
+          projectIds: apiKey.project_ids,
+        } : null,
+      };
     } catch (e) {
       return Promise.reject(e);
     }
   }
 
   getApiKeys(teamId) {
-    return db.Apikey.findAll({ where: { team_id: teamId } })
+    return db.Apikey.findAll({
+      attributes: [
+        "id", "name", "user_id", "scopes", "project_ids", "all_projects", "last_used_at",
+        "createdAt",
+      ],
+      where: { team_id: teamId },
+    })
       .then((apiKeys) => {
         if (!apiKeys || apiKeys.length < 1) return [];
 
-        return apiKeys.map((key) => ({
-          id: key.id,
-          name: key.name,
-          createdAt: key.createdAt,
-        }));
+        return apiKeys.map((key) => {
+          const permissions = normalizeScopes(key.scopes);
+          const dataApiReady = Boolean(key.user_id) && permissions.includes("data:read");
+
+          return {
+            id: key.id,
+            name: key.name,
+            createdAt: key.createdAt,
+            lastUsedAt: key.last_used_at,
+            dataApiAccess: dataApiReady ? "ready" : "unavailable",
+            permissions: dataApiReady ? permissions : [],
+            projectAccess: dataApiReady ? {
+              allProjects: Boolean(key.all_projects),
+              projectIds: normalizeProjectIds(key.project_ids),
+            } : null,
+          };
+        });
       })
       .catch((err) => {
         return Promise.reject(err);

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,8 @@ const appsRoutes = require("./apps");
 const cleanChartCache = require("./modules/CleanChartCache");
 const cleanAuthCache = require("./modules/CleanAuthCache");
 const parseQueryParams = require("./middlewares/parseQueryParams");
+const dataApiBodyError = require("./modules/dataApiBodyError");
+const { getDataApiLimits } = require("./modules/dataApiLimits");
 const db = require("./models/models");
 const packageJson = require("./package.json");
 const cleanGhostChartsCron = require("./modules/cleanGhostChartsCron");
@@ -82,6 +84,7 @@ app.use(urlencoded({
 }));
 app.set("query parser", "simple");
 app.use(json({
+  limit: Math.max(100 * 1024, getDataApiLimits().maxRequestBytes),
   verify: (req, res, buf, encoding) => {
     // Save raw body for Slack signature verification (JSON requests)
     if (req.headers["content-type"]?.includes("application/json")) {
@@ -89,6 +92,7 @@ app.use(json({
     }
   },
 }));
+app.use(dataApiBodyError);
 app.use(methodOverride("X-HTTP-Method-Override"));
 app.use(helmet({
   crossOriginEmbedderPolicy: false,

--- a/server/models/migrations/20260825090000-add-data-api-key-scope.js
+++ b/server/models/migrations/20260825090000-add-data-api-key-scope.js
@@ -1,0 +1,60 @@
+const Sequelize = require("sequelize");
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const columns = await queryInterface.describeTable("Apikey");
+
+    if (!columns.user_id) {
+      await queryInterface.addColumn("Apikey", "user_id", {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      });
+    }
+
+    if (!columns.scopes) {
+      await queryInterface.addColumn("Apikey", "scopes", {
+        type: Sequelize.TEXT("long"),
+        allowNull: true,
+      });
+    }
+    await queryInterface.bulkUpdate("Apikey", { scopes: "[]" }, { scopes: null });
+    await queryInterface.changeColumn("Apikey", "scopes", {
+      type: Sequelize.TEXT("long"),
+      allowNull: false,
+    });
+
+    if (!columns.project_ids) {
+      await queryInterface.addColumn("Apikey", "project_ids", {
+        type: Sequelize.TEXT("long"),
+        allowNull: true,
+      });
+    }
+
+    if (!columns.all_projects) {
+      await queryInterface.addColumn("Apikey", "all_projects", {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
+    }
+
+    if (!columns.last_used_at) {
+      await queryInterface.addColumn("Apikey", "last_used_at", {
+        type: Sequelize.DATE,
+        allowNull: true,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    const columns = await queryInterface.describeTable("Apikey");
+
+    const removableColumns = ["last_used_at", "all_projects", "project_ids", "scopes", "user_id"]
+      .filter((column) => columns[column]);
+    for (const column of removableColumns) {
+      // oxlint-disable-next-line no-await-in-loop -- table changes must run in order.
+      await queryInterface.removeColumn("Apikey", column);
+    }
+  },
+};

--- a/server/models/migrations/20260825091000-add-data-api-audit-key.js
+++ b/server/models/migrations/20260825091000-add-data-api-audit-key.js
@@ -1,0 +1,35 @@
+const Sequelize = require("sequelize");
+
+const INDEX_NAME = "update_run_api_key_started_at";
+
+/** @type {import("sequelize-cli").Migration} */
+module.exports = {
+  async up(queryInterface) {
+    const columns = await queryInterface.describeTable("UpdateRun");
+    if (!columns.apiKeyId) {
+      await queryInterface.addColumn("UpdateRun", "apiKeyId", {
+        type: Sequelize.UUID,
+        allowNull: true,
+      });
+    }
+
+    const indexes = await queryInterface.showIndex("UpdateRun");
+    if (!indexes.some((index) => index.name === INDEX_NAME)) {
+      await queryInterface.addIndex("UpdateRun", ["apiKeyId", "startedAt"], {
+        name: INDEX_NAME,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    const indexes = await queryInterface.showIndex("UpdateRun");
+    if (indexes.some((index) => index.name === INDEX_NAME)) {
+      await queryInterface.removeIndex("UpdateRun", INDEX_NAME);
+    }
+
+    const columns = await queryInterface.describeTable("UpdateRun");
+    if (columns.apiKeyId) {
+      await queryInterface.removeColumn("UpdateRun", "apiKeyId");
+    }
+  },
+};

--- a/server/models/models/apikey.js
+++ b/server/models/models/apikey.js
@@ -53,6 +53,51 @@ module.exports = (sequelize, DataTypes) => {
         onDelete: "cascade",
       },
     },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    scopes: {
+      type: DataTypes.TEXT("long"),
+      allowNull: false,
+      defaultValue: () => "[]",
+      get() {
+        try {
+          return JSON.parse(this.getDataValue("scopes"));
+        } catch (error) {
+          return [];
+        }
+      },
+      set(value) {
+        return this.setDataValue("scopes", JSON.stringify(value || []));
+      },
+    },
+    project_ids: {
+      type: DataTypes.TEXT("long"),
+      allowNull: true,
+      get() {
+        const value = this.getDataValue("project_ids");
+        if (value === null) return null;
+
+        try {
+          return JSON.parse(value);
+        } catch (error) {
+          return [];
+        }
+      },
+      set(value) {
+        return this.setDataValue("project_ids", value === null ? null : JSON.stringify(value));
+      },
+    },
+    all_projects: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    last_used_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
     createdAt: {
       allowNull: false,
       type: DataTypes.DATE
@@ -67,6 +112,7 @@ module.exports = (sequelize, DataTypes) => {
 
   Apikey.associate = (models) => {
     models.Apikey.belongsTo(models.Team, { foreignKey: "team_id" });
+    models.Apikey.belongsTo(models.User, { foreignKey: "user_id", constraints: false });
     models.Apikey.hasMany(models.Integration, { foreignKey: "apikey_id" });
   };
 

--- a/server/models/models/updaterun.js
+++ b/server/models/models/updaterun.js
@@ -49,6 +49,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       allowNull: true,
     },
+    apiKeyId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+    },
     queueName: {
       type: DataTypes.STRING,
       allowNull: true,

--- a/server/models/models/user.js
+++ b/server/models/models/user.js
@@ -94,6 +94,7 @@ module.exports = (sequelize, DataTypes) => {
     models.User.hasMany(models.ChartCache, { foreignKey: "user_id" });
     models.User.hasMany(models.User2fa, { foreignKey: "user_id" });
     models.User.hasMany(models.PinnedDashboard, { foreignKey: "user_id" });
+    models.User.hasMany(models.Apikey, { foreignKey: "user_id", constraints: false });
   };
 
   return User;

--- a/server/modules/chartRuntimeFilters.js
+++ b/server/modules/chartRuntimeFilters.js
@@ -269,7 +269,9 @@ function buildChartRuntimeContext(chart, filters = [], variables = {}, timezone 
     dashboardDateRange,
     effectiveDateRange,
     hasRuntimeFilters: normalizedFilters.length > 0 || Object.keys(normalizedVariables).length > 0,
-    needsSourceRefresh: Boolean(dashboardDateRange) || Object.keys(normalizedVariables).length > 0,
+    needsSourceRefresh: Boolean(dashboardDateRange)
+      || Object.keys(normalizedVariables).length > 0
+      || classifiedPayload.sourceAffecting.filters.some((filter) => filter.forceSourceRefresh),
     classifiedPayload,
     sourceAffecting: classifiedPayload.sourceAffecting,
     serverParseAffecting: classifiedPayload.serverParseAffecting,

--- a/server/modules/dataApiAccess.js
+++ b/server/modules/dataApiAccess.js
@@ -1,0 +1,138 @@
+const { Op } = require("sequelize");
+
+const TEAM_WIDE_ROLES = new Set(["teamOwner", "teamAdmin"]);
+const PROJECT_ROLES = new Set(["projectAdmin", "projectEditor", "projectViewer"]);
+const DATA_API_SCOPES = new Set(["data:read", "data:refresh"]);
+
+function normalizeProjectIds(value) {
+  if (!Array.isArray(value)) return [];
+
+  return [...new Set(value.map(Number).filter((id) => Number.isInteger(id) && id > 0))];
+}
+
+function normalizeScopes(value) {
+  if (!Array.isArray(value)) return [];
+
+  return [...new Set(value.filter((scope) => DATA_API_SCOPES.has(scope)))];
+}
+
+function getEffectiveProjectIds({
+  role,
+  roleProjectIds = [],
+  teamProjectIds = [],
+  keyProjectIds = [],
+  allProjects = false,
+}) {
+  let allowedByRole = [];
+  if (TEAM_WIDE_ROLES.has(role)) {
+    allowedByRole = normalizeProjectIds(teamProjectIds);
+  } else if (PROJECT_ROLES.has(role)) {
+    allowedByRole = normalizeProjectIds(roleProjectIds);
+  }
+
+  if (allProjects) return allowedByRole;
+
+  const allowedByKey = new Set(normalizeProjectIds(keyProjectIds));
+  return allowedByRole.filter((projectId) => allowedByKey.has(projectId));
+}
+
+async function buildDataApiAccess(db, apiKey, teamRole) {
+  let teamProjectIds = [];
+  if (TEAM_WIDE_ROLES.has(teamRole.role)) {
+    const where = { team_id: apiKey.team_id };
+    if (!apiKey.all_projects) {
+      where.id = { [Op.in]: normalizeProjectIds(apiKey.project_ids) };
+    }
+    const teamProjects = await db.Project.findAll({ attributes: ["id"], where });
+    teamProjectIds = teamProjects.map((project) => project.id);
+  }
+
+  return {
+    apiKeyId: apiKey.id,
+    teamId: apiKey.team_id,
+    userId: apiKey.user_id,
+    role: teamRole.role,
+    allProjects: Boolean(apiKey.all_projects),
+    projectIds: getEffectiveProjectIds({
+      role: teamRole.role,
+      roleProjectIds: teamRole.projects,
+      teamProjectIds,
+      keyProjectIds: apiKey.project_ids,
+      allProjects: apiKey.all_projects,
+    }),
+    scopes: normalizeScopes(apiKey.scopes),
+  };
+}
+
+async function findAccessibleChart(db, access, projectId, chartId) {
+  if (!access.projectIds.includes(projectId)) return null;
+
+  return db.Chart.findOne({
+    attributes: ["id", "project_id"],
+    where: {
+      id: chartId,
+      project_id: projectId,
+    },
+    include: [{
+      model: db.Project,
+      attributes: ["id", "team_id", "timezone"],
+      where: {
+        id: projectId,
+        team_id: access.teamId,
+      },
+      required: true,
+    }],
+  });
+}
+
+async function findAccessibleDataset(db, access, teamId, datasetId) {
+  if (teamId !== access.teamId) return null;
+
+  const dataset = await db.Dataset.findOne({
+    attributes: ["id", "name", "team_id", "project_ids", "fieldsSchema"],
+    where: {
+      id: datasetId,
+      team_id: teamId,
+    },
+  });
+  if (!dataset) return null;
+
+  const datasetProjectIds = normalizeProjectIds(dataset.project_ids);
+  if (datasetProjectIds.length === 0) {
+    return TEAM_WIDE_ROLES.has(access.role) && access.allProjects ? dataset : null;
+  }
+
+  const effectiveProjects = new Set(access.projectIds);
+  return datasetProjectIds.some((projectId) => effectiveProjects.has(projectId)) ? dataset : null;
+}
+
+async function validateKeyProjectIds(db, teamId, projectIds) {
+  if (!Array.isArray(projectIds) || projectIds.some((id) => !Number.isInteger(id) || id <= 0)) {
+    return false;
+  }
+
+  const normalizedIds = normalizeProjectIds(projectIds);
+  if (normalizedIds.length !== projectIds.length) return false;
+
+  const count = await db.Project.count({
+    where: {
+      id: { [Op.in]: normalizedIds },
+      team_id: teamId,
+    },
+  });
+
+  return count === normalizedIds.length;
+}
+
+module.exports = {
+  DATA_API_SCOPES,
+  PROJECT_ROLES,
+  TEAM_WIDE_ROLES,
+  buildDataApiAccess,
+  findAccessibleChart,
+  findAccessibleDataset,
+  getEffectiveProjectIds,
+  normalizeProjectIds,
+  normalizeScopes,
+  validateKeyProjectIds,
+};

--- a/server/modules/dataApiBodyError.js
+++ b/server/modules/dataApiBodyError.js
@@ -1,0 +1,18 @@
+const { DataApiError, sendDataApiError } = require("./dataApiResponse");
+
+function isDataApiRequest(req) {
+  return req.originalUrl?.startsWith("/api/v1/");
+}
+
+function dataApiBodyError(error, req, res, next) {
+  if (!isDataApiRequest(req)) return next(error);
+  if (error?.type === "entity.too.large" || error?.status === 413) {
+    return sendDataApiError(req, res, new DataApiError("REQUEST_TOO_LARGE"));
+  }
+  if (error instanceof SyntaxError || error?.type === "entity.parse.failed") {
+    return sendDataApiError(req, res, new DataApiError("INVALID_REQUEST"));
+  }
+  return next(error);
+}
+
+module.exports = dataApiBodyError;

--- a/server/modules/dataApiLimits.js
+++ b/server/modules/dataApiLimits.js
@@ -1,0 +1,67 @@
+const DEFAULT_DATA_API_LIMITS = Object.freeze({
+  authRateLimitMax: 30,
+  executionMs: 30000,
+  maxFilters: 50,
+  maxRequestBytes: 65536,
+  maxResponseBytes: 5242880,
+  maxStringBytes: 8192,
+  maxValueDepth: 10,
+  maxVariables: 100,
+  rateLimitMax: 60,
+});
+
+const LIMIT_ENV = Object.freeze({
+  authRateLimitMax: "CB_DATA_API_AUTH_RATE_LIMIT_MAX",
+  executionMs: "CB_DATA_API_MAX_EXECUTION_MS",
+  maxFilters: "CB_DATA_API_MAX_FILTERS",
+  maxRequestBytes: "CB_DATA_API_MAX_REQUEST_BYTES",
+  maxResponseBytes: "CB_DATA_API_MAX_RESPONSE_BYTES",
+  maxStringBytes: "CB_DATA_API_MAX_STRING_BYTES",
+  maxValueDepth: "CB_DATA_API_MAX_VALUE_DEPTH",
+  maxVariables: "CB_DATA_API_MAX_VARIABLES",
+  rateLimitMax: "CB_DATA_API_RATE_LIMIT_MAX",
+});
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getDataApiLimits(environment = process.env) {
+  return Object.entries(DEFAULT_DATA_API_LIMITS).reduce((limits, [key, fallback]) => {
+    limits[key] = positiveInteger(environment[LIMIT_ENV[key]], fallback);
+    return limits;
+  }, {});
+}
+
+function withExecutionDeadline(operation, timeoutMs = getDataApiLimits().executionMs) {
+  let timeout;
+  const abortController = new AbortController();
+  const deadlineAt = Date.now() + timeoutMs;
+  const deadline = new Promise((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      abortController.abort();
+      const error = new Error("The request exceeded the execution time limit.");
+      error.code = "EXECUTION_TIMEOUT";
+      error.statusCode = 504;
+      reject(error);
+    }, timeoutMs);
+    timeout.unref?.();
+  });
+
+  return Promise.race([
+    Promise.resolve().then(() => operation({
+      deadlineAt,
+      signal: abortController.signal,
+    })),
+    deadline,
+  ])
+    .finally(() => clearTimeout(timeout));
+}
+
+module.exports = {
+  DEFAULT_DATA_API_LIMITS,
+  getDataApiLimits,
+  positiveInteger,
+  withExecutionDeadline,
+};

--- a/server/modules/dataApiMetrics.js
+++ b/server/modules/dataApiMetrics.js
@@ -1,0 +1,28 @@
+const counters = new Map();
+
+function metricKey(name, labels = {}) {
+  const normalizedLabels = Object.keys(labels).sort().reduce((result, key) => {
+    result[key] = labels[key];
+    return result;
+  }, {});
+  return `${name}:${JSON.stringify(normalizedLabels)}`;
+}
+
+function incrementDataApiMetric(name, labels = {}, amount = 1) {
+  const key = metricKey(name, labels);
+  counters.set(key, (counters.get(key) || 0) + amount);
+}
+
+function getDataApiMetrics() {
+  return Object.fromEntries(counters.entries());
+}
+
+function resetDataApiMetrics() {
+  counters.clear();
+}
+
+module.exports = {
+  getDataApiMetrics,
+  incrementDataApiMetric,
+  resetDataApiMetrics,
+};

--- a/server/modules/dataApiResponse.js
+++ b/server/modules/dataApiResponse.js
@@ -1,0 +1,122 @@
+const { randomUUID } = require("crypto");
+
+const { getDataApiLimits } = require("./dataApiLimits");
+
+const ERROR_MESSAGES = Object.freeze({
+  API_KEY_INVALID: "The API key is not valid.",
+  API_KEY_REQUIRED: "A valid API key is required.",
+  API_KEY_SCOPE_REQUIRED: "The API key does not have the required permission.",
+  DATA_UNAVAILABLE: "The requested data is not available.",
+  EXECUTION_TIMEOUT: "The request exceeded the execution time limit.",
+  INTERNAL_ERROR: "The request could not be completed.",
+  INVALID_FILTER: "One or more filters are not valid.",
+  INVALID_REQUEST: "The request is not valid.",
+  INVALID_VARIABLE: "One or more variables are not valid.",
+  NOT_ACCEPTABLE: "This endpoint returns JSON.",
+  RATE_LIMITED: "Too many requests were sent. Try again later.",
+  REQUEST_TOO_LARGE: "The request body is too large.",
+  RESOURCE_NOT_FOUND: "The requested resource was not found.",
+  RESPONSE_TOO_LARGE: "The response is too large.",
+  UNSUPPORTED_MEDIA_TYPE: "Use application/json for this request.",
+});
+
+const ERROR_STATUS = Object.freeze({
+  API_KEY_INVALID: 401,
+  API_KEY_REQUIRED: 401,
+  API_KEY_SCOPE_REQUIRED: 403,
+  DATA_UNAVAILABLE: 503,
+  EXECUTION_TIMEOUT: 504,
+  INTERNAL_ERROR: 500,
+  INVALID_FILTER: 400,
+  INVALID_REQUEST: 400,
+  INVALID_VARIABLE: 400,
+  NOT_ACCEPTABLE: 406,
+  RATE_LIMITED: 429,
+  REQUEST_TOO_LARGE: 413,
+  RESOURCE_NOT_FOUND: 404,
+  RESPONSE_TOO_LARGE: 413,
+  UNSUPPORTED_MEDIA_TYPE: 415,
+});
+
+class DataApiError extends Error {
+  constructor(code, options = {}) {
+    super(ERROR_MESSAGES[code] || ERROR_MESSAGES.INTERNAL_ERROR);
+    this.code = ERROR_MESSAGES[code] ? code : "INTERNAL_ERROR";
+    this.statusCode = options.statusCode || ERROR_STATUS[this.code];
+    this.cause = options.cause;
+  }
+}
+
+function ensureRequestId(req) {
+  if (!req.id) req.id = randomUUID();
+  return req.id;
+}
+
+function errorBody(req, code) {
+  const safeCode = ERROR_MESSAGES[code] ? code : "INTERNAL_ERROR";
+  return {
+    error: {
+      code: safeCode,
+      message: ERROR_MESSAGES[safeCode],
+      requestId: ensureRequestId(req),
+    },
+  };
+}
+
+function sendDataApiError(req, res, error) {
+  const code = ERROR_MESSAGES[error?.code] ? error.code : "INTERNAL_ERROR";
+  const status = error?.statusCode || ERROR_STATUS[code];
+  res.set("Cache-Control", "private, no-store");
+  res.vary("Authorization");
+  return res.status(status).json(errorBody(req, code));
+}
+
+function acceptsJson(req) {
+  const accept = req.get?.("accept") || req.headers?.accept;
+  if (!accept || accept === "*/*") return true;
+  return accept.split(",").some((value) => {
+    const [mediaType, ...parameters] = value.trim().split(";");
+    const quality = parameters.find((parameter) => parameter.trim().startsWith("q="));
+    if (quality && Number(quality.trim().slice(2)) === 0) return false;
+    return mediaType === "*/*" || mediaType === "application/json" || mediaType.endsWith("+json");
+  });
+}
+
+function matchesEtag(header, etag) {
+  if (!header || !etag) return false;
+  return header.split(",").map((value) => value.trim()).some((value) => {
+    return value === "*" || value === etag || value.replace(/^W\//, "") === etag;
+  });
+}
+
+function serializeDataApiResponse(value, options = {}) {
+  const serialized = JSON.stringify(value);
+  const bytes = Buffer.byteLength(serialized, "utf8");
+  const maxBytes = options.maxBytes || getDataApiLimits().maxResponseBytes;
+  if (bytes > maxBytes) throw new DataApiError("RESPONSE_TOO_LARGE");
+  return { bytes, serialized };
+}
+
+function setDataHeaders(res, options = {}) {
+  res.set("Cache-Control", options.cacheable ? "private, no-cache" : "private, no-store");
+  res.vary("Authorization");
+  res.set("X-Chartbrew-Data-Stale", options.stale ? "true" : "false");
+  if (options.etag && options.cacheable) res.set("ETag", options.etag);
+  if (options.generatedAt) {
+    const date = new Date(options.generatedAt);
+    if (!Number.isNaN(date.getTime())) res.set("Last-Modified", date.toUTCString());
+  }
+}
+
+module.exports = {
+  DataApiError,
+  ERROR_MESSAGES,
+  ERROR_STATUS,
+  acceptsJson,
+  ensureRequestId,
+  errorBody,
+  matchesEtag,
+  sendDataApiError,
+  serializeDataApiResponse,
+  setDataHeaders,
+};

--- a/server/modules/dataApiValidation.js
+++ b/server/modules/dataApiValidation.js
@@ -1,0 +1,195 @@
+const moment = require("moment-timezone");
+
+const { getDataApiLimits } = require("./dataApiLimits");
+const { DataApiError } = require("./dataApiResponse");
+
+const FIELD_OPERATORS = new Set([
+  "is", "isNot", "contains", "notContains", "greaterThan", "greaterOrEqual",
+  "lessThan", "lessOrEqual", "isNull", "isNotNull",
+]);
+const CLIENT_ONLY_TYPES = new Set([
+  "pagination", "page", "sort", "localSort", "local_sort", "display", "view",
+  "columnToggle", "column_toggle",
+]);
+const FIELD_FILTER_KEYS = new Set([
+  "type", "field", "operator", "value", "scope", "cdcId", "forceSourceRefresh",
+]);
+const DATE_FILTER_KEYS = new Set([
+  "type", "startDate", "endDate", "scope",
+]);
+const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function parseDataApiId(value) {
+  if (typeof value !== "string" || !/^[1-9]\d*$/.test(value)) {
+    throw new DataApiError("INVALID_REQUEST");
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new DataApiError("INVALID_REQUEST");
+  return parsed;
+}
+
+function stringWithinLimit(value, maxBytes) {
+  return typeof value === "string" && Buffer.byteLength(value, "utf8") <= maxBytes;
+}
+
+function validateJsonValue(value, limits, depth = 0, ancestors = new Set()) {
+  if (depth > limits.maxValueDepth) return false;
+  if (value === null || ["boolean", "number"].includes(typeof value)) {
+    return typeof value !== "number" || Number.isFinite(value);
+  }
+  if (typeof value === "string") return stringWithinLimit(value, limits.maxStringBytes);
+  if (typeof value !== "object") return false;
+  if (ancestors.has(value)) return false;
+
+  const nextAncestors = new Set(ancestors);
+  nextAncestors.add(value);
+  if (Array.isArray(value)) {
+    return value.every((item) => validateJsonValue(item, limits, depth + 1, nextAncestors));
+  }
+  if (Object.getPrototypeOf(value) !== Object.prototype) return false;
+  return Object.entries(value).every(([key, item]) => {
+    return key.length > 0
+      && !UNSAFE_OBJECT_KEYS.has(key)
+      && stringWithinLimit(key, limits.maxStringBytes)
+      && validateJsonValue(item, limits, depth + 1, nextAncestors);
+  });
+}
+
+function validateVariables(variables, limits) {
+  if (!variables || typeof variables !== "object" || Array.isArray(variables)) {
+    throw new DataApiError("INVALID_VARIABLE");
+  }
+  const entries = Object.entries(variables);
+  if (entries.length > limits.maxVariables) throw new DataApiError("INVALID_VARIABLE");
+  entries.forEach(([key, value]) => {
+    if (!key || UNSAFE_OBJECT_KEYS.has(key) || !stringWithinLimit(key, limits.maxStringBytes)
+      || !validateJsonValue(value, limits)) {
+      throw new DataApiError("INVALID_VARIABLE");
+    }
+  });
+}
+
+function rejectUnknownKeys(value, allowed, code) {
+  if (Object.keys(value).some((key) => !allowed.has(key))) throw new DataApiError(code);
+}
+
+function validateFieldFilter(filter, limits) {
+  rejectUnknownKeys(filter, FIELD_FILTER_KEYS, "INVALID_FILTER");
+  if ((filter.type !== undefined && filter.type !== "field") || CLIENT_ONLY_TYPES.has(filter.type)
+    || typeof filter.field !== "string" || !filter.field
+    || !stringWithinLimit(filter.field, limits.maxStringBytes)
+    || !FIELD_OPERATORS.has(filter.operator)
+    || !stringWithinLimit(filter.operator, limits.maxStringBytes)) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+  if (filter.forceSourceRefresh !== undefined
+    && typeof filter.forceSourceRefresh !== "boolean") {
+    throw new DataApiError("INVALID_FILTER");
+  }
+  if (!["isNull", "isNotNull"].includes(filter.operator)
+    && !Object.hasOwn(filter, "value")) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+  if (Object.hasOwn(filter, "value") && !validateJsonValue(filter.value, limits)) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+  if (filter.scope !== undefined && !["chart", "cdc"].includes(filter.scope)) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+}
+
+function validateDateFilter(filter, limits) {
+  rejectUnknownKeys(filter, DATE_FILTER_KEYS, "INVALID_FILTER");
+  if ((filter.scope !== undefined && filter.scope !== "chart")
+    || !stringWithinLimit(filter.startDate, limits.maxStringBytes)
+    || !stringWithinLimit(filter.endDate, limits.maxStringBytes)) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+  const startMoment = moment(filter.startDate, moment.ISO_8601, true);
+  const endMoment = moment(filter.endDate, moment.ISO_8601, true);
+  if (!startMoment.isValid() || !endMoment.isValid() || startMoment.isAfter(endMoment)) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+}
+
+function validateFilters(filters, options, limits) {
+  if (!Array.isArray(filters) || filters.length > limits.maxFilters) {
+    throw new DataApiError("INVALID_FILTER");
+  }
+  const cdcIds = new Set((options.cdcIds || []).map((id) => `${id}`));
+  const schemaFields = options.schemaFields ? new Set(options.schemaFields) : null;
+
+  filters.forEach((filter) => {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      throw new DataApiError("INVALID_FILTER");
+    }
+    if (filter.type === "date") {
+      if (options.resourceType !== "chart") throw new DataApiError("INVALID_FILTER");
+      validateDateFilter(filter, limits);
+      return;
+    }
+    validateFieldFilter(filter, limits);
+    if (options.resourceType === "dataset") {
+      if (filter.scope === "cdc" || filter.cdcId !== undefined) {
+        throw new DataApiError("INVALID_FILTER");
+      }
+      if ((filter.field.match(/\[\]/g) || []).length !== 1
+        || !/^root(?:\[\]|\.)/.test(filter.field)) {
+        throw new DataApiError("INVALID_FILTER");
+      }
+      if (schemaFields && schemaFields.size > 0 && !schemaFields.has(filter.field)) {
+        throw new DataApiError("INVALID_FILTER");
+      }
+      return;
+    }
+    if (filter.scope === "cdc") {
+      if (filter.cdcId === undefined || !cdcIds.has(`${filter.cdcId}`)) {
+        throw new DataApiError("INVALID_FILTER");
+      }
+    } else if (filter.cdcId !== undefined) {
+      throw new DataApiError("INVALID_FILTER");
+    }
+  });
+}
+
+function validatePostBody(body, options = {}) {
+  const limits = options.limits || getDataApiLimits();
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new DataApiError("INVALID_REQUEST");
+  }
+  const allowed = options.resourceType === "dataset"
+    ? new Set(["variables", "filters", "refresh", "timezone"])
+    : new Set(["variables", "filters", "refresh"]);
+  rejectUnknownKeys(body, allowed, "INVALID_REQUEST");
+
+  const request = {
+    filters: body.filters === undefined ? [] : body.filters,
+    refresh: body.refresh === undefined ? false : body.refresh,
+    variables: body.variables === undefined ? {} : body.variables,
+  };
+  if (typeof request.refresh !== "boolean") throw new DataApiError("INVALID_REQUEST");
+  validateVariables(request.variables, limits);
+  validateFilters(request.filters, options, limits);
+
+  if (options.resourceType === "dataset") {
+    request.timezone = body.timezone === undefined ? "UTC" : body.timezone;
+    if (typeof request.timezone !== "string" || !moment.tz.zone(request.timezone)) {
+      throw new DataApiError("INVALID_REQUEST");
+    }
+  }
+  return request;
+}
+
+function requiresRefreshScope(request) {
+  return request.refresh
+    || Object.keys(request.variables || {}).length > 0
+    || (request.filters || []).some((filter) => filter.type === "date" || filter.forceSourceRefresh);
+}
+
+module.exports = {
+  FIELD_OPERATORS,
+  parseDataApiId,
+  requiresRefreshScope,
+  validateJsonValue,
+  validatePostBody,
+};

--- a/server/modules/datasetData.js
+++ b/server/modules/datasetData.js
@@ -1,0 +1,75 @@
+const crypto = require("crypto");
+
+const { discoverDatasetFieldsSchema } = require("./datasetSchema");
+const { toJsonValue } = require("../visualization/preparedData");
+
+const DATASET_DATA_VERSION = 1;
+const FIELD_TYPES = new Set(["number", "date", "string", "boolean", "array", "object", "unknown"]);
+
+function unwrapModelValues(value, ancestors = new Set()) {
+  if (!value || typeof value !== "object" || value instanceof Date) return value;
+  if (ancestors.has(value)) return undefined;
+  const nextAncestors = new Set(ancestors);
+  nextAncestors.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => unwrapModelValues(item, nextAncestors));
+  }
+
+  const source = value.dataValues && typeof value.toJSON === "function" ? value.toJSON() : value;
+  return Object.keys(source).reduce((result, key) => {
+    const item = unwrapModelValues(source[key], nextAncestors);
+    if (item !== undefined) result[key] = item;
+    return result;
+  }, {});
+}
+
+function getDatasetFields(dataset, data) {
+  const storedSchema = dataset?.fieldsSchema && typeof dataset.fieldsSchema === "object"
+    ? dataset.fieldsSchema
+    : null;
+  const schema = storedSchema && Object.keys(storedSchema).length > 0
+    ? storedSchema
+    : discoverDatasetFieldsSchema(data);
+
+  return Object.entries(schema || {}).map(([key, type]) => ({
+    key,
+    type: FIELD_TYPES.has(type) ? type : "unknown",
+  })).sort((left, right) => left.key.localeCompare(right.key));
+}
+
+function createDatasetData({ dataset, data, generatedAt = new Date() }) {
+  const generatedDate = generatedAt instanceof Date ? generatedAt : new Date(generatedAt);
+  const normalizedData = unwrapModelValues(data);
+  return toJsonValue({
+    version: DATASET_DATA_VERSION,
+    generatedAt: generatedDate.toISOString(),
+    resource: {
+      kind: "dataset",
+      id: dataset.id,
+      name: dataset.name || null,
+    },
+    fields: getDatasetFields(dataset, normalizedData),
+    data: normalizedData,
+  });
+}
+
+function serializeDatasetData(datasetData, options = {}) {
+  const value = { ...datasetData };
+  if (options.includeGeneratedAt === false) delete value.generatedAt;
+  return JSON.stringify(toJsonValue(value));
+}
+
+function getDatasetDataFingerprint(datasetData) {
+  return crypto.createHash("sha256")
+    .update(serializeDatasetData(datasetData, { includeGeneratedAt: false }))
+    .digest("hex");
+}
+
+module.exports = {
+  DATASET_DATA_VERSION,
+  createDatasetData,
+  getDatasetDataFingerprint,
+  getDatasetFields,
+  serializeDatasetData,
+  unwrapModelValues,
+};

--- a/server/modules/updateAudit.js
+++ b/server/modules/updateAudit.js
@@ -286,6 +286,7 @@ function cloneTraceContext(traceContext = {}) {
     datasetId: sourceTraceContext.datasetId || null,
     dataRequestId: sourceTraceContext.dataRequestId || null,
     connectionId: sourceTraceContext.connectionId || null,
+    apiKeyId: sourceTraceContext.apiKeyId || null,
     queueName: sourceTraceContext.queueName || null,
     jobId: sourceTraceContext.jobId || null,
     startedAt: hydrateDate(sourceTraceContext.startedAt),
@@ -342,6 +343,7 @@ async function startRun(payload = {}, parentTraceContext = null) {
     connectionId: payload.connectionId !== undefined
       ? payload.connectionId
       : baseContext.connectionId,
+    apiKeyId: payload.apiKeyId !== undefined ? payload.apiKeyId : baseContext.apiKeyId,
     queueName: payload.queueName !== undefined ? payload.queueName : baseContext.queueName,
     jobId: payload.jobId !== undefined ? payload.jobId : baseContext.jobId,
     nextSequence: 1,
@@ -360,6 +362,7 @@ async function startRun(payload = {}, parentTraceContext = null) {
     datasetId: context.datasetId,
     dataRequestId: context.dataRequestId,
     connectionId: context.connectionId,
+    apiKeyId: context.apiKeyId,
     queueName: context.queueName,
     jobId: context.jobId,
     status: payload.status || "running",
@@ -390,6 +393,7 @@ async function startRun(payload = {}, parentTraceContext = null) {
     datasetId: context.datasetId,
     dataRequestId: context.dataRequestId,
     connectionId: context.connectionId,
+    apiKeyId: context.apiKeyId,
     queueName: context.queueName,
     jobId: context.jobId,
     summary: createValues.summary,

--- a/server/modules/verifyDataApiKey.js
+++ b/server/modules/verifyDataApiKey.js
@@ -1,0 +1,158 @@
+const { createHash, timingSafeEqual } = require("crypto");
+const { Op } = require("sequelize");
+
+const db = require("../models/models");
+const TeamController = require("../controllers/TeamController");
+const { buildDataApiAccess, normalizeScopes } = require("./dataApiAccess");
+const { incrementDataApiMetric } = require("./dataApiMetrics");
+const { DataApiError, sendDataApiError } = require("./dataApiResponse");
+const verifySessionToken = require("./verifySessionToken");
+
+const LAST_USED_WRITE_INTERVAL_MS = 5 * 60 * 1000;
+const teamController = new TeamController();
+
+function dataApiError(req, res, code) {
+  const ipKey = createHash("sha256").update(String(req.ip || "unknown")).digest("hex").slice(0, 16);
+  incrementDataApiMetric("authorization_failures", { code });
+  console.warn("[data-api] authorization_failed", { // oxlint-disable-line no-console
+    code,
+    ipKey,
+    requestId: req.id,
+  });
+  return sendDataApiError(req, res, new DataApiError(code));
+}
+
+function readBearerToken(req) {
+  const authorizationHeaders = [];
+  for (let index = 0; index < (req.rawHeaders || []).length; index += 2) {
+    if (String(req.rawHeaders[index]).toLowerCase() === "authorization") {
+      authorizationHeaders.push(req.rawHeaders[index + 1]);
+    }
+  }
+
+  if (authorizationHeaders.length > 1) return null;
+
+  const authorization = authorizationHeaders[0] || req.headers?.authorization;
+  if (typeof authorization !== "string") return null;
+
+  const match = authorization.match(/^Bearer ([^\s,]+)$/i);
+  return match ? match[1] : null;
+}
+
+function hasRequiredClaims(decoded) {
+  return decoded?.tokenType === "api_key"
+    && typeof decoded.apiKeyId === "string"
+    && decoded.apiKeyId.length > 0
+    && Number.isInteger(Number(decoded.teamId))
+    && Number.isInteger(Number(decoded.id));
+}
+
+function tokenDigest(token) {
+  return createHash("sha256").update(String(token)).digest();
+}
+
+function tokensMatch(suppliedToken, storedToken) {
+  if (typeof suppliedToken !== "string" || typeof storedToken !== "string") return false;
+  return timingSafeEqual(tokenDigest(suppliedToken), tokenDigest(storedToken));
+}
+
+async function updateLastUsed(apiKey) {
+  const lastUsedAt = apiKey.last_used_at ? new Date(apiKey.last_used_at).getTime() : 0;
+  if (Date.now() - lastUsedAt < LAST_USED_WRITE_INTERVAL_MS) return;
+
+  try {
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - LAST_USED_WRITE_INTERVAL_MS);
+    await db.Apikey.update({ last_used_at: now }, {
+      where: {
+        id: apiKey.id,
+        [Op.or]: [
+          { last_used_at: null },
+          { last_used_at: { [Op.lte]: cutoff } },
+        ],
+      },
+    });
+  } catch (error) {
+    // Authentication must not fail because a usage timestamp could not be stored.
+  }
+}
+
+function verifyDataApiKey(requiredScope = "data:read") {
+  return async (req, res, next) => {
+    const token = readBearerToken(req);
+    if (!token) {
+      return dataApiError(req, res, "API_KEY_REQUIRED");
+    }
+
+    let decoded;
+    try {
+      decoded = verifySessionToken(token);
+    } catch (error) {
+      return dataApiError(req, res, "API_KEY_INVALID");
+    }
+
+    if (!hasRequiredClaims(decoded)) {
+      return dataApiError(req, res, "API_KEY_INVALID");
+    }
+
+    try {
+      const apiKey = await db.Apikey.findOne({
+        attributes: [
+          "id", "token", "team_id", "user_id", "scopes", "project_ids", "all_projects",
+          "last_used_at",
+        ],
+        where: { id: decoded.apiKeyId },
+      });
+
+      if (!apiKey || !tokensMatch(token, apiKey.token)) {
+        return dataApiError(req, res, "API_KEY_INVALID");
+      }
+
+      if (
+        Number(decoded.id) !== apiKey.user_id
+        || Number(decoded.teamId) !== apiKey.team_id
+        || !apiKey.user_id
+      ) {
+        return dataApiError(req, res, "API_KEY_INVALID");
+      }
+
+      const blacklisted = await db.TokenBlacklist.findOne({
+        attributes: ["id"],
+        where: { token },
+      });
+      if (blacklisted) {
+        return dataApiError(req, res, "API_KEY_INVALID");
+      }
+
+      if (!normalizeScopes(apiKey.scopes).includes(requiredScope)) {
+        return dataApiError(req, res, "API_KEY_SCOPE_REQUIRED");
+      }
+
+      const [user, teamRole] = await Promise.all([
+        db.User.findOne({ attributes: ["id", "active"], where: { id: apiKey.user_id } }),
+        teamController.getTeamRole(apiKey.team_id, apiKey.user_id),
+      ]);
+
+      if (!user || user.active === false || !teamRole) {
+        return dataApiError(req, res, "API_KEY_INVALID");
+      }
+
+      const access = await buildDataApiAccess(db, apiKey, teamRole);
+      if (!access.role || !["teamOwner", "teamAdmin", "projectAdmin", "projectEditor", "projectViewer"].includes(access.role)) {
+        return dataApiError(req, res, "API_KEY_INVALID");
+      }
+
+      req.apiKeyAccess = access;
+      await updateLastUsed(apiKey);
+      return next();
+    } catch (error) {
+      return dataApiError(req, res, "API_KEY_INVALID");
+    }
+  };
+}
+
+verifyDataApiKey.hasRequiredClaims = hasRequiredClaims;
+verifyDataApiKey.readBearerToken = readBearerToken;
+verifyDataApiKey.tokensMatch = tokensMatch;
+
+module.exports = verifyDataApiKey;

--- a/server/sources/shared/connectorRuntime.js
+++ b/server/sources/shared/connectorRuntime.js
@@ -7,6 +7,42 @@ const {
   finishEvent,
 } = require("../../modules/updateAudit");
 
+const SENSITIVE_AUDIT_FIELDS = new Set([
+  "bodySnippet",
+  "filters",
+  "headerNames",
+  "queryHash",
+  "queryPreview",
+  "responseSnippet",
+  "routeHash",
+  "routeSnippet",
+  "variables",
+]);
+
+function buildConnectorAuditPayload(auditContext, payload = {}) {
+  const mergedPayload = {
+    ...(auditContext?.requestMetadata || {}),
+    ...payload,
+  };
+  if (!auditContext?.redactSensitivePayload) return mergedPayload;
+
+  return Object.entries(mergedPayload).reduce((safePayload, [key, value]) => {
+    if (!SENSITIVE_AUDIT_FIELDS.has(key)) safePayload[key] = value;
+    return safePayload;
+  }, {});
+}
+
+function getConnectorAuditError(auditContext, error, stage) {
+  const wrappedError = error instanceof Error ? error : new Error(String(error));
+  wrappedError.auditStage = wrappedError.auditStage || stage;
+  if (!auditContext?.redactSensitivePayload) return wrappedError;
+
+  const safeError = new Error("The data source request failed.");
+  safeError.code = "DATA_UNAVAILABLE";
+  safeError.auditStage = wrappedError.auditStage;
+  return safeError;
+}
+
 async function checkAndGetCache(connectionId, dataRequest) {
   try {
     const drCache = await drCacheController.findLast(dataRequest.id);
@@ -38,10 +74,10 @@ async function completeConnectorAudit(auditContext, payload = {}, summary = null
     return;
   }
 
-  const finalPayload = {
-    ...(auditContext.requestMetadata || {}),
-    ...payload,
-  };
+  const finalPayload = buildConnectorAuditPayload(auditContext, payload);
+  const finalSummary = summary
+    ? buildConnectorAuditPayload(auditContext, summary)
+    : finalPayload;
 
   if (auditContext.requestEvent) {
     await finishEvent(auditContext.traceContext, auditContext.requestEvent, "success", finalPayload);
@@ -50,7 +86,7 @@ async function completeConnectorAudit(auditContext, payload = {}, summary = null
   await completeRun(auditContext.traceContext, {
     status: "success",
     payload: finalPayload,
-    summary: summary || finalPayload,
+    summary: finalSummary,
   });
 }
 
@@ -61,21 +97,18 @@ async function failConnectorAudit(auditContext, error, stage = "connection", pay
 
   const wrappedError = error instanceof Error ? error : new Error(String(error));
   wrappedError.auditStage = wrappedError.auditStage || stage;
-
-  const finalPayload = {
-    ...(auditContext.requestMetadata || {}),
-    ...payload,
-  };
+  const auditError = getConnectorAuditError(auditContext, wrappedError, stage);
+  const finalPayload = buildConnectorAuditPayload(auditContext, payload);
 
   if (auditContext.requestEvent) {
     await finishEvent(auditContext.traceContext, auditContext.requestEvent, "failed", {
       ...finalPayload,
-      errorMessage: wrappedError.message,
+      errorMessage: auditError.message,
     });
   }
 
-  await failRun(auditContext.traceContext, wrappedError, {
-    stage: wrappedError.auditStage || stage,
+  await failRun(auditContext.traceContext, auditError, {
+    stage: auditError.auditStage || stage,
     payload: finalPayload,
     summary: finalPayload,
   });
@@ -84,7 +117,9 @@ async function failConnectorAudit(auditContext, error, stage = "connection", pay
 }
 
 module.exports = {
+  buildConnectorAuditPayload,
   checkAndGetCache,
   completeConnectorAudit,
   failConnectorAudit,
+  getConnectorAuditError,
 };

--- a/server/tests/integration/dataApiKeySecurity.test.js
+++ b/server/tests/integration/dataApiKeySecurity.test.js
@@ -1,0 +1,295 @@
+import express from "express";
+import { createRequire } from "module";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import {
+  beforeAll, beforeEach, describe, expect, it,
+} from "vitest";
+
+import { getModels } from "../helpers/dbHelpers.js";
+import { testDbManager } from "../helpers/testDbManager.js";
+
+const require = createRequire(import.meta.url);
+
+describe("Data API key security", () => {
+  let app;
+  let db;
+  let settings;
+  let TeamController;
+
+  beforeAll(async () => {
+    if (!testDbManager.getSequelize()) await testDbManager.start();
+    db = await getModels();
+    settings = require("../../settings-dev.js");
+    TeamController = require("../../controllers/TeamController.js");
+  });
+
+  beforeEach(async () => {
+    await db.sequelize.sync({ force: true });
+
+    app = express();
+    app.use(express.json());
+    const verifyDataApiKey = require("../../modules/verifyDataApiKey.js");
+    app.get("/protected", verifyDataApiKey("data:read"), (req, res) => {
+      return res.json(req.apiKeyAccess);
+    });
+  });
+
+  async function createFixture({
+    role = "teamOwner",
+    roleProjects,
+    allProjects = false,
+    keyProjects,
+    scopes = ["data:read"],
+  } = {}) {
+    const team = await db.Team.create({ name: "Team" });
+    const user = await db.User.create({
+      name: "Key owner",
+      email: `owner-${Date.now()}-${Math.random()}@example.com`,
+      password: "password",
+      active: true,
+      tutorials: {},
+    });
+    const firstProject = await db.Project.create({
+      team_id: team.id,
+      name: "First",
+      brewName: `first-${Date.now()}-${Math.random()}`,
+    });
+    const secondProject = await db.Project.create({
+      team_id: team.id,
+      name: "Second",
+      brewName: `second-${Date.now()}-${Math.random()}`,
+    });
+    await db.TeamRole.create({
+      team_id: team.id,
+      user_id: user.id,
+      role,
+      projects: roleProjects || [firstProject.id],
+    });
+
+    const controller = new TeamController();
+    const createdKey = await controller.createApiKey(team.id, user, {
+      name: "Data key",
+      scopes,
+      allProjects,
+      projectIds: keyProjects || (allProjects ? [] : [firstProject.id]),
+    });
+
+    return {
+      createdKey, firstProject, secondProject, team, user,
+    };
+  }
+
+  it.each([
+    ["teamOwner", ["first"]],
+    ["teamAdmin", ["first"]],
+    ["projectAdmin", ["first"]],
+    ["projectEditor", ["first"]],
+    ["projectViewer", ["first"]],
+  ])("applies stored project restrictions for %s", async (role, expectedNames) => {
+    const fixture = await createFixture({ role });
+
+    const response = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${fixture.createdKey.token}`);
+
+    const projectNames = response.body.projectIds.map((id) => {
+      if (id === fixture.firstProject.id) return "first";
+      if (id === fixture.secondProject.id) return "second";
+      return "unknown";
+    });
+    expect(response.status).toBe(200);
+    expect(projectNames).toEqual(expectedNames);
+    expect(response.body.role).toBe(role);
+    expect(response.body).not.toHaveProperty("token");
+  });
+
+  it.each([
+    ["teamOwner", 2],
+    ["teamAdmin", 2],
+    ["projectAdmin", 1],
+    ["projectEditor", 1],
+    ["projectViewer", 1],
+  ])("uses current role access for an all-project %s key", async (role, expectedCount) => {
+    const fixture = await createFixture({ role, allProjects: true });
+
+    const response = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${fixture.createdKey.token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.projectIds).toHaveLength(expectedCount);
+  });
+
+  it("rejects legacy and session-style tokens", async () => {
+    const team = await db.Team.create({ name: "Team" });
+    const user = await db.User.create({
+      name: "Legacy owner",
+      email: "legacy@example.com",
+      password: "password",
+      active: true,
+      tutorials: {},
+    });
+    await db.TeamRole.create({ team_id: team.id, user_id: user.id, role: "teamOwner" });
+    const controller = new TeamController();
+    const legacyKey = await controller.createApiKey(team.id, user, { name: "Legacy key" });
+    const sessionToken = jwt.sign({ id: user.id }, settings.encryptionKey);
+
+    for (const token of [legacyKey.token, sessionToken]) {
+      const response = await request(app).get("/protected").set("Authorization", `Bearer ${token}`);
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("API_KEY_INVALID");
+    }
+  });
+
+  it("rejects deleted, blacklisted, and cross-team key records", async () => {
+    const deleted = await createFixture();
+    await db.Apikey.destroy({ where: { id: deleted.createdKey.id } });
+
+    const blacklisted = await createFixture();
+    await db.TokenBlacklist.create({ token: blacklisted.createdKey.token });
+
+    const crossTeam = await createFixture();
+    const otherTeam = await db.Team.create({ name: "Other team" });
+    await db.Apikey.update({ team_id: otherTeam.id }, { where: { id: crossTeam.createdKey.id } });
+
+    for (const token of [deleted.createdKey.token, blacklisted.createdKey.token, crossTeam.createdKey.token]) {
+      const response = await request(app).get("/protected").set("Authorization", `Bearer ${token}`);
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe("API_KEY_INVALID");
+    }
+  });
+
+  it("rejects a key when its owner no longer has a team role", async () => {
+    const fixture = await createFixture();
+    await db.TeamRole.destroy({ where: { team_id: fixture.team.id, user_id: fixture.user.id } });
+
+    const response = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${fixture.createdKey.token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe("API_KEY_INVALID");
+  });
+
+  it("rejects disabled users and keys without the required scope", async () => {
+    const disabled = await createFixture();
+    await db.User.update({ active: false }, { where: { id: disabled.user.id } });
+
+    const missingScope = await createFixture();
+    await db.Apikey.update({ scopes: [] }, { where: { id: missingScope.createdKey.id } });
+
+    const disabledResponse = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${disabled.createdKey.token}`);
+    const scopeResponse = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${missingScope.createdKey.token}`);
+
+    expect(disabledResponse.status).toBe(401);
+    expect(disabledResponse.body.error.code).toBe("API_KEY_INVALID");
+    expect(scopeResponse.status).toBe(403);
+    expect(scopeResponse.body.error.code).toBe("API_KEY_SCOPE_REQUIRED");
+  });
+
+  it("rejects share-style tokens", async () => {
+    const fixture = await createFixture();
+    const shareToken = jwt.sign({
+      id: fixture.user.id,
+      teamId: fixture.team.id,
+      tokenType: "share",
+    }, settings.encryptionKey);
+
+    const response = await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${shareToken}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe("API_KEY_INVALID");
+  });
+
+  it("creates and lists scoped keys through the key-management API", async () => {
+    const fixture = await createFixture();
+    const managementApp = express();
+    managementApp.use(express.json());
+    require("../../api/TeamRoute.js")(managementApp);
+    const sessionToken = jwt.sign({
+      id: fixture.user.id,
+      email: fixture.user.email,
+    }, settings.encryptionKey);
+
+    const createResponse = await request(managementApp)
+      .post(`/team/${fixture.team.id}/apikey`)
+      .set("Authorization", `Bearer ${sessionToken}`)
+      .send({
+        name: "Management API key",
+        scopes: ["data:read", "data:refresh"],
+        allProjects: false,
+        projectIds: [fixture.firstProject.id],
+      });
+
+    expect(createResponse.status).toBe(200);
+    expect(jwt.verify(createResponse.body.token, settings.encryptionKey)).toMatchObject({
+      id: fixture.user.id,
+      apiKeyId: createResponse.body.id,
+      teamId: fixture.team.id,
+      tokenType: "api_key",
+    });
+
+    const listResponse = await request(managementApp)
+      .get(`/team/${fixture.team.id}/apikey`)
+      .set("Authorization", `Bearer ${sessionToken}`);
+    const listItem = listResponse.body.find((key) => key.id === createResponse.body.id);
+
+    expect(listResponse.status).toBe(200);
+    expect(listItem).toMatchObject({
+      dataApiAccess: "ready",
+      permissions: ["data:read", "data:refresh"],
+      projectAccess: {
+        allProjects: false,
+        projectIds: [fixture.firstProject.id],
+      },
+    });
+    expect(listItem).not.toHaveProperty("token");
+  });
+
+  it("tracks successful use without writing again inside five minutes", async () => {
+    const fixture = await createFixture();
+
+    await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${fixture.createdKey.token}`)
+      .expect(200);
+    const firstUse = await db.Apikey.findByPk(fixture.createdKey.id);
+
+    await request(app)
+      .get("/protected")
+      .set("Authorization", `Bearer ${fixture.createdKey.token}`)
+      .expect(200);
+    const secondUse = await db.Apikey.findByPk(fixture.createdKey.id);
+
+    expect(firstUse.last_used_at).not.toBeNull();
+    expect(secondUse.last_used_at.getTime()).toBe(firstUse.last_used_at.getTime());
+  });
+
+  it("lists legacy keys without tokens and does not revoke them when a new scoped key is created", async () => {
+    const fixture = await createFixture();
+    const controller = new TeamController();
+    const legacyKey = await controller.createApiKey(fixture.team.id, fixture.user, { name: "Legacy key" });
+    const newScopedKey = await controller.createApiKey(fixture.team.id, fixture.user, {
+      name: legacyKey.name,
+      scopes: ["data:read"],
+      allProjects: false,
+      projectIds: [fixture.firstProject.id],
+    });
+
+    const keys = await controller.getApiKeys(fixture.team.id);
+    const legacyListItem = keys.find((key) => key.id === legacyKey.id);
+    const scopedListItem = keys.find((key) => key.id === newScopedKey.id);
+
+    expect(legacyListItem.dataApiAccess).toBe("unavailable");
+    expect(legacyListItem).not.toHaveProperty("token");
+    expect(scopedListItem.dataApiAccess).toBe("ready");
+    expect(await db.Apikey.findByPk(legacyKey.id)).not.toBeNull();
+  });
+});

--- a/server/tests/integration/dataApiRoute.test.js
+++ b/server/tests/integration/dataApiRoute.test.js
@@ -1,0 +1,748 @@
+import express from "express";
+import { createRequire } from "module";
+import request from "supertest";
+import {
+  afterEach, beforeAll, beforeEach, describe, expect, it, vi,
+} from "vitest";
+
+import { getModels } from "../helpers/dbHelpers.js";
+import { testDbManager } from "../helpers/testDbManager.js";
+
+const require = createRequire(import.meta.url);
+
+describe("Data API routes", () => {
+  let app;
+  let db;
+  let getSourceById;
+  let runtimeCache;
+  let TeamController;
+  let VisualizationEngine;
+
+  beforeAll(async () => {
+    if (!testDbManager.getSequelize()) await testDbManager.start();
+    db = await getModels();
+    ({ getSourceById } = require("../../sources/index.js"));
+    runtimeCache = require("../../modules/runtimeCache.js");
+    TeamController = require("../../controllers/TeamController.js");
+    ({ VisualizationEngine } = require("../../visualization/VisualizationEngine.js"));
+  });
+
+  beforeEach(async () => {
+    await db.sequelize.sync({ force: true });
+    await runtimeCache.resetForTests();
+    app = express();
+    app.set("trust proxy", 1);
+    app.use(express.json({
+      verify: (req, _res, buffer, encoding) => {
+        req.rawBody = buffer.toString(encoding || "utf8");
+      },
+    }));
+    app.use(require("../../modules/dataApiBodyError.js"));
+    require("../../api/DataApiRoute.js")(app);
+  });
+
+  afterEach(() => {
+    [
+      "CB_DATA_API_AUTH_RATE_LIMIT_MAX",
+      "CB_DATA_API_ENABLED",
+      "CB_DATA_API_MAX_EXECUTION_MS",
+      "CB_DATA_API_MAX_REQUEST_BYTES",
+      "CB_DATA_API_MAX_RESPONSE_BYTES",
+      "CB_DATA_API_RATE_LIMIT_MAX",
+    ].forEach((key) => delete process.env[key]);
+  });
+
+  async function createFixture() {
+    const team = await db.Team.create({ name: "Data API Team" });
+    const user = await db.User.create({
+      active: true,
+      email: `data-api-${Date.now()}-${Math.random()}@example.com`,
+      name: "Data API owner",
+      password: "password",
+      tutorials: {},
+    });
+    const project = await db.Project.create({
+      brewName: `data-api-${Date.now()}-${Math.random()}`,
+      ghost: false,
+      name: "Data API Project",
+      team_id: team.id,
+      timezone: "Asia/Bangkok",
+    });
+    await db.TeamRole.create({
+      projects: [project.id],
+      role: "teamOwner",
+      team_id: team.id,
+      user_id: user.id,
+    });
+    const key = await new TeamController().createApiKey(team.id, user, {
+      allProjects: false,
+      name: "Data API key",
+      projectIds: [project.id],
+      scopes: ["data:read", "data:refresh"],
+    });
+    const connection = await db.Connection.create({
+      host: "localhost",
+      name: "Orders database",
+      project_ids: [project.id],
+      team_id: team.id,
+      type: "postgres",
+    });
+    const dataset = await db.Dataset.create({
+      conditions: [],
+      draft: false,
+      fieldsSchema: {
+        "root[].amount": "number",
+        "root[].customer.id": "number",
+        "root[].customer.name": "string",
+        "root[].customerId": "number",
+        "root[].month": "string",
+        "root[].status": "string",
+      },
+      name: "Orders",
+      project_ids: [project.id],
+      team_id: team.id,
+    });
+    const ordersRequest = await db.DataRequest.create({
+      connection_id: connection.id,
+      dataset_id: dataset.id,
+      query: "select customer_id, month, amount, status from orders",
+    });
+    // The current test schema has a legacy DataRequest.id -> Dataset.id constraint.
+    await db.Dataset.create({
+      draft: true,
+      name: "Join support",
+      project_ids: [project.id],
+      team_id: team.id,
+    });
+    const customersRequest = await db.DataRequest.create({
+      connection_id: connection.id,
+      dataset_id: dataset.id,
+      query: "select id, name from customers",
+    });
+    await dataset.update({
+      joinSettings: {
+        joins: [{
+          alias: "customer",
+          dr_field: "root[].customerId",
+          dr_id: ordersRequest.id,
+          join_field: "root[].id",
+          join_id: customersRequest.id,
+        }],
+      },
+      main_dr_id: ordersRequest.id,
+    });
+    const chart = await db.Chart.create({
+      draft: false,
+      name: "Order totals",
+      project_id: project.id,
+      type: "bar",
+    });
+    const cdc = await db.ChartDatasetConfig.create({
+      chart_id: chart.id,
+      conditions: [],
+      dataset_id: dataset.id,
+      legend: "Order totals",
+      xAxis: "root[].month",
+      yAxis: "root[].amount",
+      yAxisOperation: "none",
+    });
+
+    return {
+      cdc, chart, connection, customersRequest, dataset, key, ordersRequest, project, team,
+    };
+  }
+
+  function authorize(call, token) {
+    return call.set("Authorization", `Bearer ${token}`).set("Accept", "application/json");
+  }
+
+  function mockOrderSource(fixture) {
+    const orders = [
+      { customerId: 10, month: "Jan", amount: 120, status: "paid" },
+      { customerId: 11, month: "Feb", amount: 80, status: "pending" },
+      { customerId: 10, month: "Mar", amount: 140, status: "paid" },
+    ];
+    const customers = [
+      { id: 10, name: "Ada" },
+      { id: 11, name: "Lin" },
+    ];
+    return vi.spyOn(getSourceById("postgres").backend, "runDataRequest")
+      .mockImplementation(async ({ dataRequest }) => ({
+        dataRequest,
+        responseData: {
+          data: dataRequest.id === fixture.ordersRequest.id ? orders : customers,
+        },
+      }));
+  }
+
+  it("returns exact joined dataset data and applies runtime filters after the join", async () => {
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+
+    const defaultResponse = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`),
+      fixture.key.token
+    );
+    expect(defaultResponse.status).toBe(200);
+    expect(defaultResponse.body.data).toEqual([
+      {
+        customerId: 10,
+        month: "Jan",
+        amount: 120,
+        status: "paid",
+        customer: { id: 10, name: "Ada" },
+      },
+      {
+        customerId: 11,
+        month: "Feb",
+        amount: 80,
+        status: "pending",
+        customer: { id: 11, name: "Lin" },
+      },
+      {
+        customerId: 10,
+        month: "Mar",
+        amount: 140,
+        status: "paid",
+        customer: { id: 10, name: "Ada" },
+      },
+    ]);
+    expect(defaultResponse.body.resource).toEqual({
+      id: fixture.dataset.id,
+      kind: "dataset",
+      name: "Orders",
+    });
+    expect(defaultResponse.headers.etag).toMatch(/^"dd-v1-[a-f0-9]{64}"$/);
+    expect(defaultResponse.headers["x-chartbrew-data-stale"]).toBe("false");
+
+    process.env.CB_DATA_API_MAX_RESPONSE_BYTES = "20";
+    const conditionalResponse = await authorize(
+      request(app)
+        .get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`)
+        .set("If-None-Match", defaultResponse.headers.etag),
+      fixture.key.token
+    );
+    expect(conditionalResponse.status).toBe(304);
+    expect(conditionalResponse.text).toBe("");
+    delete process.env.CB_DATA_API_MAX_RESPONSE_BYTES;
+
+    const sourceCallsBeforeFilter = sourceSpy.mock.calls.length;
+    const filteredResponse = await authorize(
+      request(app)
+        .post(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`)
+        .send({
+          filters: [{
+            type: "field",
+            field: "root[].customer.name",
+            operator: "is",
+            value: "Ada",
+          }],
+          timezone: "Asia/Bangkok",
+        }),
+      fixture.key.token
+    );
+    expect(filteredResponse.status).toBe(200);
+    expect(filteredResponse.body.data).toEqual([
+      {
+        customerId: 10,
+        month: "Jan",
+        amount: 120,
+        status: "paid",
+        customer: { id: 10, name: "Ada" },
+      },
+      {
+        customerId: 10,
+        month: "Mar",
+        amount: 140,
+        status: "paid",
+        customer: { id: 10, name: "Ada" },
+      },
+    ]);
+    expect(filteredResponse.headers["cache-control"]).toBe("private, no-store");
+    sourceSpy.mock.calls.slice(sourceCallsBeforeFilter).forEach(([options]) => {
+      expect(options.filters).toEqual([]);
+    });
+
+    sourceSpy.mockClear();
+    const variableResponse = await authorize(
+      request(app)
+        .post(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`)
+        .send({ variables: { region: "APAC" } }),
+      fixture.key.token
+    );
+    expect(variableResponse.status).toBe(200);
+    const variableSourceCalls = sourceSpy.mock.calls.length;
+    const cachedVariableResponse = await authorize(
+      request(app)
+        .post(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`)
+        .send({ variables: { region: "APAC" } }),
+      fixture.key.token
+    );
+    expect(cachedVariableResponse.status).toBe(200);
+    expect(cachedVariableResponse.body.data).toEqual(variableResponse.body.data);
+    expect(sourceSpy).toHaveBeenCalledTimes(variableSourceCalls);
+    expect(sourceSpy).toHaveBeenCalled();
+    sourceSpy.mockRestore();
+  });
+
+  it("keeps dataset metadata unchanged for runtime POST requests", async () => {
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+    await fixture.dataset.update({ fieldsSchema: {} });
+
+    const response = await authorize(
+      request(app)
+        .post(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`)
+        .send({ refresh: true }),
+      fixture.key.token
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.fields.length).toBeGreaterThan(0);
+    expect((await db.Dataset.findByPk(fixture.dataset.id)).fieldsSchema).toEqual({});
+    sourceSpy.mockRestore();
+  });
+
+  it("returns exact transformed dataset data", async () => {
+    const fixture = await createFixture();
+    const transformed = await db.Dataset.create({
+      draft: false,
+      name: "Order items",
+      project_ids: [fixture.project.id],
+      team_id: fixture.team.id,
+    });
+    const dataRequest = await db.DataRequest.create({
+      connection_id: fixture.connection.id,
+      dataset_id: transformed.id,
+      query: "select orders with items",
+      transform: {
+        enabled: true,
+        type: "flattenNested",
+        config: {
+          baseArrayPath: "orders",
+          nestedArrayPath: "items",
+          outputFields: {
+            orderId: { from: "base", path: "id" },
+            sku: { from: "nested", path: "sku" },
+            quantity: { from: "nested", path: "quantity" },
+          },
+        },
+      },
+    });
+    await transformed.update({ main_dr_id: dataRequest.id });
+    const sourceSpy = vi.spyOn(getSourceById("postgres").backend, "runDataRequest")
+      .mockResolvedValue({
+        dataRequest,
+        responseData: {
+          data: {
+            orders: [
+              { id: 1, items: [{ sku: "book", quantity: 2 }, { sku: "pen", quantity: 1 }] },
+              { id: 2, items: [{ sku: "book", quantity: 3 }] },
+            ],
+          },
+        },
+      });
+
+    const response = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${transformed.id}/data`),
+      fixture.key.token
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual([
+      { orderId: 1, quantity: 2, sku: "book" },
+      { orderId: 1, quantity: 1, sku: "pen" },
+      { orderId: 2, quantity: 3, sku: "book" },
+    ]);
+    sourceSpy.mockRestore();
+  });
+
+  it("returns canonical chart rows without calling a renderer compiler", async () => {
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+    const compilerSpy = vi.spyOn(VisualizationEngine.prototype, "compilePrepared");
+
+    const response = await authorize(
+      request(app).get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`),
+      fixture.key.token
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0].rows.map(({ category, value }) => ({ category, value })))
+      .toEqual([
+        { category: "Jan", value: 120 },
+        { category: "Feb", value: 80 },
+        { category: "Mar", value: 140 },
+      ]);
+    expect(response.body).not.toHaveProperty("configuration");
+    expect(response.body).not.toHaveProperty("renderer");
+    expect(compilerSpy).not.toHaveBeenCalled();
+
+    const stored = await db.Chart.unscoped().findByPk(fixture.chart.id);
+    expect(stored.preparedData.results[0].rows).toEqual(response.body.results[0].rows);
+
+    sourceSpy.mockRejectedValue(new Error("The source is offline"));
+    const snapshotResponse = await authorize(
+      request(app)
+        .get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+        .set("If-None-Match", response.headers.etag),
+      fixture.key.token
+    );
+    expect(snapshotResponse.status).toBe(304);
+    expect(snapshotResponse.text).toBe("");
+    expect(compilerSpy).not.toHaveBeenCalled();
+
+    sourceSpy.mockClear();
+    await fixture.ordersRequest.update({
+      query: "select customer_id, month, amount, status from orders where active = true",
+    });
+    const staleResponse = await authorize(
+      request(app).get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`),
+      fixture.key.token
+    );
+    expect(staleResponse.status).toBe(200);
+    expect(staleResponse.headers["x-chartbrew-data-stale"]).toBe("true");
+    expect(staleResponse.body.results[0].rows).toEqual(response.body.results[0].rows);
+    await runtimeCache.runSingleFlight(
+      `data-api-default-refresh:${fixture.chart.id}`,
+      async () => null
+    ).catch(() => null);
+    expect(sourceSpy).toHaveBeenCalled();
+    expect(compilerSpy).not.toHaveBeenCalled();
+    compilerSpy.mockRestore();
+    sourceSpy.mockRestore();
+  });
+
+  it("returns exact runtime chart rows and keeps runtime data out of the durable snapshot", async () => {
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+    const compilerSpy = vi.spyOn(VisualizationEngine.prototype, "compilePrepared");
+
+    const response = await authorize(
+      request(app)
+        .post(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+        .send({
+          filters: [{
+            type: "field",
+            field: "root[].status",
+            operator: "is",
+            value: "paid",
+            scope: "cdc",
+            cdcId: fixture.cdc.id,
+          }],
+        }),
+      fixture.key.token
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.results[0].rows.map(({ category, value }) => ({ category, value })))
+      .toEqual([
+        { category: "Jan", value: 120 },
+        { category: "Mar", value: 140 },
+      ]);
+    expect(compilerSpy).not.toHaveBeenCalled();
+    expect((await db.Chart.unscoped().findByPk(fixture.chart.id)).preparedData).toBeNull();
+
+    const sourceCalls = sourceSpy.mock.calls.length;
+    const cachedResponse = await authorize(
+      request(app)
+        .post(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+        .send({
+          filters: [{
+            type: "field",
+            field: "root[].status",
+            operator: "is",
+            value: "paid",
+            scope: "cdc",
+            cdcId: fixture.cdc.id,
+          }],
+        }),
+      fixture.key.token
+    );
+    expect(cachedResponse.status).toBe(200);
+    expect(cachedResponse.body).toEqual(response.body);
+    expect(sourceSpy).toHaveBeenCalledTimes(sourceCalls);
+    compilerSpy.mockRestore();
+    sourceSpy.mockRestore();
+  });
+
+  it("substitutes runtime variables without putting their names or values in audit records", async () => {
+    const fixture = await createFixture();
+    await fixture.ordersRequest.update({
+      query: "select customer_id, month, amount, status from orders where region = '{{region}}'",
+    });
+    await db.VariableBinding.create({
+      entity_id: `${fixture.ordersRequest.id}`,
+      entity_type: "DataRequest",
+      name: "region",
+      required: false,
+      type: "string",
+    });
+    const sourceSpy = mockOrderSource(fixture);
+
+    const response = await authorize(
+      request(app)
+        .post(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+        .send({ variables: { region: "APAC" } }),
+      fixture.key.token
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.results[0].rows.map(({ category, value }) => ({ category, value })))
+      .toEqual([
+        { category: "Jan", value: 120 },
+        { category: "Feb", value: 80 },
+        { category: "Mar", value: 140 },
+      ]);
+    expect(sourceSpy.mock.calls.some(([options]) => options.processedQuery?.includes("APAC")))
+      .toBe(true);
+
+    const runs = await db.UpdateRun.findAll({ where: { apiKeyId: fixture.key.id } });
+    const events = await db.UpdateRunEvent.findAll({
+      where: { runId: runs.map((run) => run.id) },
+    });
+    const auditJson = JSON.stringify({
+      events: events.map((event) => event.toJSON()),
+      runs: runs.map((run) => run.toJSON()),
+    });
+    expect(auditJson).not.toContain("APAC");
+    expect(auditJson).not.toContain("region");
+    expect(auditJson).not.toContain("select customer_id");
+    sourceSpy.mockRestore();
+  });
+
+  it("uses safe errors, scope checks, parent checks, and bounded audit summaries", async () => {
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+    await db.Apikey.update({ scopes: ["data:read"] }, { where: { id: fixture.key.id } });
+
+    const scopeResponse = await authorize(
+      request(app)
+        .post(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+        .send({ refresh: true }),
+      fixture.key.token
+    );
+    expect(scopeResponse.status).toBe(403);
+    expect(scopeResponse.body.error).toMatchObject({
+      code: "API_KEY_SCOPE_REQUIRED",
+      message: "The API key does not have the required permission.",
+    });
+    expect(scopeResponse.body.error.requestId).toBeTruthy();
+
+    const parentResponse = await authorize(
+      request(app).get(`/api/v1/projects/${fixture.project.id + 1}/charts/${fixture.chart.id}/data`),
+      fixture.key.token
+    );
+    expect(parentResponse.status).toBe(404);
+    expect(parentResponse.body.error.code).toBe("RESOURCE_NOT_FOUND");
+
+    const runs = await db.UpdateRun.findAll({
+      order: [["id", "ASC"]],
+      where: { apiKeyId: fixture.key.id, triggerType: "data_api" },
+    });
+    expect(runs).toHaveLength(2);
+    expect(runs.map((run) => run.entityType)).toEqual(["chart_data", "chart_data"]);
+    expect(JSON.stringify(runs.map((run) => run.summary))).not.toContain("root[].status");
+    expect(JSON.stringify(runs.map((run) => run.summary))).not.toContain("select ");
+    sourceSpy.mockRestore();
+  });
+
+  it("returns stable HTTP contract errors and records invalid authorized requests", async () => {
+    process.env.CB_DATA_API_ENABLED = "false";
+    const disabled = await request(app).get("/api/v1/projects/1/charts/1/data");
+    expect(disabled.status).toBe(404);
+    expect(disabled.body.error.code).toBe("RESOURCE_NOT_FOUND");
+    delete process.env.CB_DATA_API_ENABLED;
+
+    const malformed = await request(app)
+      .post("/api/v1/projects/1/charts/1/data")
+      .set("Content-Type", "application/json")
+      .send("{");
+    expect(malformed.status).toBe(400);
+    expect(malformed.body.error.code).toBe("INVALID_REQUEST");
+
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+    const badAccept = await request(app)
+      .get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+      .set("Authorization", `Bearer ${fixture.key.token}`)
+      .set("Accept", "text/html");
+    expect(badAccept.status).toBe(406);
+    expect(badAccept.body.error.code).toBe("NOT_ACCEPTABLE");
+
+    const badMedia = await request(app)
+      .post(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`)
+      .set("Authorization", `Bearer ${fixture.key.token}`)
+      .set("Content-Type", "text/plain")
+      .send("value");
+    expect(badMedia.status).toBe(415);
+    expect(badMedia.body.error.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+
+    const queryResponse = await authorize(
+      request(app).get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data?refresh=true`),
+      fixture.key.token
+    );
+    expect(queryResponse.status).toBe(400);
+    expect(queryResponse.body.error.code).toBe("INVALID_REQUEST");
+
+    const invalidId = await authorize(
+      request(app).get(`/api/v1/projects/${fixture.project.id}/charts/1e2/data`),
+      fixture.key.token
+    );
+    expect(invalidId.status).toBe(400);
+    expect(invalidId.body.error.code).toBe("INVALID_REQUEST");
+    expect(await db.UpdateRun.count({
+      where: { apiKeyId: fixture.key.id, entityType: "chart_data" },
+    })).toBe(1);
+    sourceSpy.mockRestore();
+  });
+
+  it("enforces request, response, and per-key rate limits without partial data", async () => {
+    const fixture = await createFixture();
+    const sourceSpy = mockOrderSource(fixture);
+
+    process.env.CB_DATA_API_MAX_REQUEST_BYTES = "20";
+    const requestLimit = await authorize(
+      request(app)
+        .post(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`)
+        .send({ variables: { region: "a-long-region" } }),
+      fixture.key.token
+    );
+    expect(requestLimit.status).toBe(413);
+    expect(requestLimit.body.error.code).toBe("REQUEST_TOO_LARGE");
+    delete process.env.CB_DATA_API_MAX_REQUEST_BYTES;
+
+    process.env.CB_DATA_API_MAX_RESPONSE_BYTES = "20";
+    const responseLimit = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`),
+      fixture.key.token
+    );
+    expect(responseLimit.status).toBe(413);
+    expect(responseLimit.body.error.code).toBe("RESPONSE_TOO_LARGE");
+    expect(responseLimit.body).not.toHaveProperty("data");
+    delete process.env.CB_DATA_API_MAX_RESPONSE_BYTES;
+
+    const keyOwner = await db.User.findByPk((await db.Apikey.findByPk(fixture.key.id)).user_id);
+    const rateKey = await new TeamController().createApiKey(fixture.team.id, keyOwner, {
+      allProjects: false,
+      name: "Rate key",
+      projectIds: [fixture.project.id],
+      scopes: ["data:read"],
+    });
+    process.env.CB_DATA_API_RATE_LIMIT_MAX = "1";
+    const first = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`),
+      rateKey.token
+    );
+    const limited = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`),
+      rateKey.token
+    );
+    expect(first.status).toBe(200);
+    expect(limited.status).toBe(429);
+    expect(limited.body.error.code).toBe("RATE_LIMITED");
+    expect(limited.headers["retry-after"]).toBeTruthy();
+
+    const secondKey = await new TeamController().createApiKey(fixture.team.id, keyOwner, {
+      allProjects: false,
+      name: "Second key",
+      projectIds: [fixture.project.id],
+      scopes: ["data:read"],
+    });
+    const isolated = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`),
+      secondKey.token
+    );
+    expect(isolated.status).toBe(200);
+    sourceSpy.mockRestore();
+  });
+
+  it("preserves object, scalar, null, and nested-array dataset results", async () => {
+    const fixture = await createFixture();
+    const shapeDataset = await db.Dataset.create({
+      draft: false,
+      name: "Shapes",
+      project_ids: [fixture.project.id],
+      team_id: fixture.team.id,
+    });
+    const shapeRequest = await db.DataRequest.create({
+      connection_id: fixture.connection.id,
+      dataset_id: shapeDataset.id,
+      query: "select exact shape",
+    });
+    await shapeDataset.update({ main_dr_id: shapeRequest.id });
+    const values = [
+      { total: 12, meta: { source: "exact" } },
+      42,
+      null,
+      { groups: [{ name: "A", values: [1, 2] }] },
+    ];
+    const sourceSpy = vi.spyOn(getSourceById("postgres").backend, "runDataRequest");
+
+    for (const value of values) {
+      sourceSpy.mockResolvedValueOnce({
+        dataRequest: shapeRequest,
+        responseData: { data: value },
+      });
+      const response = await authorize(
+        request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${shapeDataset.id}/data`),
+        fixture.key.token
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(value);
+    }
+    sourceSpy.mockRestore();
+  });
+
+  it("returns a timeout and aborts a source that supports AbortSignal", async () => {
+    const fixture = await createFixture();
+    process.env.CB_DATA_API_MAX_EXECUTION_MS = "50";
+    let receivedSignal;
+    const sourceSpy = vi.spyOn(getSourceById("postgres").backend, "runDataRequest")
+      .mockImplementation(({ signal }) => {
+        receivedSignal = signal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("Source aborted")), { once: true });
+        });
+      });
+
+    const response = await authorize(
+      request(app).get(`/api/v1/teams/${fixture.team.id}/datasets/${fixture.dataset.id}/data`),
+      fixture.key.token
+    );
+    expect(response.status).toBe(504);
+    expect(response.body.error.code).toBe("EXECUTION_TIMEOUT");
+    expect(receivedSignal.aborted).toBe(true);
+
+    const run = await db.UpdateRun.findOne({
+      order: [["id", "ASC"]],
+      where: { apiKeyId: fixture.key.id, entityType: "dataset_data" },
+    });
+    expect(run).toMatchObject({ status: "failed", errorCode: "EXECUTION_TIMEOUT" });
+    sourceSpy.mockRestore();
+  });
+
+  it.each(["teamOwner", "teamAdmin", "projectAdmin", "projectEditor", "projectViewer"])(
+    "applies current %s project access at route time",
+    async (role) => {
+      const fixture = await createFixture();
+      const sourceSpy = mockOrderSource(fixture);
+      const apiKey = await db.Apikey.findByPk(fixture.key.id);
+      await db.TeamRole.update({ role, projects: [fixture.project.id] }, {
+        where: { team_id: fixture.team.id, user_id: apiKey.user_id },
+      });
+
+      const allowed = await authorize(
+        request(app).get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`),
+        fixture.key.token
+      );
+      expect(allowed.status).toBe(200);
+
+      await db.TeamRole.update({ projects: [] }, {
+        where: { team_id: fixture.team.id, user_id: apiKey.user_id },
+      });
+      const afterProjectRemoval = await authorize(
+        request(app).get(`/api/v1/projects/${fixture.project.id}/charts/${fixture.chart.id}/data`),
+        fixture.key.token
+      );
+      expect(afterProjectRemoval.status).toBe(role.startsWith("project") ? 404 : 200);
+      sourceSpy.mockRestore();
+    }
+  );
+});

--- a/server/tests/unit/dataApiAccess.test.js
+++ b/server/tests/unit/dataApiAccess.test.js
@@ -1,0 +1,104 @@
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  buildDataApiAccess,
+  getEffectiveProjectIds,
+  normalizeProjectIds,
+  normalizeScopes,
+  validateKeyProjectIds,
+} = require("../../modules/dataApiAccess.js");
+
+describe("dataApiAccess", () => {
+  it.each(["teamOwner", "teamAdmin"])("limits %s access with the key project list", (role) => {
+    expect(getEffectiveProjectIds({
+      role,
+      teamProjectIds: [1, 2, 3],
+      keyProjectIds: [2, 3],
+    })).toEqual([2, 3]);
+  });
+
+  it.each(["projectAdmin", "projectEditor", "projectViewer"])(
+    "intersects %s role projects with key projects",
+    (role) => {
+      expect(getEffectiveProjectIds({
+        role,
+        roleProjectIds: [1, 2],
+        teamProjectIds: [1, 2, 3],
+        keyProjectIds: [2, 3],
+      })).toEqual([2]);
+    }
+  );
+
+  it("uses the current role projects for an all-project key", () => {
+    expect(getEffectiveProjectIds({
+      role: "projectViewer",
+      roleProjectIds: [1, 3],
+      teamProjectIds: [1, 2, 3],
+      keyProjectIds: [],
+      allProjects: true,
+    })).toEqual([1, 3]);
+  });
+
+  it("returns no projects for an unknown or removed role", () => {
+    expect(getEffectiveProjectIds({
+      role: "unknown",
+      teamProjectIds: [1, 2],
+      keyProjectIds: [1, 2],
+    })).toEqual([]);
+  });
+
+  it("normalizes project IDs and accepted scopes", () => {
+    expect(normalizeProjectIds([2, "2", -1, "bad", 3])).toEqual([2, 3]);
+    expect(normalizeScopes(["data:read", "unknown", "data:read"])).toEqual(["data:read"]);
+  });
+
+  it("requires positive integer project IDs during key creation", async () => {
+    const db = { Project: { count: async () => 2 } };
+
+    await expect(validateKeyProjectIds(db, 1, [1, 2])).resolves.toBe(true);
+    await expect(validateKeyProjectIds(db, 1, [1, "2"])).resolves.toBe(false);
+    await expect(validateKeyProjectIds(db, 1, [true])).resolves.toBe(false);
+  });
+
+  it("does not load every team project for project-scoped roles", async () => {
+    let projectQueries = 0;
+    const db = {
+      Project: {
+        findAll: async () => {
+          projectQueries += 1;
+          return [{ id: 2 }];
+        },
+      },
+    };
+
+    const projectAccess = await buildDataApiAccess(db, {
+      id: "key",
+      team_id: 1,
+      user_id: 2,
+      scopes: ["data:read"],
+      project_ids: [2],
+      all_projects: true,
+    }, {
+      role: "projectViewer",
+      projects: [2],
+    });
+    expect(projectAccess.projectIds).toEqual([2]);
+    expect(projectQueries).toBe(0);
+
+    const teamAccess = await buildDataApiAccess(db, {
+      id: "key",
+      team_id: 1,
+      user_id: 2,
+      scopes: ["data:read"],
+      project_ids: [2],
+      all_projects: false,
+    }, {
+      role: "teamAdmin",
+      projects: [],
+    });
+    expect(teamAccess.projectIds).toEqual([2]);
+    expect(projectQueries).toBe(1);
+  });
+});

--- a/server/tests/unit/dataApiContracts.test.js
+++ b/server/tests/unit/dataApiContracts.test.js
@@ -1,0 +1,239 @@
+const {
+  DEFAULT_DATA_API_LIMITS,
+  getDataApiLimits,
+  positiveInteger,
+  withExecutionDeadline,
+} = require("../../modules/dataApiLimits");
+const {
+  acceptsJson,
+  DataApiError,
+  matchesEtag,
+  serializeDataApiResponse,
+} = require("../../modules/dataApiResponse");
+const {
+  parseDataApiId,
+  requiresRefreshScope,
+  validatePostBody,
+} = require("../../modules/dataApiValidation");
+const { filterDatasetResult } = require("../../visualization/filterDatasets");
+const {
+  buildConnectorAuditPayload,
+  getConnectorAuditError,
+} = require("../../sources/shared/connectorRuntime");
+
+describe("Data API contracts", () => {
+  it("uses positive environment limits and safe defaults", () => {
+    expect(positiveInteger("12", 5)).toBe(12);
+    expect(positiveInteger("0", 5)).toBe(5);
+    expect(positiveInteger("word", 5)).toBe(5);
+    expect(getDataApiLimits({})).toEqual(DEFAULT_DATA_API_LIMITS);
+    expect(getDataApiLimits({ CB_DATA_API_MAX_FILTERS: "4" }).maxFilters).toBe(4);
+  });
+
+  it("accepts only positive base-10 integer IDs", () => {
+    expect(parseDataApiId("42")).toBe(42);
+    ["0", "-1", "1.5", "1e2", "01abc", ""].forEach((value) => {
+      expect(() => parseDataApiId(value)).toThrow(DataApiError);
+    });
+  });
+
+  it("validates chart runtime input and refresh authority", () => {
+    const request = validatePostBody({
+      variables: { region: "APAC" },
+      filters: [{
+        type: "field",
+        field: "root[].status",
+        operator: "is",
+        value: "paid",
+        scope: "cdc",
+        cdcId: 8,
+      }],
+    }, {
+      resourceType: "chart",
+      cdcIds: [8],
+    });
+
+    expect(request).toEqual({
+      variables: { region: "APAC" },
+      filters: [{
+        type: "field",
+        field: "root[].status",
+        operator: "is",
+        value: "paid",
+        scope: "cdc",
+        cdcId: 8,
+      }],
+      refresh: false,
+    });
+    expect(requiresRefreshScope(request)).toBe(true);
+  });
+
+  it("rejects unknown input, foreign CDCs, and client-only filters", () => {
+    expect(() => validatePostBody({ unknown: true }, { resourceType: "chart" }))
+      .toThrow("The request is not valid.");
+    expect(() => validatePostBody({
+      filters: [{
+        type: "field",
+        field: "root[].status",
+        operator: "is",
+        value: "paid",
+        scope: "cdc",
+        cdcId: 99,
+      }],
+    }, { resourceType: "chart", cdcIds: [8] })).toThrow("One or more filters are not valid.");
+    expect(() => validatePostBody({
+      filters: [{
+        type: "sort",
+        field: "root[].amount",
+        operator: "is",
+        value: 1,
+      }],
+    }, { resourceType: "dataset" })).toThrow("One or more filters are not valid.");
+
+    [
+      { type: "", field: "root[].amount", operator: "is", value: 1 },
+      { field: "root[].amount", operator: "is", value: 1, origin: "dashboard" },
+      { field: "root[].amount", operator: "is", value: 1, exposed: false },
+      { field: "root[].amount", operator: "is", value: 1, clientOnly: false },
+      { field: "root[].amount", operator: "is", value: 1, forceSourceRefresh: "false" },
+      { type: "date", startDate: "2026-08-01", endDate: "2026-08-02", scope: "other" },
+    ].forEach((filter) => {
+      expect(() => validatePostBody({ filters: [filter] }, { resourceType: "chart" }))
+        .toThrow("One or more filters are not valid.");
+    });
+  });
+
+  it("validates dataset timezone and stored schema fields", () => {
+    expect(validatePostBody({
+      timezone: "Asia/Bangkok",
+      filters: [{
+        type: "field",
+        field: "root[].amount",
+        operator: "greaterOrEqual",
+        value: 100,
+      }],
+    }, {
+      resourceType: "dataset",
+      schemaFields: ["root[].amount"],
+    }).timezone).toBe("Asia/Bangkok");
+
+    expect(() => validatePostBody({ timezone: "Moon/Base" }, { resourceType: "dataset" }))
+      .toThrow("The request is not valid.");
+    expect(() => validatePostBody({
+      filters: [{
+        type: "field",
+        field: "root[].secret",
+        operator: "is",
+        value: true,
+      }],
+    }, {
+      resourceType: "dataset",
+      schemaFields: ["root[].amount"],
+    })).toThrow("One or more filters are not valid.");
+    expect(() => validatePostBody({
+      filters: [{ field: "root.amount", operator: "is", value: 100 }],
+    }, { resourceType: "dataset" })).toThrow("One or more filters are not valid.");
+    expect(() => validatePostBody({
+      filters: [{ field: "root[].items[].amount", operator: "is", value: 100 }],
+    }, { resourceType: "dataset" })).toThrow("One or more filters are not valid.");
+  });
+
+  it("bounds nested values, strings, filter counts, and variable counts", () => {
+    const limits = {
+      ...DEFAULT_DATA_API_LIMITS,
+      maxFilters: 1,
+      maxStringBytes: 4,
+      maxValueDepth: 1,
+      maxVariables: 1,
+    };
+    expect(() => validatePostBody({ variables: { first: 1, last: 2 } }, {
+      resourceType: "chart",
+      limits,
+    })).toThrow("One or more variables are not valid.");
+    expect(() => validatePostBody({ variables: { longName: 1 } }, {
+      resourceType: "chart",
+      limits,
+    })).toThrow("One or more variables are not valid.");
+    expect(() => validatePostBody({ variables: { key: { a: { b: 1 } } } }, {
+      resourceType: "chart",
+      limits,
+    })).toThrow("One or more variables are not valid.");
+    expect(() => validatePostBody({
+      variables: JSON.parse("{\"safe\":{\"__proto__\":{\"polluted\":true}}}"),
+    }, { resourceType: "chart" })).toThrow("One or more variables are not valid.");
+  });
+
+  it("matches strong and weak ETags without accepting partial values", () => {
+    const etag = "\"pd-v1-abc\"";
+    expect(matchesEtag(etag, etag)).toBe(true);
+    expect(matchesEtag(`W/${etag}`, etag)).toBe(true);
+    expect(matchesEtag(`"other", ${etag}`, etag)).toBe(true);
+    expect(matchesEtag("\"pd-v1-ab\"", etag)).toBe(false);
+  });
+
+  it("honors JSON content negotiation quality", () => {
+    const request = (accept) => ({ headers: { accept } });
+    expect(acceptsJson(request("application/json"))).toBe(true);
+    expect(acceptsJson(request("application/problem+json"))).toBe(true);
+    expect(acceptsJson(request("text/html, application/json;q=0"))).toBe(false);
+  });
+
+  it("measures UTF-8 response bytes and rejects complete oversized responses", () => {
+    expect(serializeDataApiResponse({ value: "é" }).bytes)
+      .toBe(Buffer.byteLength(JSON.stringify({ value: "é" }), "utf8"));
+    expect(() => serializeDataApiResponse({ value: "é" }, { maxBytes: 5 }))
+      .toThrow("The response is too large.");
+  });
+
+  it("returns a stable execution timeout", async () => {
+    await expect(withExecutionDeadline(() => new Promise(() => {}), 5))
+      .rejects.toMatchObject({ code: "EXECUTION_TIMEOUT", statusCode: 504 });
+  });
+
+  it("filters root and nested arrays without changing the source value", () => {
+    const root = [{ value: null }, { value: 2 }, {}];
+    expect(filterDatasetResult(root, [{
+      type: "field",
+      field: "root[].value",
+      operator: "isNull",
+    }])).toEqual([{ value: null }, {}]);
+    expect(root).toEqual([{ value: null }, { value: 2 }, {}]);
+
+    const nested = { payload: { rows: [{ amount: 10 }, { amount: 20 }] } };
+    expect(filterDatasetResult(nested, [{
+      type: "field",
+      field: "root.payload.rows[].amount",
+      operator: "greaterThan",
+      value: 10,
+    }])).toEqual({ payload: { rows: [{ amount: 20 }] } });
+    expect(nested).toEqual({ payload: { rows: [{ amount: 10 }, { amount: 20 }] } });
+  });
+
+  it("removes source content from Data API connector audits", () => {
+    const auditContext = {
+      redactSensitivePayload: true,
+      requestMetadata: {
+        connectionId: 3,
+        queryPreview: "select secret from accounts",
+      },
+    };
+    expect(buildConnectorAuditPayload(auditContext, {
+      bodySnippet: "secret body",
+      cacheHit: false,
+      itemCount: 2,
+      responseSnippet: "secret rows",
+    })).toEqual({
+      cacheHit: false,
+      connectionId: 3,
+      itemCount: 2,
+    });
+    expect(getConnectorAuditError(
+      auditContext,
+      new Error("database password is invalid"),
+      "connection"
+    )).toMatchObject({
+      code: "DATA_UNAVAILABLE",
+      message: "The data source request failed.",
+    });
+  });
+});

--- a/server/tests/unit/dataApiMigrations.test.js
+++ b/server/tests/unit/dataApiMigrations.test.js
@@ -1,0 +1,63 @@
+const { DataTypes, Sequelize } = require("sequelize");
+
+const keyMigration = require("../../models/migrations/20260825090000-add-data-api-key-scope");
+const auditMigration = require("../../models/migrations/20260825091000-add-data-api-audit-key");
+
+describe("Data API migrations", () => {
+  it("adds, backfills, indexes, and removes the fields on SQLite", async () => {
+    const sequelize = new Sequelize("sqlite::memory:", { logging: false });
+    const queryInterface = sequelize.getQueryInterface();
+    try {
+      await queryInterface.createTable("Apikey", {
+        id: { type: DataTypes.UUID, primaryKey: true },
+        name: { type: DataTypes.STRING, allowNull: false },
+        token: { type: DataTypes.TEXT, allowNull: false },
+        team_id: { type: DataTypes.INTEGER, allowNull: false },
+        createdAt: { type: DataTypes.DATE, allowNull: false },
+        updatedAt: { type: DataTypes.DATE, allowNull: false },
+      });
+      await queryInterface.createTable("UpdateRun", {
+        id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+        traceId: { type: DataTypes.STRING, allowNull: false },
+        rootTraceId: { type: DataTypes.STRING, allowNull: false },
+        triggerType: { type: DataTypes.STRING, allowNull: false },
+        entityType: { type: DataTypes.STRING, allowNull: false },
+        status: { type: DataTypes.STRING, allowNull: false },
+        startedAt: { type: DataTypes.DATE, allowNull: false },
+        createdAt: { type: DataTypes.DATE, allowNull: false },
+        updatedAt: { type: DataTypes.DATE, allowNull: false },
+      });
+      await queryInterface.bulkInsert("Apikey", [{
+        id: "48f81a1f-c730-435c-a2b7-6b72f5f775ce",
+        name: "Legacy key",
+        token: "encrypted",
+        team_id: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }]);
+
+      await keyMigration.up(queryInterface);
+      await auditMigration.up(queryInterface);
+
+      const keyColumns = await queryInterface.describeTable("Apikey");
+      expect(Object.keys(keyColumns)).toEqual(expect.arrayContaining([
+        "user_id", "scopes", "project_ids", "all_projects", "last_used_at",
+      ]));
+      expect(keyColumns.scopes.allowNull).toBe(false);
+      const [legacyRows] = await sequelize.query("SELECT scopes FROM Apikey");
+      expect(legacyRows).toEqual([{ scopes: "[]" }]);
+
+      const auditColumns = await queryInterface.describeTable("UpdateRun");
+      expect(auditColumns.apiKeyId).toBeTruthy();
+      expect((await queryInterface.showIndex("UpdateRun")).map((index) => index.name))
+        .toContain("update_run_api_key_started_at");
+
+      await auditMigration.down(queryInterface);
+      await keyMigration.down(queryInterface);
+      expect((await queryInterface.describeTable("UpdateRun")).apiKeyId).toBeUndefined();
+      expect((await queryInterface.describeTable("Apikey")).scopes).toBeUndefined();
+    } finally {
+      await sequelize.close();
+    }
+  });
+});

--- a/server/tests/unit/datasetData.test.js
+++ b/server/tests/unit/datasetData.test.js
@@ -1,0 +1,88 @@
+const {
+  createDatasetData,
+  getDatasetDataFingerprint,
+  serializeDatasetData,
+} = require("../../modules/datasetData");
+
+describe("DatasetData v1", () => {
+  it("preserves exact nested data and sorts fields and object keys", () => {
+    const data = createDatasetData({
+      dataset: {
+        id: 18,
+        name: "Orders",
+        fieldsSchema: {
+          "root[].customer.name": "string",
+          "root[].amount": "number",
+        },
+      },
+      generatedAt: "2026-08-25T08:00:00.000Z",
+      data: [{
+        z: undefined,
+        customer: { name: "Ada", rank: 1 },
+        amount: Infinity,
+        paid: true,
+        createdAt: new Date("2026-08-20T04:00:00.000Z"),
+        nullable: null,
+      }],
+    });
+
+    expect(data).toEqual({
+      data: [{
+        amount: null,
+        createdAt: "2026-08-20T04:00:00.000Z",
+        customer: { name: "Ada", rank: 1 },
+        nullable: null,
+        paid: true,
+      }],
+      fields: [
+        { key: "root[].amount", type: "number" },
+        { key: "root[].customer.name", type: "string" },
+      ],
+      generatedAt: "2026-08-25T08:00:00.000Z",
+      resource: { id: 18, kind: "dataset", name: "Orders" },
+      version: 1,
+    });
+  });
+
+  it("detects fields when no stored schema exists", () => {
+    const data = createDatasetData({
+      dataset: { id: 2, name: "Values" },
+      data: [{ score: 4, active: false }],
+    });
+    expect(data.fields).toEqual([
+      { key: "root[].active", type: "boolean" },
+      { key: "root[].score", type: "number" },
+    ]);
+  });
+
+  it.each([null, 42, "value", true, { value: 4 }])("keeps non-array result shape", (value) => {
+    const data = createDatasetData({ dataset: { id: 2, name: "Value" }, data: value });
+    expect(data.data).toEqual(value);
+  });
+
+  it("excludes only generation time from the content fingerprint", () => {
+    const first = createDatasetData({
+      dataset: { id: 2, name: "Values" },
+      generatedAt: "2026-08-25T08:00:00.000Z",
+      data: [{ score: 4 }],
+    });
+    const second = { ...first, generatedAt: "2026-08-26T08:00:00.000Z" };
+    const changed = { ...second, data: [{ score: 5 }] };
+    expect(getDatasetDataFingerprint(first)).toBe(getDatasetDataFingerprint(second));
+    expect(getDatasetDataFingerprint(first)).not.toBe(getDatasetDataFingerprint(changed));
+    expect(serializeDatasetData(first)).toContain("generatedAt");
+  });
+
+  it("unwraps model values without exposing model metadata", () => {
+    const row = {
+      dataValues: { amount: 12 },
+      _options: { secret: true },
+      toJSON() {
+        return { ...this.dataValues };
+      },
+    };
+    const data = createDatasetData({ dataset: { id: 2, name: "Values" }, data: [row] });
+    expect(data.data).toEqual([{ amount: 12 }]);
+    expect(JSON.stringify(data)).not.toContain("_options");
+  });
+});

--- a/server/tests/unit/updateAudit.test.js
+++ b/server/tests/unit/updateAudit.test.js
@@ -31,6 +31,7 @@ describe("updateAudit", () => {
       entityType: "chart",
       status: "running",
       teamId: 1,
+      apiKeyId: "5e951c4f-0c79-4f70-b8fb-5993ea20bc12",
       projectId: 10,
       chartId: 100,
       summary: {
@@ -66,6 +67,7 @@ describe("updateAudit", () => {
     });
 
     expect(persistedRun.status).toBe("success");
+    expect(persistedRun.apiKeyId).toBe("5e951c4f-0c79-4f70-b8fb-5993ea20bc12");
     expect(persistedRun.summary).toEqual({
       chartId: 100,
       datasetCount: 2,

--- a/server/tests/unit/verifyDataApiKey.test.js
+++ b/server/tests/unit/verifyDataApiKey.test.js
@@ -1,0 +1,44 @@
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const verifyDataApiKey = require("../../modules/verifyDataApiKey.js");
+
+describe("verifyDataApiKey helpers", () => {
+  it("accepts only the required API-key claims", () => {
+    expect(verifyDataApiKey.hasRequiredClaims({
+      id: 1,
+      apiKeyId: "key-id",
+      teamId: 2,
+      tokenType: "api_key",
+    })).toBe(true);
+    expect(verifyDataApiKey.hasRequiredClaims({ id: 1, teamId: 2 })).toBe(false);
+    expect(verifyDataApiKey.hasRequiredClaims({
+      id: 1,
+      apiKeyId: "key-id",
+      teamId: 2,
+      tokenType: "share",
+    })).toBe(false);
+  });
+
+  it("rejects malformed and repeated bearer headers", () => {
+    expect(verifyDataApiKey.readBearerToken({
+      rawHeaders: ["Authorization", "Bearer token"],
+      headers: {},
+    })).toBe("token");
+    expect(verifyDataApiKey.readBearerToken({
+      rawHeaders: ["Authorization", "Bearer one", "Authorization", "Bearer two"],
+      headers: {},
+    })).toBe(null);
+    expect(verifyDataApiKey.readBearerToken({
+      rawHeaders: ["Authorization", "Bearer token extra"],
+      headers: {},
+    })).toBe(null);
+  });
+
+  it("compares token digests without comparing variable-length token buffers", () => {
+    expect(verifyDataApiKey.tokensMatch("same-token", "same-token")).toBe(true);
+    expect(verifyDataApiKey.tokensMatch("same-token", "other-token")).toBe(false);
+    expect(verifyDataApiKey.tokensMatch("short", "a-much-longer-token")).toBe(false);
+  });
+});

--- a/server/tests/unit/visualizationPreparedData.test.js
+++ b/server/tests/unit/visualizationPreparedData.test.js
@@ -55,7 +55,7 @@ function buildEngine({
 }
 
 function buildCurrentMarkEngine(mark) {
-  if (["bar", "line", "pie", "doughnut", "radar", "polar"].includes(mark)) {
+  if (["bar", "horizontalBar", "line", "pie", "doughnut", "radar", "polar"].includes(mark)) {
     return buildEngine({
       encoding: {
         category: { field: "root[].category", type: "nominal" },
@@ -387,6 +387,11 @@ describe("current chart type goldens through PreparedData", () => {
       preparedRows: [{ category: "A", value: 10 }, { category: "B", value: 20 }],
       values: [[10, 20]],
     },
+    horizontalBar: {
+      labels: ["A", "B"],
+      preparedRows: [{ category: "A", value: 10 }, { category: "B", value: 20 }],
+      values: [[10, 20]],
+    },
     line: {
       labels: ["A", "B"],
       preparedRows: [{ category: "A", value: 10 }, { category: "B", value: 20 }],
@@ -454,5 +459,16 @@ describe("current chart type goldens through PreparedData", () => {
     });
 
     expect(getGoldenOutput(mark, result)).toEqual(expected[mark]);
+  });
+
+  it.each(Object.keys(expected))("keeps prepared-only %s data equal to the normal chart path", (mark) => {
+    const generatedAt = "2026-08-19T00:00:00.000Z";
+    const preparedEngine = buildCurrentMarkEngine(mark);
+    const normalEngine = buildCurrentMarkEngine(mark);
+    const preparedOnly = preparedEngine.prepare({ generatedAt }).preparedData;
+    const normal = normalEngine.render({ generatedAt }).preparedData;
+
+    expect(toPublicPreparedData(preparedOnly)).toEqual(toPublicPreparedData(normal));
+    expect(serializePreparedData(preparedOnly)).toBe(serializePreparedData(normal));
   });
 });

--- a/server/visualization/filterDatasets.js
+++ b/server/visualization/filterDatasets.js
@@ -3,6 +3,7 @@ const {
   getDatasetDateConditions,
   getDatasetRuntimeFilters,
 } = require("../modules/chartRuntimeFilters");
+const _ = require("lodash");
 const dataFilter = require("../charts/dataFilter");
 const { resolveDatasetDateField } = require("./dateField");
 
@@ -155,7 +156,45 @@ function filterVisualizationDatasets({
   };
 }
 
+function filterDatasetResult(data, filters = [], timezone = "UTC") {
+  return filters.reduce((filteredData, filter) => {
+    const arrayMarker = filter.field.indexOf("[]");
+    if (arrayMarker < 0) return filteredData;
+
+    const collectionPath = filter.field.slice(0, arrayMarker).replace(/^root\.?/, "");
+    const rowField = filter.field.slice(arrayMarker + 3);
+    const collection = collectionPath ? _.get(filteredData, collectionPath) : filteredData;
+    if (!Array.isArray(collection) || !rowField) return filteredData;
+
+    let nextCollection;
+    if (filter.operator === "isNull") {
+      nextCollection = collection.filter((row) => {
+        const value = _.get(row, rowField);
+        return value === null || value === undefined;
+      });
+    } else if (filter.operator === "isNotNull") {
+      nextCollection = collection.filter((row) => {
+        const value = _.get(row, rowField);
+        return value !== null && value !== undefined;
+      });
+    } else {
+      nextCollection = dataFilter(
+        collection,
+        `root[].${rowField}`,
+        [{ ...filter, field: `root[].${rowField}` }],
+        timezone
+      ).data;
+    }
+
+    if (!collectionPath) return nextCollection;
+    const nextData = _.cloneDeep(filteredData);
+    _.set(nextData, collectionPath, nextCollection);
+    return nextData;
+  }, data);
+}
+
 module.exports = {
+  filterDatasetResult,
   filterVisualizationDatasets,
   getBindingSelector,
   getVariableConditions,

--- a/server/vitest.pure.config.js
+++ b/server/vitest.pure.config.js
@@ -6,6 +6,10 @@ export default defineConfig({
     globals: true,
     include: [
       "tests/unit/chartJsCartesianCompiler.test.js",
+      "tests/unit/dataApiAccess.test.js",
+      "tests/unit/dataApiContracts.test.js",
+      "tests/unit/dataApiMigrations.test.js",
+      "tests/unit/datasetData.test.js",
       "tests/unit/embeddedChartPayload.test.js",
       "tests/unit/echartsCompiler.test.js",
       "tests/unit/kpiReview.test.js",
@@ -22,6 +26,7 @@ export default defineConfig({
       "tests/unit/scheduleWeekdays.test.js",
       "tests/unit/visualizationCompilers.test.js",
       "tests/unit/visualizationPreparedData.test.js",
+      "tests/unit/verifyDataApiKey.test.js",
     ],
     maxWorkers: 1,
     pool: "forks",


### PR DESCRIPTION
## Summary

- Add scoped API keys for team and project data access.
- Add versioned GET and POST endpoints for chart and dataset data.
- Add strict validation, access checks, limits, caching, ETags, audit records, and safe error responses.
- Mark legacy API keys in the API key interface.
- Add the detailed implementation specification and test coverage.

## Validation

- 1,021 server unit tests passed.
- 206 server integration tests passed.
- Client Data API, AI, and visualization tests passed.
- Client production build passed.
- Server and client lint passed.